### PR TITLE
Allow user to provide environment ID as a cli flag

### DIFF
--- a/bbl/fixtures/cloudformation-no-elb.json
+++ b/bbl/fixtures/cloudformation-no-elb.json
@@ -380,7 +380,7 @@
         "VPC": {
             "Properties": {
                 "CidrBlock": {"Ref": "VPCCIDR"},
-                "Tags": [{"Key": "Name", "Value": "vpc-bbl-env-lake-timestamp"}]
+                "Tags": [{"Key": "Name", "Value": "vpc-some-env-id"}]
             },
             "Type": "AWS::EC2::VPC"
         },

--- a/bbl/load_balancers_test.go
+++ b/bbl/load_balancers_test.go
@@ -403,7 +403,7 @@ var _ = Describe("load balancers", func() {
 				KeyPair: storage.KeyPair{
 					Name: "some-keypair-name",
 				},
-				EnvID: "bbl-env-lake-timestamp",
+				EnvID: "some-env-id",
 			}, tempDirectory)
 
 			fakeAWS.Stacks.Set(awsbackend.Stack{

--- a/commands/commands_usage.go
+++ b/commands/commands_usage.go
@@ -5,7 +5,8 @@ const (
 
   --aws-access-key-id        AWS Access Key ID to use (Defaults to environment variable BBL_AWS_ACCESS_KEY_ID)
   --aws-secret-access-key    AWS Secret Access Key to use (Defaults to environment variable BBL_AWS_SECRET_ACCESS_KEY)
-  --aws-region               AWS region to use (Defaults to environment variable BBL_AWS_REGION)`
+  --aws-region               AWS region to use (Defaults to environment variable BBL_AWS_REGION)
+  --environment-id           Optional environment identifier (bbl will generate an environment id if one is not provided)`
 
 	DestroyCommandUsage = `Tears down BOSH director infrastructure
 

--- a/commands/commands_usage_test.go
+++ b/commands/commands_usage_test.go
@@ -18,7 +18,8 @@ var _ = Describe("Commands Usage", func() {
 
   --aws-access-key-id        AWS Access Key ID to use (Defaults to environment variable BBL_AWS_ACCESS_KEY_ID)
   --aws-secret-access-key    AWS Secret Access Key to use (Defaults to environment variable BBL_AWS_SECRET_ACCESS_KEY)
-  --aws-region               AWS region to use (Defaults to environment variable BBL_AWS_REGION)`))
+  --aws-region               AWS region to use (Defaults to environment variable BBL_AWS_REGION)
+  --environment-id           Optional environment identifier (bbl will generate an environment id if one is not provided)`))
 			})
 		})
 	})


### PR DESCRIPTION
* this allows teams to give their environments meaningful names and
avoids confusion caused by repeat lake names

Signed-off-by: David Morhovich <dmorhovich@pivotal.io> 