### PR TITLE
Add explicit instructions for creating a load balancer

### DIFF
--- a/concourse.md
+++ b/concourse.md
@@ -7,7 +7,8 @@ This document will walk through deploying a concourse clustered install to GCP u
 
 * bbl
 * A GCP Service Account key as described in README.md
-* BBL up. e.g. ```bbl up --gcp-zone us-west1-a --gcp-region us-west1 --gcp-service-account-key service-account.key.json --gcp-project-id my-gcp-project-id --iaas gcp```
+* BBL up, e.g. ```bbl up --gcp-zone us-west1-a --gcp-region us-west1 --gcp-service-account-key service-account.key.json --gcp-project-id my-gcp-project-id --iaas gcp```
+* Add a load balancer, e.g. ```bbl create-lbs --type concourse --cert <path-to-tls-cert> --key <path-to-tls-key>```
 * This guide will assume the [Bosh v2 CLI](https://bosh.io/docs/cli-v2.html) is installed, but bosh v1 CLI will work, with some minor changes.
 
 ## Create a bosh deployment manifest
@@ -15,8 +16,8 @@ This document will walk through deploying a concourse clustered install to GCP u
 Scale instance types, disks and instance count based on your needs. Other sizes are available, see ```bosh cloud-config```.
 
 1. Start with the sample manifest from the [Concourse documentation](http://concourse.ci/clusters-with-bosh.html)
-2. Replace all ```vm_type: REPLACE_ME``` with ```vm_type: n1-standard-1```.
-3. Add the vm_extension ```lbs``` to the instance_group "web"
+2. Replace all ```vm_type: REPLACE_ME``` with ```vm_type: n1-standard-2```.
+3. Add the vm_extension ```lb``` to the instance_group "web"
 4. Add the property ```tls_bind_port: 443``` to the instance_group "web"
 5. Add the vm_extension ```50GB_ephemeral_disk``` to the instance_group "worker"
 6. Replace all ```persistent_disk_type: REPLACE_ME``` with ```persistent_disk_type: 5GB```


### PR DESCRIPTION
- Show how to create a load balance for Concourse
- The default name of the load balancer vm extension is `lb`
- By default, bbl does not add a `vm_type` of `n1-standard-1`