### PR TITLE
bbl up doesn't require `--iaas` now

### DIFF
--- a/docs/getting-started-aws.md
+++ b/docs/getting-started-aws.md
@@ -79,8 +79,7 @@ following command:
 bbl up \
 	--aws-access-key-id <INSERT ACCESS KEY ID> \
 	--aws-secret-access-key <INSERT SECRET ACCESS KEY> \
-	--aws-region us-west-1 \
-	--iaas aws
+	--aws-region us-west-1
 ```
 
 The process takes around 5-8 minutes. When the process is finished


### PR DESCRIPTION
```
○ → bbl up --help
Usage:
  bbl [GLOBAL OPTIONS] up [OPTIONS]

Global Options:
  --help      [-h]       Print usage
  --state-dir            Directory containing bbl-state.json

[up command options]
  Deploys BOSH director on AWS

  --aws-access-key-id        AWS Access Key ID to use (Defaults to environment variable BBL_AWS_ACCESS_KEY_ID)
  --aws-secret-access-key    AWS Secret Access Key to use (Defaults to environment variable BBL_AWS_SECRET_ACCESS_KEY)
  --aws-region               AWS region to use (Defaults to environment variable BBL_AWS_REGION)
```