### PR TITLE
Removing disabling of router TLS termination

### DIFF
--- a/cloudfoundry.md
+++ b/cloudfoundry.md
@@ -50,6 +50,6 @@ bosh upload-stemcell ~/Downloads/light-bosh-stemcell-XXXX.X-google-kvm-ubuntu-tr
 ## Deploy
 
 ```
-bosh -d cf deploy --vars-store cf-deployment-vars.yml -o opsfiles/gcp.yml -o opsfiles/disable-router-tls-termination.yml cf-deployment.yml
+bosh -d cf deploy --vars-store cf-deployment-vars.yml -o opsfiles/gcp.yml cf-deployment.yml
 
 ```


### PR DESCRIPTION
Looks like following these instructions ends up setting up a websocket LB which forwards TCP 80 and 443 to the gorouter. Things like `cf logs` fail now without the router terminating TLS.