### PR TITLE
Add vm_type `n1-standard-1` to cloud config

### DIFF
--- a/cloudconfig/gcp/cloud_config_template.go
+++ b/cloudconfig/gcp/cloud_config_template.go
@@ -54,6 +54,11 @@ vm_types:
     root_disk_size_gb: 10
     root_disk_type: pd-ssd
 
+- name: n1-standard-1
+  cloud_properties:
+    machine_type: n1-standard-1
+    root_disk_size_gb: 10
+    root_disk_type: pd-ssd
 - name: n1-standard-2
   cloud_properties:
     machine_type: n1-standard-2

--- a/cloudconfig/gcp/fixtures/cloud-config-cf-lb.yml
+++ b/cloudconfig/gcp/fixtures/cloud-config-cf-lb.yml
@@ -155,6 +155,11 @@ vm_types:
     root_disk_size_gb: 10
     root_disk_type: pd-ssd
 
+- name: n1-standard-1
+  cloud_properties:
+    machine_type: n1-standard-1
+    root_disk_size_gb: 10
+    root_disk_type: pd-ssd
 - name: n1-standard-2
   cloud_properties:
     machine_type: n1-standard-2

--- a/cloudconfig/gcp/fixtures/cloud-config-concourse-lb.yml
+++ b/cloudconfig/gcp/fixtures/cloud-config-concourse-lb.yml
@@ -155,6 +155,11 @@ vm_types:
     root_disk_size_gb: 10
     root_disk_type: pd-ssd
 
+- name: n1-standard-1
+  cloud_properties:
+    machine_type: n1-standard-1
+    root_disk_size_gb: 10
+    root_disk_type: pd-ssd
 - name: n1-standard-2
   cloud_properties:
     machine_type: n1-standard-2

--- a/cloudconfig/gcp/fixtures/cloud-config-no-lb.yml
+++ b/cloudconfig/gcp/fixtures/cloud-config-no-lb.yml
@@ -155,6 +155,11 @@ vm_types:
     root_disk_size_gb: 10
     root_disk_type: pd-ssd
 
+- name: n1-standard-1
+  cloud_properties:
+    machine_type: n1-standard-1
+    root_disk_size_gb: 10
+    root_disk_type: pd-ssd
 - name: n1-standard-2
   cloud_properties:
     machine_type: n1-standard-2


### PR DESCRIPTION
Although this machine type is already present under the names `default`
and `m3.medium`, it seems sensible to include it under its own name as
well, given that we've got vm_types `n1-standard-{2,4,8,16,32}`.

This is slightly related to PR #105, which addresses the documentation of this vm_type's non-existence.