### PR TITLE
Add vm_extension `preemptible` to cloud config

### DIFF
--- a/cloudconfig/gcp/cloud_config_generator.go
+++ b/cloudconfig/gcp/cloud_config_generator.go
@@ -32,6 +32,7 @@ type VMExtensionCloudProperties struct {
 	EphemeralExternalIP *bool    `yaml:"ephemeral_external_ip,omitempty"`
 	BackendService      string   `yaml:"backend_service,omitempty"`
 	Tags                []string `yaml:"tags,omitempty"`
+	Preemptible         *bool    `yaml:"preemptible,omitempty"`
 }
 
 type CloudConfig struct {

--- a/cloudconfig/gcp/cloud_config_template.go
+++ b/cloudconfig/gcp/cloud_config_template.go
@@ -197,4 +197,7 @@ vm_extensions:
 - name: internet-not-required
   cloud_properties:
     ephemeral_external_ip: false
+- name: preemptible
+  cloud_properties:
+    preemptible: true
 `

--- a/cloudconfig/gcp/fixtures/cloud-config-cf-lb.yml
+++ b/cloudconfig/gcp/fixtures/cloud-config-cf-lb.yml
@@ -298,6 +298,9 @@ vm_extensions:
 - name: internet-not-required
   cloud_properties:
     ephemeral_external_ip: false
+- name: preemptible
+  cloud_properties:
+    preemptible: true
 - name: cf-router-network-properties
   cloud_properties:
     backend_service: router-backend-service

--- a/cloudconfig/gcp/fixtures/cloud-config-concourse-lb.yml
+++ b/cloudconfig/gcp/fixtures/cloud-config-concourse-lb.yml
@@ -298,6 +298,9 @@ vm_extensions:
 - name: internet-not-required
   cloud_properties:
     ephemeral_external_ip: false
+- name: preemptible
+  cloud_properties:
+    preemptible: true
 - name: lb
   cloud_properties:
     target_pool: concourse-target-pool

--- a/cloudconfig/gcp/fixtures/cloud-config-no-lb.yml
+++ b/cloudconfig/gcp/fixtures/cloud-config-no-lb.yml
@@ -298,4 +298,6 @@ vm_extensions:
 - name: internet-not-required
   cloud_properties:
     ephemeral_external_ip: false
-
+- name: preemptible
+  cloud_properties:
+    preemptible: true


### PR DESCRIPTION
The GCP CPI supports a resource pool option named [`preemptible`][1]
that is useful to opt into for deployments with BOSH resurrector enabled.

 [1]: https://github.com/cloudfoundry-incubator/bosh-google-cpi-release/blob/f8918e185be638d84f85be0073572fdca3bd039b/src/bosh-google-cpi/README.md#bosh-resource-pool-options