### PR TITLE
Update GCP service account create steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ gcloud iam service-accounts create <service account name>
 
 gcloud iam service-accounts keys create --iam-account=<service account name> <service account name>.key.json
 
-gcloud projects add-iam-policy-binding <project id> --member='<service account name>' --role='roles/editor'
+gcloud projects add-iam-policy-binding <project id> --member='serviceAccount:<service account name>' --role='roles/editor'
 ```
 
 ## Usage


### PR DESCRIPTION
According to https://cloud.google.com/iam/docs/granting-roles-to-service-accounts#granting_access_to_a_service_account_for_a_resource, you need to prefix your service account with `serviceAccount:`