### PR TITLE
Fix GCP commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Example:
 ```
 gcloud iam service-accounts create <service account name>
 
-gcloud iam service-accounts keys create --iam-account=<service account name> <service account name>.key.json
+gcloud iam service-accounts keys create --iam-account='<service account name>@<project id>.iam.gserviceaccount.com' <service account name>.key.json
 
-gcloud projects add-iam-policy-binding <project id> --member='<service account name>' --role='roles/editor'
+gcloud projects add-iam-policy-binding <project id> --member='user:<service account name>@<project id>.iam.gserviceaccount.com' --role='roles/editor'
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ gcloud iam service-accounts create <service account name>
 
 gcloud iam service-accounts keys create --iam-account='<service account name>@<project id>.iam.gserviceaccount.com' <service account name>.key.json
 
-gcloud projects add-iam-policy-binding <project id> --member='user:<service account name>@<project id>.iam.gserviceaccount.com' --role='roles/editor'
+gcloud projects add-iam-policy-binding <project id> --member='serviceAccount:<service account name>@<project id>.iam.gserviceaccount.com' --role='roles/editor'
 ```
 
 ## Usage


### PR DESCRIPTION
Add some missing details to the GCP setup steps

- `gcloud iam service-accounts keys create` requires the full service account name
- `gcloud projects add-iam-policy-binding` requires a `serviceAccount:` prefix and the full service account name