### PR TITLE
Instruct users to bind http traffic to port 80

### DIFF
--- a/docs/concourse.md
+++ b/docs/concourse.md
@@ -23,9 +23,10 @@ Scale instance types, disks and instance count based on your needs. Other sizes 
 2. Replace all ```vm_type: REPLACE_ME``` with ```vm_type: n1-standard-1```.
 3. Add the vm_extension ```lb``` to the instance_group "web"
 4. Add ```tls_bind_port: 443``` as a property of the job named "atc"
-5. Add the vm_extension ```50GB_ephemeral_disk``` to the instance_group "worker"
-6. Replace all ```persistent_disk_type: REPLACE_ME``` with ```persistent_disk_type: 5GB```
-7. Fill out the remaining REPLACE_ME in the sample manifest with your own data, such as auth groups, SSL certs, and external URL
+5. Add ```bind_port: 80``` as a property of the job named "atc". This ensures that ```http``` traffic is redirected to ```https```.
+6. Add the vm_extension ```50GB_ephemeral_disk``` to the instance_group "worker"
+7. Replace all ```persistent_disk_type: REPLACE_ME``` with ```persistent_disk_type: 5GB```
+8. Fill out the remaining REPLACE_ME in the sample manifest with your own data, such as auth groups, SSL certs, and external URL
 
 
 ## Set the bosh environment


### PR DESCRIPTION
* If `bind_port` is not defined, it defaults to port `8080`. Thus http
  traffic is served on a non-standard port.
* This causes `http://concourse-url` to not work. Also `http` to `https`
  redirection doesn't work.
* The load balancer is set-up to forward `443` and `80` to the backing web node.
    Also ATC will redirect `80` to `443`. So this should still be nice and secure.