### PR TITLE
Revert "Revert "Promote `bbl print-env` workflow for AWS users""

### DIFF
--- a/docs/getting-started-aws.md
+++ b/docs/getting-started-aws.md
@@ -32,6 +32,7 @@ This user will be issuing API requests to create the infrastructure such
 as EC2 instances, load balancers, subnets, etc.
 
 The user must have the following `policy`:
+
 ```
 {
     "Version": "2012-10-17",
@@ -39,7 +40,7 @@ The user must have the following `policy`:
         {
             "Effect": "Allow",
             "Action": [
-		"ec2:*",
+                "ec2:*",
                 "cloudformation:*",
                 "elasticloadbalancing:*",
                 "route53:*",
@@ -56,6 +57,7 @@ The user must have the following `policy`:
 
 To create a user and associated policy with the AWS CLI run the 
 following commands (policy text must be in your clipboard):
+
 ```
 $ aws iam create-user --user-name "bbl-user"
 $ aws iam put-user-policy --user-name "bbl-user" \
@@ -116,6 +118,7 @@ should never be modified by hand.
 - bosh-init state and manifest (for the currently deployed director)
 
 The best way to extract this info is by issuing commands like 
+
 ```
 $ bbl director-username
 some-username
@@ -123,9 +126,9 @@ $ bbl director-ca-cert
 --- BEGIN CERTIFICATE ---
 ...
 --- END CERTIFICATE ---
+```
 
 and so on...
-```
 
 In order to run these commands, the current directory must contain the
 `bbl-state.json`.
@@ -133,7 +136,15 @@ In order to run these commands, the current directory must contain the
 ### Connecting to the BOSH director
 
 To setup your BOSH CLI with the new director you'll need the following
-commands to get the credentials:
+command to get the credentials:
+
+```
+eval "$(bbl print-env)"
+```
+
+#### Alternatives to `bbl print-env`
+
+Separate commands are available for the `bbl print-env` fields:
 
 ```
 $ bbl director-address
@@ -149,7 +160,7 @@ MIIDtzCCAp+gAwIBAgIJAIPgaUgWRCE8MA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
 -----END CERTIFICATE-----
 ```
 
-Save CA certificate to the file:
+You might save the CA certificate to a file:
 
 ```
 $ bbl director-ca-cert > bosh.crt
@@ -166,7 +177,8 @@ Username: user-d3783rk
 Password: p-23dah71sk1
 ```
 
-Display cloud config:
+Display cloud config to test setup and show configuration mapping:
+
 ```
 $ bosh cloud-config
 ...


### PR DESCRIPTION
Reverts cloudfoundry/bosh-bootloader#175

This was a mistake, we should have just merged master into develop in the first place.