### PR TITLE
Fix name validation regex

### DIFF
--- a/helpers/env_id_manager.go
+++ b/helpers/env_id_manager.go
@@ -100,7 +100,7 @@ func (e EnvIDManager) validateName(envID string) error {
 		return nil
 	}
 
-	matched, err := matchString("^(?:[a-z](?:[-a-z0-9]+[a-z0-9])?)$", envID)
+	matched, err := matchString("^(?:[a-z](?:[-a-z0-9]*[a-z0-9])?)$", envID)
 	if err != nil {
 		return err
 	}

--- a/helpers/env_id_manager_test.go
+++ b/helpers/env_id_manager_test.go
@@ -96,6 +96,25 @@ var _ = Describe("EnvIDManager", func() {
 			})
 		})
 
+		Context("when the name provided is two characters", func() {
+			It("returns the name provided", func() {
+				state, err := envIDManager.Sync(storage.State{
+					IAAS: "gcp",
+				}, "ci")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(state.EnvID).To(Equal("ci"))
+			})
+
+			Context("when the name ends with a hyphen", func() {
+				It("returns the name", func() {
+					_, err := envIDManager.Sync(storage.State{
+						IAAS: "gcp",
+					}, "c-")
+					Expect(err).To(MatchError("Names must start with a letter and be alphanumeric or hyphenated."))
+				})
+			})
+		})
+
 		Context("failure cases", func() {
 			It("returns an error when the NetworkClient cannot check if a network exists", func() {
 				networkClient.CheckExistsCall.Returns.Error = errors.New("failed to get network list")


### PR DESCRIPTION
- Regex didn't allow a valid two character name e.g. ci, but it did
allow a single character name and a three character name

Signed-off-by: Slawek Ligus <sligus@pivotal.io>