### PR TITLE
Changes to enable `bosh ssh job/0`

### DIFF
--- a/bosh/manager.go
+++ b/bosh/manager.go
@@ -344,7 +344,7 @@ func (m *Manager) GetJumpboxDeploymentVars(state storage.State, terraformOutputs
 			Zone:           state.GCP.Zone,
 			Network:        getTerraformOutput("network_name", terraformOutputs),
 			Subnetwork:     getTerraformOutput("subnetwork_name", terraformOutputs),
-			Tags:           []string{getTerraformOutput("bosh_open_tag_name", terraformOutputs)},
+			Tags:           []string{getTerraformOutput("bosh_open_tag_name", terraformOutputs), getTerraformOutput("jumpbox_tag_name", terraformOutputs)},
 			ProjectID:      state.GCP.ProjectID,
 			CredentialJSON: state.GCP.ServiceAccountKey,
 		}

--- a/bosh/manager_test.go
+++ b/bosh/manager_test.go
@@ -75,6 +75,7 @@ director_ssl:
 					"network_name":           "some-network",
 					"subnetwork_name":        "some-subnetwork",
 					"bosh_open_tag_name":     "some-jumpbox-tag",
+					"jumpbox_tag_name":       "some-jumpbox-fw-tag",
 					"bosh_director_tag_name": "some-director-tag",
 					"internal_tag_name":      "some-internal-tag",
 					"external_ip":            "some-external-ip",
@@ -267,6 +268,7 @@ kms_key_arn: some-kms-arn
 				"network_name":           "some-network",
 				"subnetwork_name":        "some-subnetwork",
 				"bosh_open_tag_name":     "some-jumpbox-tag",
+				"jumpbox_tag_name":       "some-jumpbox-fw-tag",
 				"bosh_director_tag_name": "some-director-tag",
 				"internal_tag_name":      "some-internal-tag",
 				"external_ip":            "some-external-ip",
@@ -306,6 +308,7 @@ network: some-network
 subnetwork: some-subnetwork
 tags:
 - some-jumpbox-tag
+- some-jumpbox-fw-tag
 project_id: some-project-id
 gcp_credentials_json: some-credential-json
 `
@@ -685,6 +688,7 @@ private_key: some-private-key
 					"network_name":       "some-network",
 					"subnetwork_name":    "some-subnetwork",
 					"bosh_open_tag_name": "some-jumpbox-tag",
+					"jumpbox_tag_name":   "some-jumpbox-fw-tag",
 					"external_ip":        "some-external-ip",
 				})
 				Expect(vars).To(Equal(`internal_cidr: 10.0.0.0/24
@@ -697,6 +701,7 @@ network: some-network
 subnetwork: some-subnetwork
 tags:
 - some-jumpbox-tag
+- some-jumpbox-fw-tag
 project_id: some-project-id
 gcp_credentials_json: some-credential-json
 `))
@@ -728,6 +733,7 @@ gcp_credentials_json: some-credential-json
 					"network_name":           "some-network",
 					"subnetwork_name":        "some-subnetwork",
 					"bosh_open_tag_name":     "some-jumpbox-tag",
+					"jumpbox_tag_name":       "some-jumpbox-fw-tag",
 					"bosh_director_tag_name": "some-director-tag",
 					"internal_tag_name":      "some-internal-tag",
 					"external_ip":            "some-external-ip",

--- a/commands/print_env.go
+++ b/commands/print_env.go
@@ -83,8 +83,8 @@ func (p PrintEnv) Execute(args []string, state storage.State) error {
 	jumpboxURL := strings.Split(state.Jumpbox.URL, ":")[0]
 
 	p.logger.Println(fmt.Sprintf("export BOSH_ALL_PROXY=socks5://localhost:%s", portNumber))
-	p.logger.Println(fmt.Sprintf("export BOSH_GW_PRIVATE_KEY=%s", privateKeyPath))
-	p.logger.Println(fmt.Sprintf("ssh -f -N -o StrictHostKeyChecking=no -D %s jumpbox@%s -i $BOSH_GW_PRIVATE_KEY", portNumber, jumpboxURL))
+	p.logger.Println(fmt.Sprintf("export JUMPBOX_PRIVATE_KEY=%s", privateKeyPath))
+	p.logger.Println(fmt.Sprintf("ssh -f -N -o StrictHostKeyChecking=no -D %s jumpbox@%s -i $JUMPBOX_PRIVATE_KEY", portNumber, jumpboxURL))
 
 	return nil
 }

--- a/commands/print_env_test.go
+++ b/commands/print_env_test.go
@@ -63,8 +63,8 @@ var _ = Describe("PrintEnv", func() {
 			Expect(logger.PrintlnCall.Messages).To(ContainElement("export BOSH_ENVIRONMENT=some-director-address"))
 
 			Expect(logger.PrintlnCall.Messages).To(ContainElement(MatchRegexp(`export BOSH_ALL_PROXY=socks5://localhost:\d+`)))
-			Expect(logger.PrintlnCall.Messages).To(ContainElement(MatchRegexp(`export BOSH_GW_PRIVATE_KEY=.*\/bosh_jumpbox_private.key`)))
-			Expect(logger.PrintlnCall.Messages).To(ContainElement(MatchRegexp(`ssh -f -N -o StrictHostKeyChecking=no -D \d+ jumpbox@some-magical-jumpbox-url -i \$BOSH_GW_PRIVATE_KEY`)))
+			Expect(logger.PrintlnCall.Messages).To(ContainElement(MatchRegexp(`JUMPBOX_PRIVATE_KEY=.*\/bosh_jumpbox_private.key`)))
+			Expect(logger.PrintlnCall.Messages).To(ContainElement(MatchRegexp(`ssh -f -N -o StrictHostKeyChecking=no -D \d+ jumpbox@some-magical-jumpbox-url -i \$JUMPBOX_PRIVATE_KEY`)))
 		})
 
 		It("writes private key to file in temp dir", func() {

--- a/terraform/aws/aws_templates.go
+++ b/terraform/aws/aws_templates.go
@@ -261,6 +261,15 @@ resource "aws_security_group_rule" "internal_security_group_rule_allow_internet"
   cidr_blocks              = ["0.0.0.0/0"]
 }
 
+resource "aws_security_group_rule" "internal_security_group_rule_ssh" {
+  security_group_id        = "${aws_security_group.internal_security_group.id}"
+  type                     = "ingress"
+  protocol                 = "TCP"
+  from_port                = 22
+  to_port                  = 22
+  source_security_group_id = "${aws_security_group.jumpbox.id}"
+}
+
 output "internal_security_group" {
   value="${aws_security_group.internal_security_group.id}"
 }

--- a/terraform/aws/fixtures/template_cf_lb.tf
+++ b/terraform/aws/fixtures/template_cf_lb.tf
@@ -270,6 +270,15 @@ resource "aws_security_group_rule" "internal_security_group_rule_allow_internet"
   cidr_blocks              = ["0.0.0.0/0"]
 }
 
+resource "aws_security_group_rule" "internal_security_group_rule_ssh" {
+  security_group_id        = "${aws_security_group.internal_security_group.id}"
+  type                     = "ingress"
+  protocol                 = "TCP"
+  from_port                = 22
+  to_port                  = 22
+  source_security_group_id = "${aws_security_group.jumpbox.id}"
+}
+
 output "internal_security_group" {
   value="${aws_security_group.internal_security_group.id}"
 }

--- a/terraform/aws/fixtures/template_cf_lb_with_domain.tf
+++ b/terraform/aws/fixtures/template_cf_lb_with_domain.tf
@@ -270,6 +270,15 @@ resource "aws_security_group_rule" "internal_security_group_rule_allow_internet"
   cidr_blocks              = ["0.0.0.0/0"]
 }
 
+resource "aws_security_group_rule" "internal_security_group_rule_ssh" {
+  security_group_id        = "${aws_security_group.internal_security_group.id}"
+  type                     = "ingress"
+  protocol                 = "TCP"
+  from_port                = 22
+  to_port                  = 22
+  source_security_group_id = "${aws_security_group.jumpbox.id}"
+}
+
 output "internal_security_group" {
   value="${aws_security_group.internal_security_group.id}"
 }

--- a/terraform/aws/fixtures/template_concourse_lb.tf
+++ b/terraform/aws/fixtures/template_concourse_lb.tf
@@ -270,6 +270,15 @@ resource "aws_security_group_rule" "internal_security_group_rule_allow_internet"
   cidr_blocks              = ["0.0.0.0/0"]
 }
 
+resource "aws_security_group_rule" "internal_security_group_rule_ssh" {
+  security_group_id        = "${aws_security_group.internal_security_group.id}"
+  type                     = "ingress"
+  protocol                 = "TCP"
+  from_port                = 22
+  to_port                  = 22
+  source_security_group_id = "${aws_security_group.jumpbox.id}"
+}
+
 output "internal_security_group" {
   value="${aws_security_group.internal_security_group.id}"
 }

--- a/terraform/aws/fixtures/template_no_lb.tf
+++ b/terraform/aws/fixtures/template_no_lb.tf
@@ -270,6 +270,15 @@ resource "aws_security_group_rule" "internal_security_group_rule_allow_internet"
   cidr_blocks              = ["0.0.0.0/0"]
 }
 
+resource "aws_security_group_rule" "internal_security_group_rule_ssh" {
+  security_group_id        = "${aws_security_group.internal_security_group.id}"
+  type                     = "ingress"
+  protocol                 = "TCP"
+  from_port                = 22
+  to_port                  = 22
+  source_security_group_id = "${aws_security_group.jumpbox.id}"
+}
+
 output "internal_security_group" {
   value="${aws_security_group.internal_security_group.id}"
 }

--- a/terraform/gcp/fixtures/gcp_template_cf_lb.tf
+++ b/terraform/gcp/fixtures/gcp_template_cf_lb.tf
@@ -40,6 +40,10 @@ output "bosh_director_tag_name" {
 	value = "${google_compute_firewall.bosh-director.name}"
 }
 
+output "jumpbox_tag_name" {
+	value = "${var.env_id}-jumpbox"
+}
+
 output "internal_tag_name" {
     value = "${google_compute_firewall.internal.name}"
 }
@@ -115,6 +119,20 @@ resource "google_compute_firewall" "internal-to-director" {
   }
 
   target_tags = ["${var.env_id}-bosh-director"]
+}
+
+resource "google_compute_firewall" "jumpbox-to-all" {
+  name    = "${var.env_id}-jumpbox-to-all"
+  network = "${google_compute_network.bbl-network.name}"
+
+  source_tags = ["${var.env_id}-jumpbox"]
+
+  allow {
+    ports = ["22"]
+    protocol = "tcp"
+  }
+
+  target_tags = ["${var.env_id}-internal", "${var.env_id}-bosh-director"]
 }
 
 resource "google_compute_firewall" "internal" {

--- a/terraform/gcp/fixtures/gcp_template_cf_lb_dns.tf
+++ b/terraform/gcp/fixtures/gcp_template_cf_lb_dns.tf
@@ -40,6 +40,10 @@ output "bosh_director_tag_name" {
 	value = "${google_compute_firewall.bosh-director.name}"
 }
 
+output "jumpbox_tag_name" {
+	value = "${var.env_id}-jumpbox"
+}
+
 output "internal_tag_name" {
     value = "${google_compute_firewall.internal.name}"
 }
@@ -115,6 +119,20 @@ resource "google_compute_firewall" "internal-to-director" {
   }
 
   target_tags = ["${var.env_id}-bosh-director"]
+}
+
+resource "google_compute_firewall" "jumpbox-to-all" {
+  name    = "${var.env_id}-jumpbox-to-all"
+  network = "${google_compute_network.bbl-network.name}"
+
+  source_tags = ["${var.env_id}-jumpbox"]
+
+  allow {
+    ports = ["22"]
+    protocol = "tcp"
+  }
+
+  target_tags = ["${var.env_id}-internal", "${var.env_id}-bosh-director"]
 }
 
 resource "google_compute_firewall" "internal" {

--- a/terraform/gcp/fixtures/gcp_template_concourse_lb.tf
+++ b/terraform/gcp/fixtures/gcp_template_concourse_lb.tf
@@ -40,6 +40,10 @@ output "bosh_director_tag_name" {
 	value = "${google_compute_firewall.bosh-director.name}"
 }
 
+output "jumpbox_tag_name" {
+	value = "${var.env_id}-jumpbox"
+}
+
 output "internal_tag_name" {
     value = "${google_compute_firewall.internal.name}"
 }
@@ -115,6 +119,20 @@ resource "google_compute_firewall" "internal-to-director" {
   }
 
   target_tags = ["${var.env_id}-bosh-director"]
+}
+
+resource "google_compute_firewall" "jumpbox-to-all" {
+  name    = "${var.env_id}-jumpbox-to-all"
+  network = "${google_compute_network.bbl-network.name}"
+
+  source_tags = ["${var.env_id}-jumpbox"]
+
+  allow {
+    ports = ["22"]
+    protocol = "tcp"
+  }
+
+  target_tags = ["${var.env_id}-internal", "${var.env_id}-bosh-director"]
 }
 
 resource "google_compute_firewall" "internal" {

--- a/terraform/gcp/fixtures/gcp_template_no_lb.tf
+++ b/terraform/gcp/fixtures/gcp_template_no_lb.tf
@@ -40,6 +40,10 @@ output "bosh_director_tag_name" {
 	value = "${google_compute_firewall.bosh-director.name}"
 }
 
+output "jumpbox_tag_name" {
+	value = "${var.env_id}-jumpbox"
+}
+
 output "internal_tag_name" {
     value = "${google_compute_firewall.internal.name}"
 }
@@ -115,6 +119,20 @@ resource "google_compute_firewall" "internal-to-director" {
   }
 
   target_tags = ["${var.env_id}-bosh-director"]
+}
+
+resource "google_compute_firewall" "jumpbox-to-all" {
+  name    = "${var.env_id}-jumpbox-to-all"
+  network = "${google_compute_network.bbl-network.name}"
+
+  source_tags = ["${var.env_id}-jumpbox"]
+
+  allow {
+    ports = ["22"]
+    protocol = "tcp"
+  }
+
+  target_tags = ["${var.env_id}-internal", "${var.env_id}-bosh-director"]
 }
 
 resource "google_compute_firewall" "internal" {

--- a/terraform/gcp/gcp_templates.go
+++ b/terraform/gcp/gcp_templates.go
@@ -43,6 +43,10 @@ output "bosh_director_tag_name" {
 	value = "${google_compute_firewall.bosh-director.name}"
 }
 
+output "jumpbox_tag_name" {
+	value = "${var.env_id}-jumpbox"
+}
+
 output "internal_tag_name" {
     value = "${google_compute_firewall.internal.name}"
 }
@@ -118,6 +122,20 @@ resource "google_compute_firewall" "internal-to-director" {
   }
 
   target_tags = ["${var.env_id}-bosh-director"]
+}
+
+resource "google_compute_firewall" "jumpbox-to-all" {
+  name    = "${var.env_id}-jumpbox-to-all"
+  network = "${google_compute_network.bbl-network.name}"
+
+  source_tags = ["${var.env_id}-jumpbox"]
+
+  allow {
+    ports = ["22"]
+    protocol = "tcp"
+  }
+
+  target_tags = ["${var.env_id}-internal", "${var.env_id}-bosh-director"]
 }
 
 resource "google_compute_firewall" "internal" {


### PR DESCRIPTION
Opens port 22 from the jumpbox to internal on AWS
Opens port 22 from the jumpbox to the director and the internal tag on GCP
Creates a new tag for the jumpbox, "env-id-jumpbox"
Renames the variable used for `bbl print-env` from BOSH_GW_PRIVATE_KEY to JUMPBOX_PRIVATE_KEY. I found this confusing, as BOSH_ALL_PROXY supercedes BOSH_GW_PRIVATE_KEY in all cases.

[#151273881]

RE: #197