### PR TITLE
bbl version reports SHA in scripts/bbl

### DIFF
--- a/scripts/bbl
+++ b/scripts/bbl
@@ -1,4 +1,4 @@
 #!/bin/bash -exu
 
-go install github.com/cloudfoundry/bosh-bootloader/bbl
+go install -ldflags="-X main.Version=$(git rev-parse --short=6 HEAD)" github.com/cloudfoundry/bosh-bootloader/bbl 
 bbl "${@:-""}"


### PR DESCRIPTION
```
unclephil:bosh-bootloader efarrar$ ./scripts/bbl version
++ git rev-parse --short=6 HEAD
+ go install '-ldflags=-X main.Version=92d424' github.com/cloudfoundry/bosh-bootloader/bbl
+ bbl version
bbl 887d43 (darwin/amd64)
unclephil:bosh-bootloader efarrar$ 
```