### PR TITLE
Adds keepalive setting to ssh tunnel

### DIFF
--- a/commands/print_env.go
+++ b/commands/print_env.go
@@ -84,7 +84,7 @@ func (p PrintEnv) Execute(args []string, state storage.State) error {
 
 	p.logger.Println(fmt.Sprintf("export BOSH_ALL_PROXY=socks5://localhost:%s", portNumber))
 	p.logger.Println(fmt.Sprintf("export JUMPBOX_PRIVATE_KEY=%s", privateKeyPath))
-	p.logger.Println(fmt.Sprintf("ssh -f -N -o StrictHostKeyChecking=no -o -o ServerAliveInterval=300 -D %s jumpbox@%s -i $JUMPBOX_PRIVATE_KEY", portNumber, jumpboxURL))
+	p.logger.Println(fmt.Sprintf("ssh -f -N -o StrictHostKeyChecking=no -o ServerAliveInterval=300 -D %s jumpbox@%s -i $JUMPBOX_PRIVATE_KEY", portNumber, jumpboxURL))
 
 	return nil
 }

--- a/commands/print_env.go
+++ b/commands/print_env.go
@@ -84,7 +84,7 @@ func (p PrintEnv) Execute(args []string, state storage.State) error {
 
 	p.logger.Println(fmt.Sprintf("export BOSH_ALL_PROXY=socks5://localhost:%s", portNumber))
 	p.logger.Println(fmt.Sprintf("export JUMPBOX_PRIVATE_KEY=%s", privateKeyPath))
-	p.logger.Println(fmt.Sprintf("ssh -f -N -o StrictHostKeyChecking=no -D %s jumpbox@%s -i $JUMPBOX_PRIVATE_KEY", portNumber, jumpboxURL))
+	p.logger.Println(fmt.Sprintf("ssh -f -N -o StrictHostKeyChecking=no -o -o ServerAliveInterval=300 -D %s jumpbox@%s -i $JUMPBOX_PRIVATE_KEY", portNumber, jumpboxURL))
 
 	return nil
 }

--- a/commands/print_env_test.go
+++ b/commands/print_env_test.go
@@ -69,7 +69,7 @@ var _ = Describe("PrintEnv", func() {
 
 			Expect(logger.PrintlnCall.Messages).To(ContainElement(MatchRegexp(`export BOSH_ALL_PROXY=socks5://localhost:\d+`)))
 			Expect(logger.PrintlnCall.Messages).To(ContainElement(MatchRegexp(`JUMPBOX_PRIVATE_KEY=.*\/bosh_jumpbox_private.key`)))
-			Expect(logger.PrintlnCall.Messages).To(ContainElement(MatchRegexp(`ssh -f -N -o StrictHostKeyChecking=no -D \d+ jumpbox@some-magical-jumpbox-url -i \$JUMPBOX_PRIVATE_KEY`)))
+			Expect(logger.PrintlnCall.Messages).To(ContainElement(MatchRegexp(`ssh -f -N -o StrictHostKeyChecking=no -o -o ServerAliveInterval=300 -D \d+ jumpbox@some-magical-jumpbox-url -i \$JUMPBOX_PRIVATE_KEY`)))
 		})
 
 		It("writes private key to file in temp dir", func() {

--- a/commands/print_env_test.go
+++ b/commands/print_env_test.go
@@ -69,7 +69,7 @@ var _ = Describe("PrintEnv", func() {
 
 			Expect(logger.PrintlnCall.Messages).To(ContainElement(MatchRegexp(`export BOSH_ALL_PROXY=socks5://localhost:\d+`)))
 			Expect(logger.PrintlnCall.Messages).To(ContainElement(MatchRegexp(`JUMPBOX_PRIVATE_KEY=.*\/bosh_jumpbox_private.key`)))
-			Expect(logger.PrintlnCall.Messages).To(ContainElement(MatchRegexp(`ssh -f -N -o StrictHostKeyChecking=no -o -o ServerAliveInterval=300 -D \d+ jumpbox@some-magical-jumpbox-url -i \$JUMPBOX_PRIVATE_KEY`)))
+			Expect(logger.PrintlnCall.Messages).To(ContainElement(MatchRegexp(`ssh -f -N -o StrictHostKeyChecking=no -o ServerAliveInterval=300 -D \d+ jumpbox@some-magical-jumpbox-url -i \$JUMPBOX_PRIVATE_KEY`)))
 		})
 
 		It("writes private key to file in temp dir", func() {


### PR DESCRIPTION
Setting `ServerAliveInterval` will keep the proxy tunnel from hanging up when connected to the typical ubuntu stemcell.  This is a temporary fix while waiting on bosh-cli to natively support tunneling.