### PR TITLE
use correct syntax for "$(bbl print-env)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ brew install bbl
 
 1. `bbl up --iaas <MY IAAS>` with IAAS credentials as flags or environment variables.
 
-1. `eval $(bbl print-env)` to target the director that you just created.
+1. `eval "$(bbl print-env)"` to target the director that you just created.
 
 1. `bosh ssh`, `bosh deploy` or `bosh status` should all just work with no further information needed from bbl.
 


### PR DESCRIPTION
- the cert doesn't parse correctly without the surrounding quotes

You get an annoying pem encoding error without the quotes when you actually try to use bosh.