### PR TITLE
Correlate director address to CIDR

### DIFF
--- a/bosh/manager.go
+++ b/bosh/manager.go
@@ -283,9 +283,19 @@ func (m *Manager) CreateDirector(state storage.State, terraformOutputs terraform
 
 	directorVars := getDirectorVars(variables)
 
+	internalCIDR := terraformOutputs.GetString("internal_cidr")
+	parsedInternalCIDR, err := ParseCIDRBlock(internalCIDR)
+	if err != nil {
+		internalCIDR = "10.0.0.0/24"
+		parsedInternalCIDR, _ = ParseCIDRBlock(internalCIDR)
+	}
+	internalIP := parsedInternalCIDR.GetNthIP(6).String()
+
+
+
 	state.BOSH = storage.BOSH{
 		DirectorName:           fmt.Sprintf("bosh-%s", state.EnvID),
-		DirectorAddress:        directorVars.address,
+		DirectorAddress:        fmt.Sprintf("https://%s:25555", internalIP),
 		DirectorUsername:       directorVars.username,
 		DirectorPassword:       directorVars.password,
 		DirectorSSLCA:          directorVars.sslCA,

--- a/bosh/manager_test.go
+++ b/bosh/manager_test.go
@@ -178,7 +178,7 @@ gcp_credentials_json: some-credential-json
 				Expect(stateWithDirector.BOSH).To(Equal(storage.BOSH{
 					Variables:              boshVars,
 					DirectorName:           "bosh-some-env-id",
-					DirectorAddress:        "https://10.0.0.6:25555",
+					DirectorAddress:        "https://10.2.0.6:25555",
 					DirectorUsername:       "admin",
 					DirectorPassword:       "some-admin-password",
 					DirectorSSLCA:          "some-ca",


### PR DESCRIPTION
We currently assert that if you set the director IP to 10.2.0.6 then the director URI will be `https://10.0.0.6:25555`