### PR TITLE
Small language updates to cidr block update sect

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -66,10 +66,10 @@ Numerous settings can be reconfigured permanently by editing `$BBL_STATE_DIR/var
 1. Plan the environment:
     ```
     mkdir some-env && cd some-env
-    BBL_AWS_ACCESS_KEY_ID=MYKEY
-    BBL_AWS_SECRET_ACCESS_KEY=MYSECRET
+    echo BBL_AWS_ACCESS_KEY_ID=MYKEY
+    echo BBL_AWS_SECRET_ACCESS_KEY=MYSECRET
     bbl plan --iaas aws --aws-region us-west-1
-    echo "cidr_block=\"192.168.0.0/20\"" >> vars/terraform.tfvars
+    echo -e "\nvpc_cidr=\"192.168.0.0/20\"" >> vars/terraform.tfvars
     ```
 1. Create the environment:
     ```


### PR DESCRIPTION
1.  Added -e and \n to update the tfvars file on a new line.
2.  I believe that the variable to be modified is meant to be vpc_cidr rather than cidr_block

Might be worth mentioning the smallest cidr block that can currently be used is \20.  Reasonable for cf.  Probably overkill for concourse.