### PR TITLE
Fix docs to say --lb-cert and --lb-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For detailed, IaaS specific instructions see your preferred IaaS's getting start
 
 1. Create an environment and target the BOSH director as described above
 
-1. `bbl plan --lb-type cf --cert cert --key key && bbl plan` with a certificate and key as flags or environment variables.
+1. `bbl plan --lb-type cf --lb-cert cert --lb-key key && bbl plan` with a certificate and key as flags or environment variables.
 (Continue to provide the IaaS credentials as flags or environment variables.)
 
 1. `bosh deploy cf.yml -o operations/<MY IaaS>` using the [CF deployment manifest!](https://github.com/cloudfoundry/cf-deployment)


### PR DESCRIPTION
`--cert` and `--key` are no longer the right flags.