### PR TITLE
fixed reference to Concourse website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # bosh-bootloader
 Also known as `bbl` *(pronounced: "bubble")*, bosh-bootloader is a command line
-utility for standing up a [CloudFoundry](https://cloudfoundry.org/) or [Concourse](https://concourse.ci) installation
+utility for standing up a [CloudFoundry](https://cloudfoundry.org/) or [Concourse](https://concourse-ci.org) installation
 on an IaaS. `bbl` currently supports AWS, GCP and Azure. Openstack and vSphere support are planned.
 
-* [CI](https://wings.concourse.ci/teams/cf-infrastructure/pipelines/bosh-bootloader)
+* [CI](https://wings.concourse-ci.org/teams/cf-infrastructure/pipelines/bosh-bootloader)
 * [Tracker](https://www.pivotaltracker.com/n/projects/1488988)
 
 ## Guides


### PR DESCRIPTION
fixed reference to Concourse website to the new `.org` domain