### PR TITLE
Remove the unsupported cloud property "type: gp2"

### DIFF
--- a/cloudconfig/azure/base_ops_template.go
+++ b/cloudconfig/azure/base_ops_template.go
@@ -58,7 +58,6 @@ const (
   value:
     ephemeral_disk:
       size: 10240
-      type: gp2
     instance_type: Standard_F1
 
 - type: replace
@@ -66,7 +65,6 @@ const (
   value:
     ephemeral_disk:
       size: 10240
-      type: gp2
     instance_type: Standard_F2
 
 - type: replace
@@ -74,7 +72,6 @@ const (
   value:
     ephemeral_disk:
       size: 10240
-      type: gp2
     instance_type: Standard_F4
 
 - type: replace
@@ -82,7 +79,6 @@ const (
   value:
     ephemeral_disk:
       size: 10240
-      type: gp2
     instance_type: Standard_D12_v2
 
 - type: replace
@@ -90,7 +86,6 @@ const (
   value:
     ephemeral_disk:
       size: 10240
-      type: gp2
     instance_type: Standard_GS2
 
 - type: replace
@@ -98,7 +93,6 @@ const (
   value:
     ephemeral_disk:
       size: 10240
-      type: gp2
     instance_type: Standard_D1
 `
 )

--- a/cloudconfig/azure/fixtures/azure-ops.yml
+++ b/cloudconfig/azure/fixtures/azure-ops.yml
@@ -54,7 +54,6 @@
   value:
     ephemeral_disk:
       size: 10240
-      type: gp2
     instance_type: Standard_F1
 
 - type: replace
@@ -62,7 +61,6 @@
   value:
     ephemeral_disk:
       size: 10240
-      type: gp2
     instance_type: Standard_F2
 
 - type: replace
@@ -70,7 +68,6 @@
   value:
     ephemeral_disk:
       size: 10240
-      type: gp2
     instance_type: Standard_F4
 
 - type: replace
@@ -78,7 +75,6 @@
   value:
     ephemeral_disk:
       size: 10240
-      type: gp2
     instance_type: Standard_D12_v2
 
 - type: replace
@@ -86,7 +82,6 @@
   value:
     ephemeral_disk:
       size: 10240
-      type: gp2
     instance_type: Standard_GS2
 
 - type: replace
@@ -94,7 +89,6 @@
   value:
     ephemeral_disk:
       size: 10240
-      type: gp2
     instance_type: Standard_D1
 
 - type: replace


### PR DESCRIPTION
Azure CPI doesn't support the cloud property `type: gp2` for the ephemeral disk.
See: https://bosh.io/docs/azure-cpi.html#resource-pools