### PR TITLE
No longer necessary to upload stemcell

### DIFF
--- a/docs/concourse.md
+++ b/docs/concourse.md
@@ -20,8 +20,6 @@ install to GCP using `bbl` and `bosh`.
 
   eval "$(bbl print-env)"
 
-  bosh upload-stemcell https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-trusty-go_agent
-
   cd $GOPATH/src/github.com/concourse/concourse-bosh-deployment/cluster
   ```
 


### PR DESCRIPTION
- The instruction to upload the stemcell has been removed, as bosh-bootloader now does this for you
- We observed this while running through the instructions
- We could not find this change mentioned in the release notes

Paired with @blgm 