### PR TITLE
Service account permissions

### DIFF
--- a/plan-patches/cfcr-gcp/README.md
+++ b/plan-patches/cfcr-gcp/README.md
@@ -1,5 +1,10 @@
 # Patch: cfcr-gcp
 
+Prerequisites:
+
+1. When running `bbl up`, ensure the service account used has the additional role 'roles/resourcemanager.projectIamAdmin'.
+   This is required to create the cfcr IAM bindings for your project
+
 Steps to deploy cfcr with bbl:
 
 1. Follow the normal steps to bbl up with a patch

--- a/plan-patches/cfcr-gcp/terraform/cfcr_iam_override.tf
+++ b/plan-patches/cfcr-gcp/terraform/cfcr_iam_override.tf
@@ -24,6 +24,15 @@ data "google_iam_policy" "admin" {
   }
 
   binding {
+    role = "roles/storage.objectViewer"
+
+    members = [
+      "serviceAccount:${google_service_account.master.email}",
+      "serviceAccount:${google_service_account.worker.email}",
+    ]
+  }
+
+  binding {
     role = "roles/compute.networkAdmin"
 
     members = [


### PR DESCRIPTION
Adds additional permissions required for GCP service accounts when applying CFCR GCP plan patches.