### PR TITLE
Revert "Azure resource group name is configurable"

### DIFF
--- a/terraform/azure/templates/cf_dns.tf
+++ b/terraform/azure/templates/cf_dns.tf
@@ -6,7 +6,7 @@ data "azurerm_public_ip" "cf-lb" {
 
 resource "azurerm_dns_zone" "cf" {
   name                = "${var.system_domain}"
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name = "${azurerm_resource_group.bosh.name}"
 
   tags {
     environment = "${var.env_id}"
@@ -16,7 +16,7 @@ resource "azurerm_dns_zone" "cf" {
 resource "azurerm_dns_a_record" "cf" {
   name                = "*"
   zone_name           = "${azurerm_dns_zone.cf.name}"
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name = "${azurerm_resource_group.bosh.name}"
   ttl                 = "300"
   records             = ["${data.azurerm_public_ip.cf-lb.ip_address}"]
 }
@@ -24,7 +24,7 @@ resource "azurerm_dns_a_record" "cf" {
 resource "azurerm_dns_a_record" "bosh" {
   name                = "bosh"
   zone_name           = "${azurerm_dns_zone.cf.name}"
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name = "${azurerm_resource_group.bosh.name}"
   ttl                 = "300"
   records             = ["${azurerm_public_ip.bosh.ip_address}"]
 }

--- a/terraform/azure/templates/cf_lb.tf
+++ b/terraform/azure/templates/cf_lb.tf
@@ -7,14 +7,14 @@ variable "pfx_password" {}
 resource "azurerm_subnet" "cf-sn" {
   name                 = "${var.env_id}-cf-sn"
   address_prefix       = "${cidrsubnet(var.network_cidr, 8, 1)}"
-  resource_group_name  = "${var.resource_group_name}"
+  resource_group_name  = "${azurerm_resource_group.bosh.name}"
   virtual_network_name = "${azurerm_virtual_network.bosh.name}"
 }
 
 resource "azurerm_network_security_group" "cf" {
   name                = "${var.env_id}-cf"
   location            = "${var.region}"
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name = "${azurerm_resource_group.bosh.name}"
 
   tags {
     environment = "${var.env_id}"
@@ -31,7 +31,7 @@ resource "azurerm_network_security_rule" "cf-http" {
   destination_port_range      = "80"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${var.resource_group_name}"
+  resource_group_name         = "${azurerm_resource_group.bosh.name}"
   network_security_group_name = "${azurerm_network_security_group.cf.name}"
 }
 
@@ -45,7 +45,7 @@ resource "azurerm_network_security_rule" "cf-https" {
   destination_port_range      = "443"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${var.resource_group_name}"
+  resource_group_name         = "${azurerm_resource_group.bosh.name}"
   network_security_group_name = "${azurerm_network_security_group.cf.name}"
 }
 
@@ -59,20 +59,20 @@ resource "azurerm_network_security_rule" "cf-log" {
   destination_port_range      = "4443"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${var.resource_group_name}"
+  resource_group_name         = "${azurerm_resource_group.bosh.name}"
   network_security_group_name = "${azurerm_network_security_group.cf.name}"
 }
 
 resource "azurerm_public_ip" "cf" {
   name                         = "${var.env_id}-cf-lb-ip"
   location                     = "${var.region}"
-  resource_group_name          = "${var.resource_group_name}"
+  resource_group_name          = "${azurerm_resource_group.bosh.name}"
   public_ip_address_allocation = "dynamic"
 }
 
 resource "azurerm_application_gateway" "cf" {
   name                = "${var.env_id}-app-gateway"
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name = "${azurerm_resource_group.bosh.name}"
   location            = "${var.region}"
 
   sku {

--- a/terraform/azure/templates/concourse_lb.tf
+++ b/terraform/azure/templates/concourse_lb.tf
@@ -1,7 +1,7 @@
 resource "azurerm_public_ip" "concourse" {
   name                         = "${var.env_id}-concourse-lb"
   location                     = "${var.region}"
-  resource_group_name          = "${var.resource_group_name}"
+  resource_group_name          = "${azurerm_resource_group.bosh.name}"
   public_ip_address_allocation = "static"
   sku                          = "Standard"
 
@@ -12,7 +12,7 @@ resource "azurerm_public_ip" "concourse" {
 
 resource "azurerm_lb" "concourse" {
   name                = "${var.env_id}-concourse-lb"
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name = "${azurerm_resource_group.bosh.name}"
   location            = "${var.region}"
   sku                 = "Standard"
 
@@ -24,7 +24,7 @@ resource "azurerm_lb" "concourse" {
 
 resource "azurerm_lb_rule" "concourse-https" {
   name                = "${var.env_id}-concourse-https"
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id     = "${azurerm_lb.concourse.id}"
 
   frontend_ip_configuration_name = "${var.env_id}-concourse-frontend-ip-configuration"
@@ -38,7 +38,7 @@ resource "azurerm_lb_rule" "concourse-https" {
 
 resource "azurerm_lb_probe" "concourse-https" {
   name                = "${var.env_id}-concourse-https"
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id     = "${azurerm_lb.concourse.id}"
   protocol            = "TCP"
   port                = 443
@@ -46,7 +46,7 @@ resource "azurerm_lb_probe" "concourse-https" {
 
 resource "azurerm_lb_rule" "concourse-http" {
   name                = "${var.env_id}-concourse-http"
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id     = "${azurerm_lb.concourse.id}"
 
   frontend_ip_configuration_name = "${var.env_id}-concourse-frontend-ip-configuration"
@@ -60,7 +60,7 @@ resource "azurerm_lb_rule" "concourse-http" {
 
 resource "azurerm_lb_probe" "concourse-http" {
   name                = "${var.env_id}-concourse-http"
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id     = "${azurerm_lb.concourse.id}"
   protocol            = "TCP"
   port                = 80
@@ -76,7 +76,7 @@ resource "azurerm_network_security_rule" "concourse-http" {
   destination_port_range      = "80"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${var.resource_group_name}"
+  resource_group_name         = "${azurerm_resource_group.bosh.name}"
   network_security_group_name = "${azurerm_network_security_group.bosh.name}"
 }
 
@@ -90,13 +90,13 @@ resource "azurerm_network_security_rule" "concourse-https" {
   destination_port_range      = "443"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${var.resource_group_name}"
+  resource_group_name         = "${azurerm_resource_group.bosh.name}"
   network_security_group_name = "${azurerm_network_security_group.bosh.name}"
 }
 
 resource "azurerm_lb_backend_address_pool" "concourse" {
   name                = "${var.env_id}-concourse-backend-pool"
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id     = "${azurerm_lb.concourse.id}"
 }
 

--- a/terraform/azure/templates/network.tf
+++ b/terraform/azure/templates/network.tf
@@ -2,7 +2,7 @@ resource "azurerm_virtual_network" "bosh" {
   name                = "${var.env_id}-bosh-vn"
   address_space       = ["${var.network_cidr}"]
   location            = "${var.region}"
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name = "${azurerm_resource_group.bosh.name}"
 }
 
 resource "azurerm_subnet" "bosh" {

--- a/terraform/azure/templates/network_security_group.tf
+++ b/terraform/azure/templates/network_security_group.tf
@@ -1,7 +1,7 @@
 resource "azurerm_network_security_group" "bosh" {
   name                = "${var.env_id}-bosh"
   location            = "${var.region}"
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name = "${azurerm_resource_group.bosh.name}"
 
   tags {
     environment = "${var.env_id}"
@@ -18,7 +18,7 @@ resource "azurerm_network_security_rule" "ssh" {
   destination_port_range      = "22"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${var.resource_group_name}"
+  resource_group_name         = "${azurerm_resource_group.bosh.name}"
   network_security_group_name = "${azurerm_network_security_group.bosh.name}"
 }
 
@@ -32,7 +32,7 @@ resource "azurerm_network_security_rule" "bosh-agent" {
   destination_port_range      = "6868"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${var.resource_group_name}"
+  resource_group_name         = "${azurerm_resource_group.bosh.name}"
   network_security_group_name = "${azurerm_network_security_group.bosh.name}"
 }
 
@@ -46,7 +46,7 @@ resource "azurerm_network_security_rule" "bosh-director" {
   destination_port_range      = "25555"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${var.resource_group_name}"
+  resource_group_name         = "${azurerm_resource_group.bosh.name}"
   network_security_group_name = "${azurerm_network_security_group.bosh.name}"
 }
 
@@ -60,7 +60,7 @@ resource "azurerm_network_security_rule" "dns" {
   destination_port_range      = "53"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${var.resource_group_name}"
+  resource_group_name         = "${azurerm_resource_group.bosh.name}"
   network_security_group_name = "${azurerm_network_security_group.bosh.name}"
 }
 
@@ -74,6 +74,6 @@ resource "azurerm_network_security_rule" "credhub" {
   destination_port_range      = "8844"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${var.resource_group_name}"
+  resource_group_name         = "${azurerm_resource_group.bosh.name}"
   network_security_group_name = "${azurerm_network_security_group.bosh.name}"
 }

--- a/terraform/azure/templates/output.tf
+++ b/terraform/azure/templates/output.tf
@@ -7,7 +7,7 @@ output "subnet_name" {
 }
 
 output "resource_group_name" {
-  value = "${var.resource_group_name}"
+  value = "${azurerm_resource_group.bosh.name}"
 }
 
 output "storage_account_name" {

--- a/terraform/azure/templates/resource_group.tf
+++ b/terraform/azure/templates/resource_group.tf
@@ -1,5 +1,5 @@
 resource "azurerm_resource_group" "bosh" {
-  name     = "${var.resource_group_name}"
+  name     = "${var.env_id}-bosh"
   location = "${var.region}"
 
   tags {
@@ -10,7 +10,7 @@ resource "azurerm_resource_group" "bosh" {
 resource "azurerm_public_ip" "bosh" {
   name                         = "${var.env_id}-bosh"
   location                     = "${var.region}"
-  resource_group_name          = "${var.resource_group_name}"
+  resource_group_name          = "${azurerm_resource_group.bosh.name}"
   public_ip_address_allocation = "static"
 
   tags {

--- a/terraform/azure/templates/storage.tf
+++ b/terraform/azure/templates/storage.tf
@@ -6,7 +6,7 @@ resource "random_string" "account" {
 
 resource "azurerm_storage_account" "bosh" {
   name                = "${var.simple_env_id}${random_string.account.result}"
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name = "${azurerm_resource_group.bosh.name}"
 
   location                 = "${var.region}"
   account_tier             = "Standard"
@@ -23,14 +23,14 @@ resource "azurerm_storage_account" "bosh" {
 
 resource "azurerm_storage_container" "bosh" {
   name                  = "bosh"
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name   = "${azurerm_resource_group.bosh.name}"
   storage_account_name  = "${azurerm_storage_account.bosh.name}"
   container_access_type = "private"
 }
 
 resource "azurerm_storage_container" "stemcell" {
   name                  = "stemcell"
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name   = "${azurerm_resource_group.bosh.name}"
   storage_account_name  = "${azurerm_storage_account.bosh.name}"
   container_access_type = "blob"
 }


### PR DESCRIPTION
Reverts cloudfoundry/bosh-bootloader#309

This doesn't actually work because of a few problems:
- original PR didn't include a variable definition for `var.resource_group_name`
  - intended PR contained `variable "resource_group_name" {default = "${var.env_id}-bosh"}` but this change didn't get pushed
- HCL doesn't let you interpolate variable defaults with other variables
  - see [these](https://github.com/hashicorp/terraform/issues/14343) [issues](https://github.com/hashicorp/terraform/issues/4084) in Terraform
- injecting a reasonable default with `terraform/azure/input_generator.go` causes failures because the resource group `${envID}-bosh` doesn't actually exist yet
  - this means we would have to adopt a strategy similar to the hosted DNS zone strategy for AWS, where we actually check if the resource already exists by making an API call, and alter the Terraform input based on whether it does or not