### PR TITLE
Plan patch for Concourse's that want to use the director's internal Credhub

### DIFF
--- a/plan-patches/README.md
+++ b/plan-patches/README.md
@@ -29,6 +29,7 @@ Many of these have additional prep steps or specific downstream bosh deployments
 | [restricted-instance-groups-gcp](restricted-instance-groups-gcp/) | Create two seperate instance groups |
 | [colocate-gorouter-ssh-proxy-gcp](colocate-gorouter-ssh-proxy-gcp/) | Helpful if you're trying to colocate everything |
 | [prometheus-lb-gcp](prometheus-lb-gcp/) | Deploy a dedicated GCP load balancer for your prometheus cluster |
+| [concourse-credhub-gcp](concourse-credhub-gcp/) | Creates a firewall rule to allow internal vms (e.g ATC) to communicate with the director's internal UAA and Credhub servers. |
 | **VSPHERE** |     |
 | [cfcr-vsphere](cfcr-vsphere/) | Deploy a CFCR with a single master static IP and the vsphere cloud-provider |
 | **OPENSTACK** |     |

--- a/plan-patches/concourse-credhub-gcp/terraform/internal-to-director-credhub-firewall-rule_override.tf
+++ b/plan-patches/concourse-credhub-gcp/terraform/internal-to-director-credhub-firewall-rule_override.tf
@@ -1,0 +1,13 @@
+resource "google_compute_firewall" "internal-to-director-credhub" {
+  name    = "${var.env_id}-internal-to-director-credhub"
+  network = "${google_compute_network.bbl-network.name}"
+
+  source_tags = ["${var.env_id}-internal"]
+
+  allow {
+    ports    = ["8844", "8443"]
+    protocol = "tcp"
+  }
+
+  target_tags = ["${var.env_id}-bosh-director"]
+}


### PR DESCRIPTION
This PR is to enable an operator to configure a Concourse on a bbl environment on GCP to use Credhub as a Credential Manager. Default BBL environments on GCP don't allow internal vms to communicate with the the bosh director on UAA's port (8443) nor Credhub's port (8844). This patch creates a firewall rule to allow those ports.