### PR TITLE
docs: improve consistency

### DIFF
--- a/docs/cf-lbs.md
+++ b/docs/cf-lbs.md
@@ -24,8 +24,6 @@
         - `HTTPS:443` to `HTTP:80`
         - `TLS:4443`  to `TCP:80`
 
-
-
 ## GCP
 `bbl` creates 4 load balancers on GCP.
 
@@ -67,9 +65,8 @@
         - Firewall rule allowing `tcp:2222` to the target pool
         - Forwarding rule for `tcp:2222` to the target pool
 
-
 ## Microsoft Azure
-There is an application gateway.
+`bbl` creates an application gateway on Microsoft Azure.
 
 1. **cf-app-gateway**
     * In the cloud-config, this lb is referenced with the vm extension `cf-router-network-properties`.
@@ -79,7 +76,6 @@ There is an application gateway.
         - Application Gateway
         - Network Security Rules
         - Network Security Group
-
 
 ## vSphere
 N/A.

--- a/docs/cloudfoundry.md
+++ b/docs/cloudfoundry.md
@@ -1,8 +1,30 @@
-## Generic Steps for Cloud Foundry Deployment
+# Generic Steps for Cloud Foundry Deployment
 
 1. Create an environment and target the BOSH director with `eval "$(bbl print-env)"`
 
-1. `bbl plan --lb-type cf --lb-cert cert --lb-key key && bbl up` with a certificate and key as flags or environment variables.
-(Continue to provide the IaaS credentials as flags or environment variables.)
+1. `bbl plan --lb-type cf --lb-cert <PATH_TO_CERT_FILE> --lb-key <PATH_TO_KEY_FILE> && bbl up`. You can use existing certificate and key files, or generate new ones. See below for instructions on generating these files for Microsoft Azure.
 
 1. `bosh deploy cf-deployment.yml -o operations/<MY IaaS>` using the [CF deployment manifest!](https://github.com/cloudfoundry/cf-deployment)
+
+## Appendix: Generating Load Balancer Key and Certificate Files for Microsoft Azure
+
+To create Cloud Foundry load balancers for Microsoft Azure you must provide a certificate
+in the `.pfx` format:
+
+```
+openssl genrsa -out DOMAIN_NAME.key 2048
+openssl req -new -x509 -days 365 -key DOMAIN_NAME.key -out DOMAIN_NAME.crt
+openssl pkcs12 -export -out PFX_FILE -inkey DOMAIN_NAME.key -in DOMAIN_NAME.crt
+```
+
+Save the password you entered when prompted by `openssl` to a file.
+
+```
+echo SuperSecretPassword > PFX_FILE_PASSWORD
+```
+
+To `bbl  plan` or `bbl up` you can provide the `.pfx` file and password:
+
+```
+bbl plan --lb-type cf --lb-cert PFX_FILE --lb-key PFX_FILE_PASSWORD
+```

--- a/docs/concourse.md
+++ b/docs/concourse.md
@@ -1,4 +1,4 @@
-# Concourse
+# Generic Steps for Concourse Deployment
 
 This document will walk through deploying a concourse clustered
 install using `bbl` and `bosh`.

--- a/docs/credhub.md
+++ b/docs/credhub.md
@@ -1,39 +1,41 @@
-# Accessing the BOSH director credhub
+# Accessing the BOSH Director CredHub
 
-## Using CREDHUB_PROXY
-
-### Requirements
-
-- `bbl v6.2`
-- `credhub-cli v1.6.0`
-- a bbl environment
-
-### Steps
-
-`bbl print-env` prints out environment variables (`CREDHUB_CLIENT`, `CREDHUB_SECRET`, `CREDHUB_PROXY`,
-`CREDHUB_SERVER`, `CREDHUB_CA_CERT`, and others)
-that need to be exported to target the director credhub using the credhub-cli.
-
-```
-eval "$(bbl print-env)"
-
-credhub find -n 'cf_admin_password'
-```
-
-The credhub-cli will parse `CREDHUB_PROXY` and determines from the `ssh+socks5://` scheme
-that it should proxy throuhg a jumpbox via a tunnel of its own making.
-
-
-
-## Using http_proxy
+## Using `CREDHUB_PROXY`
 
 ### Requirements
 
-- `bbl pre-v6.2`
-- `credhub-cli < v1.6.0`
+- `bbl v6.2` or above
+- `credhub-cli v1.6.0` or above
 - a bbl environment
 
-### Steps
+### Instructions
+
+1. Set necessary environment variables
+
+    `bbl print-env` prints out environment variables (`CREDHUB_CLIENT`, `CREDHUB_SECRET`, `CREDHUB_PROXY`,
+`CREDHUB_SERVER`, `CREDHUB_CA_CERT`, and others) that need to be exported to target the Director CredHub using the CredHub CLI.
+
+    ```
+    eval "$(bbl print-env)"
+    ```
+
+1. Get credentials
+
+    ```
+    http_proxy=socks5://localhost:5000 credhub find -n 'cf_admin_password'
+    ```
+
+    The CredHub CLI will parse `CREDHUB_PROXY` and determines from the `ssh+socks5://` scheme that it should proxy throuhg a jumpbox via a tunnel of its own making.
+
+## Using `http_proxy`
+
+### Requirements
+
+- `bbl`
+- `credhub-cli`
+- a bbl environment
+
+### Instructions
 
 1. Set your CredHub client/secret
 
@@ -50,11 +52,13 @@ that it should proxy throuhg a jumpbox via a tunnel of its own making.
     ```
 
 1. Login
+
     ```
     http_proxy=socks5://localhost:5000 credhub login
     ```
 
 1. Get credentials
+
     ```
     http_proxy=socks5://localhost:5000 credhub find -n 'cf_admin_password'
     ```

--- a/docs/getting-started-aws.md
+++ b/docs/getting-started-aws.md
@@ -1,4 +1,4 @@
-### Getting started: AWS
+# Getting Started: AWS
 
 This guide is a walkthrough for deploying a BOSH director with `bbl`
 on AWS. Upon completion, you will have the following:
@@ -11,7 +11,7 @@ any instances BOSH deploys
 1. A copy of the manifest the BOSH director was deployed with
 1. A basic cloud config
 
-### Creating an IAM user
+## Creating an IAM user
 
 In order for `bbl` to interact with AWS, an `IAM` user must be created.
 
@@ -58,7 +58,7 @@ access key" to the terminal. These values are important and should
 be kept secret. In the next section `bbl` will use these commands to
 create infrastructure on AWS.
 
-### bbl up
+## Pave Infrastructure, Create a Jumpbox, and Create a BOSH Director
 
 `bbl` will create infrastructure and deploy a BOSH director with the
 following command:
@@ -78,58 +78,9 @@ create your bosh director. This should be checked in to version control,
 so that you have all the information necessary to later destroy or
 update this environment at a later date.
 
-### Connecting to the BOSH director
 
-To setup your BOSH CLI with the director you'll need the following
-command to set the credentials:
+## Next Steps
 
-```
-eval "$(bbl print-env)"
-```
-
-#### Alternatives to `bbl print-env`
-
-Separate commands are available for the `bbl print-env` fields:
-
-```
-$ bbl director-address
-https://10.0.0.6:25555
-
-$ bbl director-username
-user-d3783rk
-
-$ bbl director-password
-p-23dah71skl
-
-$ bbl director-ca-cert
------BEGIN CERTIFICATE-----
-MIIDtzCCAp+gAwIBAgIJAIPgaUgWRCE8MA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
-...
------END CERTIFICATE-----
-```
-
-You might save the CA certificate to a file:
-
-```
-$ bbl director-ca-cert > bosh.crt
-$ export BOSH_CA_CERT=bosh.crt
-```
-
-To login:
-
-```
-$ export BOSH_ENVIRONMENT=$(bbl director-address)
-$ bosh alias-env <INSERT TARGET NAME>
-$ bosh log-in
-Username: user-d3783rk
-Password: p-23dah71sk1
-```
-
-Display cloud config to test setup and show configuration mapping:
-
-```
-$ bosh cloud-config
-...
-```
-
-Now you're ready to deploy software with BOSH.
+* [Target the BOSH Director](howto-target-bosh-director.md)
+* [Deploy Cloud Foundry](cloudfoundry.md)
+* [Deploy Concourse](concourse.md)

--- a/docs/getting-started-azure.md
+++ b/docs/getting-started-azure.md
@@ -1,5 +1,16 @@
 # Getting Started: Microsoft Azure
 
+This guide is a walkthrough for deploying a BOSH director with `bbl`
+on Microsoft Azure. Upon completion, you will have the following:
+
+1. A BOSH director
+1. A jumpbox
+1. A set of randomly generated BOSH director credentials
+1. A generated keypair allowing you to SSH into the BOSH director and
+any instances BOSH deploys
+1. A copy of the manifest the BOSH director was deployed with
+1. A basic cloud config
+
 ## Create a Service Principal Account
 
 You can use the cli utility [az-automation](https://github.com/genevieve/az-automation)
@@ -12,7 +23,7 @@ your tenant id, the client id, and the client secret.
 These credentials will be passed to `bbl` so that
 it can interact with Azure.
 
-## Infrastructure, Jumpbox, Director
+## Pave Infrastructure, Create a Jumpbox, and Create a BOSH Director
 
 1. Export environment variables.
     ```
@@ -28,24 +39,8 @@ it can interact with Azure.
     bbl up
     ```
 
-## + Cloud Foundry Load Balancers
+## Next Steps
 
-To get all of the above plus load balancers for Cloud Foundry:
-
-1. To create cf load balancers for azure you must provide a certificate
-in the `.pfx` format:
-    ```
-    openssl genrsa -out DOMAIN_NAME.key 2048
-    openssl req -new -x509 -days 365 -key DOMAIN_NAME.key -out DOMAIN_NAME.crt
-    openssl pkcs12 -export -out PFX_FILE -inkey DOMAIN_NAME.key -in DOMAIN_NAME.crt
-    ```
-
-1. Save the password you entered when prompted by `openssl` to a file.
-    ```
-    echo SuperSecretPassword > PFX_FILE_PASSWORD
-    ```
-1. To `bbl  plan` or `bbl up` you can provide the pfx file and password:
-    ```
-    bbl plan --lb-type cf --lb-cert PFX_FILE --lb-key PFX_FILE_PASSWORD
-    bbl up
-    ```
+* [Target the BOSH Director](howto-target-bosh-director.md)
+* [Deploy Cloud Foundry](cloudfoundry.md)
+* [Deploy Concourse](concourse.md)

--- a/docs/getting-started-gcp.md
+++ b/docs/getting-started-gcp.md
@@ -1,5 +1,16 @@
 # Getting Started: GCP
 
+This guide is a walkthrough for deploying a BOSH director with `bbl`
+on GCP. Upon completion, you will have the following:
+
+1. A BOSH director
+1. A jumpbox
+1. A set of randomly generated BOSH director credentials
+1. A generated keypair allowing you to SSH into the BOSH director and
+any instances BOSH deploys
+1. A copy of the manifest the BOSH director was deployed with
+1. A basic cloud config
+
 ## Create a Service Account
 
 In order for `bbl` to interact with GCP, a service account must be created.
@@ -12,7 +23,7 @@ gcloud iam service-accounts keys create --iam-account='<service account name>@<p
 gcloud projects add-iam-policy-binding <project id> --member='serviceAccount:<service account name>@<project id>.iam.gserviceaccount.com' --role='roles/editor'
 ```
 
-## Infrastructure, Jumpbox, Director
+## Pave Infrastructure, Create a Jumpbox, and Create a BOSH Director
 
 1. Export environment variables.
     ```
@@ -25,12 +36,8 @@ gcloud projects add-iam-policy-binding <project id> --member='serviceAccount:<se
     bbl up
     ```
 
-## + Cloud Foundry Load Balancers
+## Next Steps
 
-To get all of the above plus load balancers for Cloud Foundry:
-
-1. To `bbl  plan` or `bbl up` you can provide a cert, key, and (optionally) a domain:
-    ```
-    bbl plan --lb-type cf --lb-cert $CERT --lb-key $KEY --lb-domain $DOMAIN
-    bbl up
-    ```
+* [Target the BOSH Director](howto-target-bosh-director.md)
+* [Deploy Cloud Foundry](cloudfoundry.md)
+* [Deploy Concourse](concourse.md)

--- a/docs/getting-started-openstack.md
+++ b/docs/getting-started-openstack.md
@@ -1,10 +1,21 @@
 # Getting Started: OpenStack
 
+This guide is a walkthrough for deploying a BOSH director with `bbl`
+on OpenStack. Upon completion, you will have the following:
+
+1. A BOSH director
+1. A jumpbox
+1. A set of randomly generated BOSH director credentials
+1. A generated keypair allowing you to SSH into the BOSH director and
+any instances BOSH deploys
+1. A copy of the manifest the BOSH director was deployed with
+1. A basic cloud config
+
 `bbl` creates and maintains the lifecycle of the jumpbox and BOSH director.
 
 It does not create any networks, security groups, or load balancers on OpenStack.
 
-## Jumpbox, Director
+## Create a Jumpbox and a BOSH Director
 
 1. Export environment variables.
     ```
@@ -27,3 +38,7 @@ It does not create any networks, security groups, or load balancers on OpenStack
     ```
     bbl up
     ```
+
+## Next Steps
+
+* [Target the BOSH Director](howto-target-bosh-director.md)

--- a/docs/getting-started-vsphere.md
+++ b/docs/getting-started-vsphere.md
@@ -1,10 +1,21 @@
 # Getting Started: vSphere
 
+This guide is a walkthrough for deploying a BOSH director with `bbl`
+on vSphere. Upon completion, you will have the following:
+
+1. A BOSH director
+1. A jumpbox
+1. A set of randomly generated BOSH director credentials
+1. A generated keypair allowing you to SSH into the BOSH director and
+any instances BOSH deploys
+1. A copy of the manifest the BOSH director was deployed with
+1. A basic cloud config
+
 `bbl` creates and maintains the lifecycle of the jumpbox and BOSH director.
 
 It does not create any networks, security groups, or load balancers on vSphere.
 
-## Jumbpox, Director
+## Create a Jumpbox and a BOSH Director
 
 1. Export environment variables.
     ```
@@ -24,3 +35,7 @@ It does not create any networks, security groups, or load balancers on vSphere.
     ```
     bbl up
     ```
+
+## Next Steps
+
+* [Target the BOSH Director](howto-target-bosh-director.md)

--- a/docs/howto-target-bosh-director.md
+++ b/docs/howto-target-bosh-director.md
@@ -1,0 +1,47 @@
+# How To Target The BOSH Director
+
+## The easy way: `bbl print-env`
+
+```
+eval "$(bbl print-env)"
+```
+
+## Alternatives to `bbl print-env`
+
+Separate commands are available for the `bbl print-env` fields:
+
+```
+$ bbl director-address
+https://10.0.0.6:25555
+
+$ bbl director-username
+user-d3783rk
+
+$ bbl director-password
+p-23dah71skl
+
+$ bbl director-ca-cert
+-----BEGIN CERTIFICATE-----
+MIIDtzCCAp+gAwIBAgIJAIPgaUgWRCE8MA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
+...
+-----END CERTIFICATE-----
+```
+
+You might save the CA certificate to a file:
+
+```
+$ bbl director-ca-cert > bosh.crt
+$ export BOSH_CA_CERT=bosh.crt
+```
+
+To login:
+
+```
+$ export BOSH_ENVIRONMENT=$(bbl director-address)
+$ bosh alias-env <INSERT TARGET NAME>
+$ bosh log-in
+Username: user-d3783rk
+Password: p-23dah71sk1
+```
+
+Now you're ready to deploy software with BOSH.


### PR DESCRIPTION
Primarily extract instructions for targetting BOSH Director into its own doc, and link to it from all Getting Started docs.