### PR TITLE
Update concourse guide for updated ops files

### DIFF
--- a/docs/concourse.md
+++ b/docs/concourse.md
@@ -16,13 +16,14 @@ install using `bbl` and `bosh`.
   ```bash
   bbl up --lb-type concourse
 
-  export external_url="https://$(bbl lbs | awk -F': ' '{print $2}')"
+  export external_host="$(bbl lbs | awk -F': ' '{print $2}')"
+  export external_url="https://$external_host"
 
   eval "$(bbl print-env)"
 
   bosh upload-stemcell https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-trusty-go_agent
 
-  cd $GOPATH/src/github.com/concourse/concourse-bosh-deployment/cluster
+  cd ~/workspace/concourse-bosh-deployment/cluster
   ```
 
 1. Deploy concourse.
@@ -31,7 +32,7 @@ install using `bbl` and `bosh`.
   cat >secrets.yml <<EOL
 local_user:
     username: <username>
-    password: <super-secret-password>
+    password: <super-secret-password> # bcrypted password
 EOL
 
   bosh deploy -d concourse concourse.yml \
@@ -42,9 +43,11 @@ EOL
     -o operations/privileged-http.yml \
     -o operations/privileged-https.yml \
     -o operations/tls.yml \
+    -o operations/tls-vars.yml \
     -o operations/web-network-extension.yml \
     --var network_name=default \
     --var external_url=$external_url \
+    --var external_host=$external_host \
     --var web_vm_type=default \
     --var db_vm_type=default \
     --var db_persistent_disk_type=10GB \


### PR DESCRIPTION
- use tls-vars.yml ops file
- password needs to be bcrypted (concourse v4)