### PR TITLE
Remove unnecessary http_proxy env var

### DIFF
--- a/docs/credhub.md
+++ b/docs/credhub.md
@@ -22,7 +22,7 @@
 1. Get credentials
 
     ```
-    http_proxy=socks5://localhost:5000 credhub find -n 'cf_admin_password'
+    credhub find -n 'cf_admin_password'
     ```
 
     The CredHub CLI will parse `CREDHUB_PROXY` and determines from the `ssh+socks5://` scheme that it should proxy throuhg a jumpbox via a tunnel of its own making.


### PR DESCRIPTION
This minimal PR makes a change to the credhub documentation section that describes the behavior of the credhub CLI when `CREDHUB_PROXY` is set. If `bbl print-env` has been `eval`ed before this statement as the docs suggest, then `CREDHUB_PROXY` should be set in the environment, and the `http_proxy` env var should not be necessary to communicate with the CredHub server.