### PR TITLE
Adding abiliby to provide existing Internet Gateway

### DIFF
--- a/terraform/aws/templates/base.tf
+++ b/terraform/aws/templates/base.tf
@@ -390,7 +390,7 @@ resource "aws_route_table" "bosh_route_table" {
 
 resource "aws_route" "bosh_route_table" {
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.ig.id}"
+  gateway_id             = "${local.ig_id}"
   route_table_id         = "${aws_route_table.bosh_route_table.id}"
 }
 
@@ -430,7 +430,19 @@ resource "aws_route_table_association" "route_internal_subnets" {
   route_table_id = "${aws_route_table.internal_route_table.id}"
 }
 
+variable "existing_ig_id" {
+  type        = "string"
+  default     = ""
+  description = "Optionally use an existing Internet Gateway"
+}
+
+locals {
+  ig_count = "${length(var.existing_ig_id) > 0 ? 0 : 1}"
+  ig_id     = "${length(var.existing_ig_id) > 0 ? var.existing_ig_id : join(" ", aws_internet_gateway.ig.*.id)}"
+}
+
 resource "aws_internet_gateway" "ig" {
+  count  = "${local.ig_count}"
   vpc_id = "${local.vpc_id}"
 }
 

--- a/terraform/aws/templates/base.tf
+++ b/terraform/aws/templates/base.tf
@@ -430,15 +430,16 @@ resource "aws_route_table_association" "route_internal_subnets" {
   route_table_id = "${aws_route_table.internal_route_table.id}"
 }
 
-variable "existing_ig_id" {
-  type        = "string"
-  default     = ""
-  description = "Optionally use an existing Internet Gateway"
+locals {
+  ig_count = "${length(var.existing_vpc_id) > 0 ? 0 : 1}"
+  ig_id     = "${length(var.existing_vpc_id) > 0 ? data.aws_internet_gateway.default.id : join(" ", aws_internet_gateway.ig.*.id)}"
 }
 
-locals {
-  ig_count = "${length(var.existing_ig_id) > 0 ? 0 : 1}"
-  ig_id     = "${length(var.existing_ig_id) > 0 ? var.existing_ig_id : join(" ", aws_internet_gateway.ig.*.id)}"
+data "aws_internet_gateway" "default" {
+  filter {
+    name = "attachment.vpc-id"
+    values = ["${local.vpc_id}"]
+  }
 }
 
 resource "aws_internet_gateway" "ig" {

--- a/terraform/aws/templates/lb_subnet.tf
+++ b/terraform/aws/templates/lb_subnet.tf
@@ -19,7 +19,7 @@ resource "aws_route_table" "lb_route_table" {
 
 resource "aws_route" "lb_route_table" {
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.ig.id}"
+  gateway_id             = "${local.ig_id}"
   route_table_id         = "${aws_route_table.lb_route_table.id}"
 }
 


### PR DESCRIPTION
Sometimes it is required to deploy CF into existing VPC.
There is a [variable](https://github.com/cloudfoundry/bosh-bootloader/blob/master/terraform/aws/templates/vpc.tf#L1) to set that VPC, but it does not make a sense yet, because even with existing VPC BBL still trying to create and attach new Internet Gateway. Since VPC cannot have more than one IG attached - the deployment will fail.
This PR allows to provide existing IG along with VPC, so deployment will be successfull.