### PR TITLE
re-organize the Concourse guide

### DIFF
--- a/docs/concourse.md
+++ b/docs/concourse.md
@@ -1,108 +1,131 @@
-# Generic Steps for Concourse Deployment
 
-This document will walk through deploying a concourse clustered
-install using `bbl` and `bosh`.
+# Concourse
 
 ## Prerequisites
 
-- `bbl`
-- [bosh v2](https://bosh.io/docs/cli-v2.html)
-- [concourse/concourse-bosh-deployment](https://github.com/concourse/concourse-bosh-deployment)
+If one has followed the BBL steps mentioned in the [**IaaS-Specific Getting Started Guides**](https://github.com/cloudfoundry/bosh-bootloader#iaas-specific-getting-started-guides), the foundation has been created according to your IaaS of choice, which typically includes:
 
-## Steps
+1. A BOSH director
+2. A jumpbox
+3. A set of randomly generated BOSH director credentials
+4. A generated keypair allowing you to SSH into the BOSH director and any instances BOSH deploys
+5. A copy of the manifest the BOSH director was deployed with
+6. A basic cloud config
 
-### Create an environment and upload a stemcell.
 
-  Stemcell Url for each IAAS
-  
-  ```bash
-  # GCP
-  export STEMCELL_URL="https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-xenial-go_agent"
-  # AWS
+## Deploy Concourse Cluster
+
+On top of these, below are the typical steps to deploy Concourse cluster.
+
+### 1. Create Concourse LB
+
+Let's run our scripts in the folder where one ran the `bbl up`.
+
+```
+bbl plan --lb-type concourse
+bbl up
+```
+
+> Note: this will create a new IaaS Load Balancer, with some ports (80, 443, 2222, 8443, 8844) pre-configured and opened, to front Concourse web node(s).
+
+
+### 2. Prepare for Concourse Deployment
+
+```
+eval "$(bbl print-env)"
+
+export IAAS="$(cat bbl-state.json | jq -r .iaas)"
+if [ "${IAAS}" = "aws" ]; then
+  export EXTERNAL_HOST="$(bbl outputs | grep concourse_lb_url | cut -d ' ' -f2)"
   export STEMCELL_URL="https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent"
-  # Azure
+elif [ "${IAAS}" = "gcp" ]; then
+  export EXTERNAL_HOST="$(bbl outputs | grep concourse_lb_ip | cut -d ' ' -f2)"
+  export STEMCELL_URL="https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-xenial-go_agent"
+else # Azure
+  export EXTERNAL_HOST="$(bbl outputs | grep concourse_lb_ip | cut -d ' ' -f2)"
   export STEMCELL_URL="https://bosh.io/d/stemcells/bosh-azure-hyperv-ubuntu-xenial-go_agent"
-  ```
+fi
 
-  ```bash
-  mkdir my-concourse-bbl-state
-  cd my-concourse-bbl-state
-  
-  bbl up --lb-type concourse
+bosh upload-stemcell "${STEMCELL_URL}"
+```
 
-  eval "$(bbl print-env)"
 
-  bosh upload-stemcell "${STEMCELL_URL}"
-  
-  export IAAS="$(cat bbl-state.json | jq -r .iaas)"
-  if [ "${IAAS}" = "aws" ]; then
-    export EXTERNAL_HOST="$(bbl outputs | grep concourse_lb_url | cut -d ' ' -f2)"
-  else # Azure and GCP
-    export EXTERNAL_HOST="$(bbl outputs | grep concourse_lb_ip | cut -d ' ' -f2)"
-  fi
-  ```
-
-### Deploy concourse
-
+### 3. Customize & Deploy
 
 #### On Azure and GCP
-  ```bash
-pushd $GOPATH/src/github.com/concourse/concourse-bosh-deployment/cluster
-  
-      export USERNAME="username"
-      export PASSWORD="super-secure-password"
-      cat > vars.yml <<EOL
+
+```
+git clone https://github.com/concourse/concourse-bosh-deployment.git
+
+pushd concourse-bosh-deployment/cluster
+
+    export USERNAME="username"
+    export PASSWORD="super-secure-password"
+
+    cat > ../../vars/concourse-vars-file.yml <<EOL
 external_host: "${EXTERNAL_HOST}"
 external_url: "https://${EXTERNAL_HOST}"
 local_user:
-    username: "${USERNAME}"
-    password: "${PASSWORD}"
+  username: "${USERNAME}"
+  password: "${PASSWORD}"
 network_name: 'private'
+web_instances: 1
 web_network_name: 'private'
 web_vm_type: 'default'
 web_network_vm_extension: 'lb'
 db_vm_type: 'default'
 db_persistent_disk_type: '1GB'
+worker_instances: 2
 worker_vm_type: 'default'
+worker_ephemeral_disk: '50GB_ephemeral_disk'
 deployment_name: 'concourse'
 EOL
 
-    bosh deploy -d concourse concourse.yml \
-      -l ../versions.yml \
-      -l vars.yml \
-      -o operations/basic-auth.yml \
-      -o operations/privileged-http.yml \
-      -o operations/privileged-https.yml \
-      -o operations/tls.yml \
-      -o operations/tls-vars.yml \
-      -o operations/web-network-extension.yml
-   
- popd
-  ```
-  
+  bosh deploy -d concourse concourse.yml \
+    -l ../versions.yml \
+    -l ../../vars/concourse-vars-file.yml \
+    -o operations/basic-auth.yml \
+    -o operations/privileged-http.yml \
+    -o operations/privileged-https.yml \
+    -o operations/tls.yml \
+    -o operations/tls-vars.yml \
+    -o operations/web-network-extension.yml \
+    -o operations/scale.yml \
+    -o operations/worker-ephemeral-disk.yml
+ 
+popd
+```
+
 #### On AWS
-```bash
-pushd $GOPATH/src/github.com/concourse/concourse-bosh-deployment/cluster
-  
-      export USERNAME="username"
-      export PASSWORD="super-secure-password"
-      cat > vars.yml <<EOL
+
+```
+git clone https://github.com/concourse/concourse-bosh-deployment.git
+
+pushd concourse-bosh-deployment/cluster
+
+    export USERNAME="username"
+    export PASSWORD="super-secure-password"
+
+    cat > ../../vars/concourse-vars-file.yml <<EOL
 external_host: "${EXTERNAL_HOST}"
 external_url: "https://${EXTERNAL_HOST}"
 local_user:
-    username: "${USERNAME}"
-    password: "${PASSWORD}"
+  username: "${USERNAME}"
+  password: "${PASSWORD}"
 network_name: 'private'
+web_instances: 1
 web_network_name: 'private'
 web_vm_type: 'default'
 web_network_vm_extension: 'lb'
 db_vm_type: 'default'
 db_persistent_disk_type: '1GB'
+worker_instances: 2
 worker_vm_type: 'default'
+worker_ephemeral_disk: '50GB_ephemeral_disk'
 deployment_name: 'concourse'
 EOL
 
-    cat > aws-tls-vars.yml <<EOL
+  cat > ../../vars/aws-tls-vars.yml <<EOL
 - type: replace
   path: /variables/-
   value:
@@ -123,40 +146,55 @@ EOL
       organization: atcOrg
 EOL
 
-    bosh deploy -d concourse concourse.yml \
-      -l ../versions.yml \
-      -l vars.yml \
-      -o operations/basic-auth.yml \
-      -o operations/privileged-http.yml \
-      -o operations/privileged-https.yml \
-      -o operations/tls.yml \
-      -o aws-tls-vars.yml \
-      -o operations/web-network-extension.yml
-   
+  bosh deploy -d concourse concourse.yml \
+    -l ../versions.yml \
+    -l ../../vars/concourse-vars-file.yml \
+    -o operations/basic-auth.yml \
+    -o operations/privileged-http.yml \
+    -o operations/privileged-https.yml \
+    -o operations/tls.yml \
+    -o ../../vars/aws-tls-vars.yml \
+    -o operations/web-network-extension.yml \
+    -o operations/scale.yml \
+    -o operations/worker-ephemeral-disk.yml
+ 
 popd
 ```
 
-  
-** Note: The cert and key pair generated by the `tls-vars.yml` operations file are not real. If you need to be able to talk to your concourse over a trusted tls connection, you will need to pass in a cert/key pair that your workstation will recognize. 
+> Note: do check it out [here](https://github.com/concourse/concourse-bosh-deployment/tree/master/cluster/operations) for tons of operations files by which one can tune / customize the Concourse cluster.
 
-Example:
-  ```bash
-  cat >tls-vars-vars-file.yml <<EOL
-atc_tls:
-    certificate: |
-      <some-multi-line-cert>
-    ca: |
-      <some-multi-line-ca>
-    private_key: |
-      <some-multi-line-key>
-EOL
 
-bosh deploy -d concourse concourse.yml 
-    ...
-    -l tls-vars-vars-file.yml \
-    ...
-  ```
+### 4. Check It Out
 
-## Verify Successful Deployment
-Point your browser to `https://${EXTERNAL_HOST}`.
-Log in to the concourse with `${USERNAME}` and `${PASSWORD}`
+Once it's successfully done, we can simply check it out.
+
+View the BOSH VMs' status:
+
+```
+bosh -d concourse vms
+
+...
+Deployment 'concourse'
+
+Instance                                     Process State  AZ  IPs       VM CID                                   VM Type  Active
+db/e3921a7d-ca25-4abc-9860-8fae73625507      running        z1  10.0.1.1  vm-ebe33d11-a858-45bf-61eb-89eff5bb86f8  default  true
+web/dffa0d32-6e2d-446e-838f-ecfff86f0d51     running        z1  10.0.1.0  vm-6d4585b5-fda2-4215-547a-b249de8b1384  default  true
+worker/06c58730-35f1-4c2f-9bb0-10f0216f8491  running        z1  10.0.1.2  vm-026513ed-85c7-47aa-7260-0fe7c286af36  default  true
+worker/3a0945f5-b59d-4ef9-8002-d7c8468c2f59  running        z1  10.0.1.3  vm-4ee75638-ba98-4474-7719-b523b3fabd23  default  true
+
+4 vms
+
+Succeeded
+```
+
+Open Concourse in Browser:
+
+```
+open `bosh int vars/concourse-vars-file.yml --path /external_url`
+```
+
+And login with username/password from below output:
+
+```
+bosh int vars/concourse-vars-file.yml --path /local_user
+```


### PR DESCRIPTION
The original Concourse guide is confusing as it will create everything, including Infra paving, Jumpbox, BOSH etc., from scratch, which is not exactly as part of the "What's Next".

This PR is to fine tune the flow and make it clear for users to make it another next step for deploying Concourse cluster.