### PR TITLE
Name servers list issue

### DIFF
--- a/terraform/aws/templates/cf_dns.tf
+++ b/terraform/aws/templates/cf_dns.tf
@@ -15,12 +15,12 @@ data "aws_route53_zone" "parent" {
 }
 
 output "env_dns_zone_name_servers" {
-  value = ["${split(",", local.name_servers)}"]
+  value = ["${local.name_servers}"]
 }
 
 locals {
   zone_id      = "${var.parent_zone == "" ? element(concat(aws_route53_zone.env_dns_zone.*.zone_id, list("")), 0) : element(concat(data.aws_route53_zone.parent.*.zone_id, list("")), 0)}"
-  name_servers = "${var.parent_zone == "" ? join(",", flatten(concat(aws_route53_zone.env_dns_zone.*.name_servers, list(list(""))))) :  join(",", flatten(concat(data.aws_route53_zone.env_dns_zone.*.name_servers, list(list("")))))}"
+  name_servers = "${aws_route53_zone.env_dns_zone.name_servers}"
 }
 
 resource "aws_route53_zone" "env_dns_zone" {


### PR DESCRIPTION
Hi!
In current implementation, BBL sets NS record for DNS zone as a single comma-separated string.
Example: 
`ns-1051.awsdns-03.org,ns-1546.awsdns-01.co.uk,ns-229.awsdns-28.com,ns-821.awsdns-38.net,`

This is incorrect. DNS resolution will not work. NS records have to be set as a list, one NS server per line. 
Example:
```
ns-1051.awsdns-03.org
ns-1546.awsdns-01.co.uk
ns-229.awsdns-28.com
ns-821.awsdns-38.net
```
However, this PR is not ready to merge yet, because I did not realized how to implement `parent_zone` logic there. Conditional operators cannot be used with list values. Any help is appreciated there.