### PR TITLE
Update cfcr-ops for 0.24

### DIFF
--- a/plan-patches/cfcr-gcp/cfcr-ops.yml
+++ b/plan-patches/cfcr-gcp/cfcr-ops.yml
@@ -11,9 +11,9 @@
   value: ((kubernetes_master_host))
 
 - type: replace
-  path: /instance_groups/name=master/jobs/name=cloud-provider/properties/cloud-provider/cloud-config/Global/project-id
+  path: /instance_groups/name=master/jobs/name=cloud-provider/properties/cloud-config/Global/project-id
   value: ((gcp_project_id))
 
 - type: replace
-  path: /instance_groups/name=worker/jobs/name=cloud-provider/properties/cloud-provider/cloud-config/Global/project-id
+  path: /instance_groups/name=worker/jobs/name=cloud-provider/properties/cloud-config/Global/project-id
   value: ((gcp_project_id))


### PR DESCRIPTION
Removed an extra key in the path according to https://github.com/cloudfoundry-incubator/kubo-deployment/blob/v0.24.0/manifests/ops-files/iaas/gcp/cloud-provider.yml