### PR TITLE
Add `--cmd` for `bbl ssh` to execute commands

### DIFF
--- a/commands/commands_usage.go
+++ b/commands/commands_usage.go
@@ -95,6 +95,7 @@ const (
 
   --jumpbox                Open a connection to the jumpbox
   --director               Open a connection to the director
+  --cmd                    Execute a command on the director (jumpbox not supported)
 `
 
 	RotateCommandUsage = "Rotates SSH key for the jumpbox user."


### PR DESCRIPTION
For now, this only supports executing commands on the director, as it is useful for us on the MySQL team.

In summary, this allows you to execute a command a la how ssh would originally run.

Please let me know of any feedback you have.