### PR TITLE
Add plan-patch for AWS S3 Blobstore Resources

### DIFF
--- a/plan-patches/README.md
+++ b/plan-patches/README.md
@@ -20,6 +20,7 @@ Many of these have additional prep steps or specific downstream bosh deployments
 | [1-az-aws](1-az-aws/) | Only create resources in a single availability zone |
 | [tf-backend-aws](tf-backend-aws/) | Store your terraform state in S3 |
 | [prometheus-lb-aws](prometheus-lb-aws/) | Deploy a dedicated AWS network load balancer for your prometheus cluster |
+| [s3-blobstore-aws](s3-blobstore-aws/) | Create S3 and IAM resources for an external blobstore |
 | **GCP** |     |
 | [bosh-lite-gcp](bosh-lite-gcp/) | For bosh-lites hosted on gcp |
 | [cfcr-gcp](cfcr-gcp/) | Deploy a CFCR with a kubeapi load balancer and aws cloud-provider |

--- a/plan-patches/s3-blobstore-aws/README.md
+++ b/plan-patches/s3-blobstore-aws/README.md
@@ -1,0 +1,16 @@
+# s3-blobstore-aws
+
+This plan-patch adds terraform templates to create resources required to use
+S3 for a CF blobstore.
+
+## Steps:
+
+1. Run `bbl plan`
+1. Copy the contents of the terraform directory to the terraform sub-directory
+   in your environment's state directory.
+1. Run `bbl up`
+
+## Permissions
+
+To use this plan-patch, you will need to update the IAM policy for your bbl
+IAM user to allow full access to S3 resources by adding the `s3:*` action.

--- a/plan-patches/s3-blobstore-aws/terraform/s3_blobstore_buckets.tf
+++ b/plan-patches/s3-blobstore-aws/terraform/s3_blobstore_buckets.tf
@@ -1,0 +1,19 @@
+resource "aws_s3_bucket" "buildpacks_bucket" {
+  bucket        = "${var.env_id}-buildpacks-bucket"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket" "droplets_bucket" {
+  bucket        = "${var.env_id}-droplets-bucket"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket" "packages_bucket" {
+  bucket        = "${var.env_id}-packages-bucket"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket" "resources_bucket" {
+  bucket        = "${var.env_id}-resources-bucket"
+  force_destroy = true
+}

--- a/plan-patches/s3-blobstore-aws/terraform/s3_blobstore_iam.tf
+++ b/plan-patches/s3-blobstore-aws/terraform/s3_blobstore_iam.tf
@@ -1,0 +1,47 @@
+data "template_file" "blobstore_access" {
+  template = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "$${buildpacks_bucket_arn}",
+        "$${buildpacks_bucket_arn}/*",
+        "$${droplets_bucket_arn}",
+        "$${droplets_bucket_arn}/*",
+        "$${packages_bucket_arn}",
+        "$${packages_bucket_arn}/*",
+        "$${resources_bucket_arn}",
+        "$${resources_bucket_arn}/*"
+      ]
+    }
+  ]
+}
+EOF
+
+  vars {
+    buildpacks_bucket_arn = "${aws_s3_bucket.buildpacks_bucket.arn}"
+    droplets_bucket_arn   = "${aws_s3_bucket.droplets_bucket.arn}"
+    packages_bucket_arn   = "${aws_s3_bucket.packages_bucket.arn}"
+    resources_bucket_arn  = "${aws_s3_bucket.resources_bucket.arn}"
+  }
+}
+
+resource "aws_iam_user" "blobstore_access" {
+  name = "${var.env_id}-s3-blobstore-access"
+}
+
+resource "aws_iam_access_key" "blobstore_access" {
+  user = "${aws_iam_user.blobstore_access.name}"
+}
+
+resource "aws_iam_user_policy" "blobstore_access" {
+  name = "${var.env_id}-s3-blobstore-access"
+  user = "${aws_iam_user.blobstore_access.name}"
+
+  policy = "${data.template_file.blobstore_access.rendered}"
+}

--- a/plan-patches/s3-blobstore-aws/terraform/s3_blobstore_outputs.tf
+++ b/plan-patches/s3-blobstore-aws/terraform/s3_blobstore_outputs.tf
@@ -1,0 +1,23 @@
+output "s3_blobstore_buildpacks_bucket" {
+  value = "${aws_s3_bucket.buildpacks_bucket.bucket}"
+}
+
+output "s3_blobstore_droplets_bucket" {
+  value = "${aws_s3_bucket.droplets_bucket.bucket}"
+}
+
+output "s3_blobstore_packages_bucket" {
+  value = "${aws_s3_bucket.packages_bucket.bucket}"
+}
+
+output "s3_blobstore_resources_bucket" {
+  value = "${aws_s3_bucket.resources_bucket.bucket}"
+}
+
+output "s3_blobstore_access_key_id" {
+  value = "${aws_iam_access_key.blobstore_access.id}"
+}
+
+output "s3_blobstore_secret_access_key" {
+  value = "${aws_iam_access_key.blobstore_access.secret}"
+}


### PR DESCRIPTION
Hi,

This is a PR to add a plan-patch to create S3 and IAM resources for a CF deployment to use for an external blobstore. We're planning to use this in our CI to reduce cost and felt that it would be useful to others that still deploy to AWS.

Please let us know if you have any questions.

Thanks,
@paulcwarren and Dave