### PR TITLE
Add disk value for 500 GB ephemeral disk vm extension for vsphere

### DIFF
--- a/cloudconfig/vsphere/base_ops_template.go
+++ b/cloudconfig/vsphere/base_ops_template.go
@@ -100,6 +100,11 @@ const (
     disk: 102400
 
 - type: replace
+  path: /vm_extensions/name=500GB_ephemeral_disk/cloud_properties?
+  value:
+    disk: 512000
+
+- type: replace
   path: /vm_extensions/-
   value:
     name: cf-router-network-properties


### PR DESCRIPTION
Before this commit one was unable to use the 500GB_ephemeral_disk
extension on vsphere because it had no value for disk.

Signed-off-by: Arjun Sreedharan <asreedharan@pivotal.io>

cc @sophiewigmore