### PR TITLE
Add plan-patch for GCS blobstore resources

### DIFF
--- a/plan-patches/gcs-blobstore-gcp/README.md
+++ b/plan-patches/gcs-blobstore-gcp/README.md
@@ -1,0 +1,11 @@
+# gcs-blobstore-gcp
+
+This plan-patch adds terraform templates to create resources required to use
+GCS (Google Cloud Storage) for a CF blobstore.
+
+## Steps:
+
+1. Run `bbl plan`
+1. Copy the contents of the terraform directory to the terraform sub-directory
+   in your environment's state directory.
+1. Run `bbl up`

--- a/plan-patches/gcs-blobstore-gcp/terraform/gcs_blobstore_buckets_override.tf
+++ b/plan-patches/gcs-blobstore-gcp/terraform/gcs_blobstore_buckets_override.tf
@@ -1,0 +1,19 @@
+resource "google_storage_bucket" "buildpacks" {
+  name          = "${var.env_id}-buildpacks-bucket"
+  force_destroy = true
+}
+
+resource "google_storage_bucket" "droplets" {
+  name          = "${var.env_id}-droplets-bucket"
+  force_destroy = true
+}
+
+resource "google_storage_bucket" "packages" {
+  name          = "${var.env_id}-packages-bucket"
+  force_destroy = true
+}
+
+resource "google_storage_bucket" "resources" {
+  name          = "${var.env_id}-resources-bucket"
+  force_destroy = true
+}

--- a/plan-patches/gcs-blobstore-gcp/terraform/gcs_blobstore_iam_override.tf
+++ b/plan-patches/gcs-blobstore-gcp/terraform/gcs_blobstore_iam_override.tf
@@ -1,0 +1,32 @@
+resource "google_service_account" "blobstore_service_account" {
+  account_id   = "${var.env_id}-blobstore"
+  display_name = "${var.env_id} Blobstore Service Account"
+}
+
+resource "google_service_account_key" "blobstore_service_account_key" {
+  service_account_id = "${google_service_account.blobstore_service_account.id}"
+}
+
+resource "google_storage_bucket_iam_member" "buildpacks_blobstore_cloud_storage_admin" {
+  bucket = "${google_storage_bucket.buildpacks.name}"
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.blobstore_service_account.email}"
+}
+
+resource "google_storage_bucket_iam_member" "droplets_blobstore_cloud_storage_admin" {
+  bucket = "${google_storage_bucket.droplets.name}"
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.blobstore_service_account.email}"
+}
+
+resource "google_storage_bucket_iam_member" "packages_blobstore_cloud_storage_admin" {
+  bucket = "${google_storage_bucket.packages.name}"
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.blobstore_service_account.email}"
+}
+
+resource "google_storage_bucket_iam_member" "resources_blobstore_cloud_storage_admin" {
+  bucket = "${google_storage_bucket.resources.name}"
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.blobstore_service_account.email}"
+}

--- a/plan-patches/gcs-blobstore-gcp/terraform/gcs_blobstore_outputs_override.tf
+++ b/plan-patches/gcs-blobstore-gcp/terraform/gcs_blobstore_outputs_override.tf
@@ -1,0 +1,28 @@
+output "gcs_blobstore_buildpacks_bucket" {
+  value = "${google_storage_bucket.buildpacks.name}"
+}
+
+output "gcs_blobstore_droplets_bucket" {
+  value = "${google_storage_bucket.droplets.name}"
+}
+
+output "gcs_blobstore_packages_bucket" {
+  value = "${google_storage_bucket.packages.name}"
+}
+
+output "gcs_blobstore_resources_bucket" {
+  value = "${google_storage_bucket.resources.name}"
+}
+
+output "gcs_blobstore_service_account_project" {
+  value = "${google_service_account.blobstore_service_account.project}"
+}
+
+output "gcs_blobstore_service_account_email" {
+  value = "${google_service_account.blobstore_service_account.email}"
+}
+
+output "gcs_blobstore_service_account_key" {
+  value     = "${base64decode(google_service_account_key.blobstore_service_account_key.private_key)}"
+  sensitive = true
+}


### PR DESCRIPTION
Hi,

This is a PR to add a plan-patch to create GCS and IAM resources for a CF deployment to use for an external blobstore. We're planning to use this in our CI to reduce cost and felt that it would be useful to others that deploy to GCP.

Please let us know if you have any questions.

Thanks,
Dave