### PR TITLE
Fix zone list restriction

### DIFF
--- a/terraform/gcp/template_generator.go
+++ b/terraform/gcp/template_generator.go
@@ -72,9 +72,6 @@ func (t TemplateGenerator) GenerateBackendService(zoneList []string) string {
 }
 
 func (t TemplateGenerator) GenerateInstanceGroups(zoneList []string) string {
-	if len(zoneList) > 2 {
-		zoneList = zoneList[:2]
-	}
 	var groups []string
 	for i, zone := range zoneList {
 		groups = append(groups, fmt.Sprintf(`resource "google_compute_instance_group" "router-lb-%[1]d" {

--- a/terraform/gcp/template_generator_test.go
+++ b/terraform/gcp/template_generator_test.go
@@ -47,6 +47,17 @@ resource "google_compute_instance_group" "router-lb-1" {
     port = "443"
   }
 }
+
+resource "google_compute_instance_group" "router-lb-2" {
+  name        = "${var.env_id}-router-lb-2-z3"
+  description = "terraform generated instance group that is multi-zone for https loadbalancing"
+  zone        = "z3"
+
+  named_port {
+    name = "https"
+    port = "443"
+  }
+}
 `
 		backendService = `resource "google_compute_backend_service" "router-lb-backend-service" {
   name        = "${var.env_id}-router-lb"


### PR DESCRIPTION
We're getting the following error when trying to upgrade from bbl v6 to v7 when using CF lbs. After investigation noticed that deleting the instance group at the same time as removing the backend from the backend service causes an issue because the terraform google provider is trying to delete the instance group before removing the backend from the backend service.
Here's a snippet of the error we're seeing:
```
Error: Error applying plan:

1 error(s) occurred:

* google_compute_instance_group.router-lb-2 (destroy): 1 error(s) occurred:

* google_compute_instance_group.router-lb-2: Error deleting InstanceGroup: googleapi: Error 400: The instance_group resource 'projects/cf-release-integration-luna/zones/us-west1-c/instanceGroups/luna-fresh-router-lb-2-us-west1-c' is already being used by 'projects/cf-release-integration-luna/global/backendServices/luna-fresh-router-lb', resourceInUseByAnotherResource
```

This PR removes the restriction on the number of instance groups however still keeps the restriction on the backends. This means you will still have the aforementioned instance groups but they won't be attached to the backend service.
In a later version, these changes can be reverted in order to completely delete the unused instance groups.

[#163706206](https://www.pivotaltracker.com/story/show/163706206)

Co-authored-by: Alexander Berezovsky <aberezovsky@pivotal.io>