### PR TITLE
Allow for non-default jumpbox user in bbl-state

### DIFF
--- a/bosh/all_proxy_getter.go
+++ b/bosh/all_proxy_getter.go
@@ -46,5 +46,5 @@ func (a AllProxyGetter) GeneratePrivateKey() (string, error) {
 }
 
 func (a AllProxyGetter) BoshAllProxy(jumpboxURL, privateKeyPath string) string {
-	return fmt.Sprintf("ssh+socks5://jumpbox@%s?private-key=%s", jumpboxURL, privateKeyPath)
+	return fmt.Sprintf("ssh+socks5://%s?private-key=%s", jumpboxURL, privateKeyPath)
 }

--- a/bosh/cli_provider.go
+++ b/bosh/cli_provider.go
@@ -33,6 +33,6 @@ func (c CLIProvider) AuthenticatedCLI(jumpbox storage.Jumpbox, stderr io.Writer,
 		return AuthenticatedCLI{}, err
 	}
 
-	boshAllProxy := c.allProxyGetter.BoshAllProxy(jumpbox.URL, privateKey)
+	boshAllProxy := c.allProxyGetter.BoshAllProxy(jumpbox.GetURLWithJumpboxUser(), privateKey)
 	return NewAuthenticatedCLI(stderr, c.boshCLIPath, directorAddress, directorUsername, directorPassword, directorCACert, boshAllProxy), nil
 }

--- a/bosh/cli_provider_test.go
+++ b/bosh/cli_provider_test.go
@@ -24,8 +24,8 @@ var _ = Describe("Client Provider", func() {
 
 	Describe("AuthenticatedCLI", func() {
 		It("returns an authenticated bosh cli", func() {
-			allProxyGetter.BoshAllProxyCall.Returns.URL = "some-all-proxy-url"
-			cliRunner, err := cliProvider.AuthenticatedCLI(storage.Jumpbox{URL: "https://some-jumpbox"}, nil, "some-address", "some-username", "some-password", "some-fake-ca")
+			allProxyGetter.BoshAllProxyCall.Returns.URL = "jumpbox@some-all-proxy-url"
+			cliRunner, err := cliProvider.AuthenticatedCLI(storage.Jumpbox{URL: "some-jumpbox:22"}, nil, "some-address", "some-username", "some-password", "some-fake-ca")
 			Expect(err).NotTo(HaveOccurred())
 
 			cli := cliRunner.(bosh.AuthenticatedCLI)
@@ -36,13 +36,14 @@ var _ = Describe("Client Provider", func() {
 				"--ca-cert", "some-fake-ca",
 				"--non-interactive",
 			}))
-			Expect(cli.BOSHAllProxy).To(Equal("some-all-proxy-url"))
+			Expect(cli.BOSHAllProxy).To(Equal("jumpbox@some-all-proxy-url"))
+			Expect(allProxyGetter.BoshAllProxyCall.Receives.JumpboxURL).To(Equal("jumpbox@some-jumpbox:22"))
 		})
 
 		Context("when it can not get the correct key", func() {
 			It("Errors", func() {
 				allProxyGetter.GeneratePrivateKeyCall.Returns.Error = errors.New("fruit")
-				_, err := cliProvider.AuthenticatedCLI(storage.Jumpbox{URL: "https://some-jumpbox"}, nil, "some-address", "some-username", "some-password", "some-fake-ca")
+				_, err := cliProvider.AuthenticatedCLI(storage.Jumpbox{URL: "user@some-jumpbox:2222"}, nil, "some-address", "some-username", "some-password", "some-fake-ca")
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError("fruit"))
 			})

--- a/commands/print_env.go
+++ b/commands/print_env.go
@@ -138,8 +138,8 @@ func (p PrintEnv) Execute(args []string, state storage.State) error {
 	}
 
 	variables["JUMPBOX_PRIVATE_KEY"] = privateKeyPath
-	variables["BOSH_ALL_PROXY"] = p.allProxyGetter.BoshAllProxy(state.Jumpbox.URL, privateKeyPath)
-	variables["CREDHUB_PROXY"] = p.allProxyGetter.BoshAllProxy(state.Jumpbox.URL, privateKeyPath)
+	variables["BOSH_ALL_PROXY"] = p.allProxyGetter.BoshAllProxy(state.Jumpbox.GetURLWithJumpboxUser(), privateKeyPath)
+	variables["CREDHUB_PROXY"] = p.allProxyGetter.BoshAllProxy(state.Jumpbox.GetURLWithJumpboxUser(), privateKeyPath)
 
 	p.renderVariables(renderer, variables)
 	return nil

--- a/commands/print_env_test.go
+++ b/commands/print_env_test.go
@@ -73,7 +73,7 @@ var _ = Describe("PrintEnv", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(allProxyGetter.GeneratePrivateKeyCall.CallCount).To(Equal(1))
-			Expect(allProxyGetter.BoshAllProxyCall.Receives.JumpboxURL).To(Equal("some-magical-jumpbox-url:22"))
+			Expect(allProxyGetter.BoshAllProxyCall.Receives.JumpboxURL).To(Equal("jumpbox@some-magical-jumpbox-url:22"))
 			Expect(allProxyGetter.BoshAllProxyCall.Receives.PrivateKey).To(Equal("the-key-path"))
 
 			Expect(logger.PrintlnCall.Messages).To(ContainElement("export BOSH_CLIENT=some-director-username"))
@@ -102,7 +102,7 @@ var _ = Describe("PrintEnv", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(allProxyGetter.GeneratePrivateKeyCall.CallCount).To(Equal(1))
-				Expect(allProxyGetter.BoshAllProxyCall.Receives.JumpboxURL).To(Equal("some-magical-jumpbox-url:22"))
+				Expect(allProxyGetter.BoshAllProxyCall.Receives.JumpboxURL).To(Equal("jumpbox@some-magical-jumpbox-url:22"))
 				Expect(allProxyGetter.BoshAllProxyCall.Receives.PrivateKey).To(Equal("the-key-path"))
 
 				Expect(logger.PrintlnCall.Messages).To(ContainElement("$env:BOSH_CLIENT=\"some-director-username\""))

--- a/storage/jumpbox.go
+++ b/storage/jumpbox.go
@@ -1,6 +1,10 @@
 package storage
 
-import "reflect"
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
 
 type Jumpbox struct {
 	URL       string                 `json:"url"`
@@ -11,4 +15,11 @@ type Jumpbox struct {
 
 func (j Jumpbox) IsEmpty() bool {
 	return reflect.DeepEqual(j, Jumpbox{})
+}
+
+func (j Jumpbox) GetURLWithJumpboxUser() string {
+	if strings.Contains(j.URL, "@") {
+		return j.URL
+	}
+	return fmt.Sprintf("jumpbox@%s", j.URL)
 }

--- a/storage/jumpbox_test.go
+++ b/storage/jumpbox_test.go
@@ -1,0 +1,29 @@
+package storage_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cloudfoundry/bosh-bootloader/storage"
+)
+
+var _ = Describe("Jumpbox", func() {
+	Describe("IsEmpty", func() {
+		It("returns true when the struct is empty", func() {
+			Expect(Jumpbox{}.IsEmpty()).To(BeTrue())
+		})
+		It("returns false when the struct is populated", func() {
+			Expect(Jumpbox{URL: ":)"}.IsEmpty()).To(BeFalse())
+		})
+	})
+	Describe("GetURLWithJumpboxUser", func() {
+		It("returns a jumpbox URL with default user when no user is specified in the URL", func() {
+			jumpbox := Jumpbox{URL: "1.1.1.1:22"}
+			Expect(jumpbox.GetURLWithJumpboxUser()).To(Equal("jumpbox@1.1.1.1:22"))
+		})
+		It("returns a jumpbox URL as is when the user is specified in the URL", func() {
+			jumpbox := Jumpbox{URL: "ubuntu@1.1.1.1:22"}
+			Expect(jumpbox.GetURLWithJumpboxUser()).To(Equal("ubuntu@1.1.1.1:22"))
+		})
+	})
+})


### PR DESCRIPTION
I'm writing a `bbl-adapter` for PCF deployments. The intent is to generate bbl state and use it as a drop-in replacement for `environment`-style resources in concourse, that cf-d tasks understand.

At present, bbl forces `jumpbox@` in `bbl print-env`. This change allows for a custom user in the Jumpbox URL.