### PR TITLE
Set roles for account separately

### DIFF
--- a/plan-patches/cfcr-gcp/terraform/cfcr_iam_override.tf
+++ b/plan-patches/cfcr-gcp/terraform/cfcr_iam_override.tf
@@ -8,63 +8,68 @@ resource "google_service_account" "worker" {
   display_name = "${var.env_id} cfcr-worker"
 }
 
-resource "google_project_iam_policy" "policy" {
+resource "google_project_iam_member" "storageAdminMaster" {
   project     = "${var.project_id}"
-  policy_data = "${data.google_iam_policy.admin.policy_data}"
+  role = "roles/compute.storageAdmin"
+  member = "serviceAccount:${google_service_account.master.email}"
+}
+resource "google_project_iam_member" "storageAdminWorker" {
+  project     = "${var.project_id}"
+  role = "roles/compute.storageAdmin"
+  member = "serviceAccount:${google_service_account.worker.email}"
 }
 
-data "google_iam_policy" "admin" {
-  binding {
-    role = "roles/compute.storageAdmin"
+resource "google_project_iam_member" "objectViewerMaster" {
+  project     = "${var.project_id}"
+  role = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.master.email}"
+}
+resource "google_project_iam_member" "objectViewerWorker" {
+  project     = "${var.project_id}"
+  role = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.worker.email}"
+}
 
-    members = [
-      "serviceAccount:${google_service_account.master.email}",
-      "serviceAccount:${google_service_account.worker.email}",
-    ]
-  }
+resource "google_project_iam_member" "networkAdminMaster" {
+  project     = "${var.project_id}"
+  role = "roles/compute.networkAdmin"
+  member = "serviceAccount:${google_service_account.master.email}"
+}
+resource "google_project_iam_member" "networkAdminWorker" {
+  project     = "${var.project_id}"
+  role = "roles/compute.networkAdmin"
+  member = "serviceAccount:${google_service_account.worker.email}"
+}
 
-  binding {
-    role = "roles/storage.objectViewer"
+resource "google_project_iam_member" "securityAdminMaster" {
+  project     = "${var.project_id}"
+  role = "roles/compute.securityAdmin"
+  member = "serviceAccount:${google_service_account.master.email}"
+}
+resource "google_project_iam_member" "securityAdminWorker" {
+  project     = "${var.project_id}"
+  role = "roles/compute.securityAdmin"
+  member = "serviceAccount:${google_service_account.worker.email}"
+}
 
-    members = [
-      "serviceAccount:${google_service_account.master.email}",
-      "serviceAccount:${google_service_account.worker.email}",
-    ]
-  }
+resource "google_project_iam_member" "instanceAdminMaster" {
+  project     = "${var.project_id}"
+  role = "roles/compute.instanceAdmin.v1"
+  member = "serviceAccount:${google_service_account.master.email}"
+}
+resource "google_project_iam_member" "instanceAdminWorker" {
+  project     = "${var.project_id}"
+  role = "roles/compute.instanceAdmin.v1"
+  member = "serviceAccount:${google_service_account.worker.email}"
+}
 
-  binding {
-    role = "roles/compute.networkAdmin"
-
-    members = [
-      "serviceAccount:${google_service_account.master.email}",
-      "serviceAccount:${google_service_account.worker.email}",
-    ]
-  }
-
-  binding {
-    role = "roles/compute.securityAdmin"
-
-    members = [
-      "serviceAccount:${google_service_account.master.email}",
-      "serviceAccount:${google_service_account.worker.email}",
-    ]
-  }
-
-  binding {
-    role = "roles/compute.instanceAdmin"
-
-    members = [
-      "serviceAccount:${google_service_account.master.email}",
-      "serviceAccount:${google_service_account.worker.email}",
-    ]
-  }
-
-  binding {
-    role = "roles/iam.serviceAccountActor"
-
-    members = [
-      "serviceAccount:${google_service_account.master.email}",
-      "serviceAccount:${google_service_account.worker.email}",
-    ]
-  }
+resource "google_project_iam_member" "serviceAccountActorMaster" {
+  project     = "${var.project_id}"
+  role = "roles/iam.serviceAccountActor"
+  member = "serviceAccount:${google_service_account.master.email}"
+}
+resource "google_project_iam_member" "serviceAccountActorWorker" {
+  project     = "${var.project_id}"
+  role = "roles/iam.serviceAccountActor"
+  member = "serviceAccount:${google_service_account.worker.email}"
 }


### PR DESCRIPTION
Replace changing policy to add iam membership.

Change policy deletes all the permissions when terraform upgrade fails