### PR TITLE
Plan patch for multiple CF gcp environments

### DIFF
--- a/plan-patches/n-cf-gcp/README.md
+++ b/plan-patches/n-cf-gcp/README.md
@@ -1,0 +1,37 @@
+## n-cf-gcp
+
+By default, bbl sets up environment for one single CF deployment.
+This plan patch adds support for multiple CF environments.
+
+Details:
+It creates separate load balancers and DNS records for each of the environments.
+The domain names for each environments are derived from your `lb-domain`
+flag (e.g. cf0.banana-env.com, cf1.banana-env.com etc).
+
+Important: To deploy cf you will need to use the `cf-lb-ops.yml` in order to
+properly setup the load balancers.
+
+Example
+```
+bosh -d cf0 deploy $CF_D/cf-deployment.yml \
+  -o $CF_D/operations/rename-network-and-deployment.yml \
+  -v deployment_name=cf0 \
+  -v network_name=default \
+  -o cf-lb-ops.yml \
+  -v env=0 \
+  -v system_domain=cf0.banana-env.com
+```
+
+The steps might look like such:
+
+```
+export TF_VAR_cf_env_count=<number-of-cf-deployments>
+mkdir banana-env && cd banana-env
+
+bbl plan --name banana-env --lb-type=cf --lb-cert=./certs/fake.crt --lb-key=certs/fake.key --lb-domain=banana-env.com
+
+cp -r bosh-bootloader/plan-patches/n-cf-gcp/* .
+
+bbl up
+./update-configs.sh
+```

--- a/plan-patches/n-cf-gcp/cf-lb-ops.yml
+++ b/plan-patches/n-cf-gcp/cf-lb-ops.yml
@@ -1,0 +1,14 @@
+- type: replace
+  path: /instance_groups/name=router/vm_extensions
+  value:
+  - cf-router-network-properties-((env))
+
+- type: replace
+  path: /instance_groups/name=tcp-router/vm_extensions
+  value:
+  - cf-tcp-router-network-properties-((env))
+
+- type: replace
+  path: /instance_groups/name=scheduler/vm_extensions
+  value:
+  - diego-ssh-proxy-network-properties-((env))

--- a/plan-patches/n-cf-gcp/cloud-config/cf-lbs-ops-override.yml
+++ b/plan-patches/n-cf-gcp/cloud-config/cf-lbs-ops-override.yml
@@ -1,0 +1,8 @@
+- type: remove
+  path: /vm_extensions/name=cf-router-network-properties
+
+- type: remove
+  path: /vm_extensions/name=diego-ssh-proxy-network-properties
+
+- type: remove
+  path: /vm_extensions/name=cf-tcp-router-network-properties

--- a/plan-patches/n-cf-gcp/terraform/cf-dns_override.tf
+++ b/plan-patches/n-cf-gcp/terraform/cf-dns_override.tf
@@ -1,0 +1,94 @@
+resource "random_pet" "environment" {
+  count = "${var.cf_env_count}"
+}
+
+resource "google_dns_record_set" "wildcard-dns" {
+  name       = "*.cf${count.index}.${google_dns_managed_zone.env_dns_zone.dns_name}"
+  depends_on = ["google_compute_global_address.cf-address"]
+  type       = "A"
+  ttl        = 300
+
+  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+
+  rrdatas = ["${element(google_compute_global_address.cf-address.*.address, count.index)}"]
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_dns_record_set" "bosh-dns" {
+  name       = "bosh.cf${count.index}.${google_dns_managed_zone.env_dns_zone.dns_name}"
+  depends_on = ["google_compute_address.jumpbox-ip"]
+  type       = "A"
+  ttl        = 300
+
+  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+
+  rrdatas = ["${element(google_compute_address.jumpbox-ip.*.address, count.index)}"]
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_dns_record_set" "cf-ssh-proxy" {
+  name       = "ssh.cf${count.index}.${google_dns_managed_zone.env_dns_zone.dns_name}"
+  depends_on = ["google_compute_address.cf-ssh-proxy"]
+  type       = "A"
+  ttl        = 300
+
+  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+
+  rrdatas = ["${element(google_compute_address.cf-ssh-proxy.*.address, count.index)}"]
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_dns_record_set" "tcp-dns" {
+  name       = "tcp.cf${count.index}.${google_dns_managed_zone.env_dns_zone.dns_name}"
+  depends_on = ["google_compute_address.cf-tcp-router"]
+  type       = "A"
+  ttl        = 300
+
+  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+
+  rrdatas = ["${element(google_compute_address.cf-tcp-router.*.address, count.index)}"]
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_dns_record_set" "doppler-dns" {
+  name       = "doppler.cf${count.index}.${google_dns_managed_zone.env_dns_zone.dns_name}"
+  depends_on = ["google_compute_address.cf-ws"]
+  type       = "A"
+  ttl        = 300
+
+  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+
+  rrdatas = ["${element(google_compute_address.cf-ws.*.address, count.index)}"]
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_dns_record_set" "loggregator-dns" {
+  name       = "loggregator.cf${count.index}.${google_dns_managed_zone.env_dns_zone.dns_name}"
+  depends_on = ["google_compute_address.cf-ws"]
+  type       = "A"
+  ttl        = 300
+
+  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+
+  rrdatas = ["${element(google_compute_address.cf-ws.*.address, count.index)}"]
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_dns_record_set" "wildcard-ws-dns" {
+  name       = "*.ws.cf${count.index}.${google_dns_managed_zone.env_dns_zone.dns_name}"
+  depends_on = ["google_compute_address.cf-ws"]
+  type       = "A"
+  ttl        = 300
+
+  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+
+  rrdatas = ["${element(google_compute_address.cf-ws.*.address, count.index)}"]
+
+  count = "${var.cf_env_count}"
+}

--- a/plan-patches/n-cf-gcp/terraform/cf-lb_override.tf
+++ b/plan-patches/n-cf-gcp/terraform/cf-lb_override.tf
@@ -1,0 +1,314 @@
+variable "cf_env_count" {
+  default = 1
+}
+
+output "router_backend_service" {
+  value = "${google_compute_backend_service.router-lb-backend-service.0.name}"
+}
+
+output "router_backend_services" {
+  value = "${google_compute_backend_service.router-lb-backend-service.*.name}"
+}
+
+output "router_lb_ip" {
+  value = "${google_compute_global_address.cf-address.0.address}"
+}
+
+output "ssh_proxy_lb_ip" {
+  value = "${google_compute_address.cf-ssh-proxy.0.address}"
+}
+
+output "tcp_router_lb_ip" {
+  value = "${google_compute_address.cf-tcp-router.0.address}"
+}
+
+output "ws_lb_ip" {
+  value = "${google_compute_address.cf-ws.0.address}"
+}
+
+resource "google_compute_instance_group" "router-lb-a" {
+  name        = "${var.env_id}-router-lb-us-west1-a-${count.index}"
+  description = "terraform generated instance group that is multi-zone for https loadbalancing"
+  zone        = "us-west1-a"
+
+  named_port {
+    name = "https"
+    port = "443"
+  }
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_compute_instance_group" "router-lb-b" {
+  name        = "${var.env_id}-router-lb-1-us-west1-b-${count.index}"
+  description = "terraform generated instance group that is multi-zone for https loadbalancing"
+  zone        = "us-west1-b"
+
+  named_port {
+    name = "https"
+    port = "443"
+  }
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_compute_backend_service" "router-lb-backend-service" {
+  name        = "${var.env_id}-router-lb-${count.index}"
+  port_name   = "https"
+  protocol    = "HTTPS"
+  timeout_sec = 900
+  enable_cdn  = false
+
+  backend {
+    group = "${element(google_compute_instance_group.router-lb-a.*.self_link, count.index)}"
+  }
+
+  backend {
+    group = "${element(google_compute_instance_group.router-lb-b.*.self_link, count.index)}"
+  }
+
+  health_checks = ["${element(google_compute_health_check.cf-public-health-check.*.self_link, count.index)}"]
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_compute_firewall" "firewall-cf" {
+  name       = "${var.env_id}-cf-open"
+  depends_on = ["google_compute_network.bbl-network"]
+  network    = "${google_compute_network.bbl-network.name}"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "443"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+
+  target_tags = ["${google_compute_backend_service.router-lb-backend-service.*.name}"]
+}
+
+resource "google_compute_global_address" "cf-address" {
+  name = "${var.env_id}-cf-${count.index}"
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_compute_global_forwarding_rule" "cf-http-forwarding-rule" {
+  name       = "${var.env_id}-cf-http-${count.index}"
+  ip_address = "${element(google_compute_global_address.cf-address.*.address, count.index)}"
+  target     = "${element(google_compute_target_http_proxy.cf-http-lb-proxy.*.self_link, count.index)}"
+  port_range = "80"
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_compute_global_forwarding_rule" "cf-https-forwarding-rule" {
+  name       = "${var.env_id}-cf-https-${count.index}"
+  ip_address = "${element(google_compute_global_address.cf-address.*.address, count.index)}"
+  target     = "${element(google_compute_target_https_proxy.cf-https-lb-proxy.*.self_link, count.index)}"
+  port_range = "443"
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_compute_target_http_proxy" "cf-http-lb-proxy" {
+  name        = "${var.env_id}-http-proxy-${count.index}"
+  description = "really a load balancer but listed as an http proxy"
+  url_map     = "${element(google_compute_url_map.cf-https-lb-url-map.*.self_link, count.index)}"
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_compute_target_https_proxy" "cf-https-lb-proxy" {
+  name             = "${var.env_id}-https-proxy-${count.index}"
+  description      = "really a load balancer but listed as an https proxy"
+  url_map          = "${element(google_compute_url_map.cf-https-lb-url-map.*.self_link, count.index)}"
+  ssl_certificates = ["${google_compute_ssl_certificate.cf-cert.self_link}"]
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_compute_url_map" "cf-https-lb-url-map" {
+  name = "${var.env_id}-cf-http-${count.index}"
+
+  default_service = "${element(google_compute_backend_service.router-lb-backend-service.*.self_link, count.index)}"
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_compute_health_check" "cf-public-health-check" {
+  name = "${var.env_id}-cf-public-${count.index}"
+
+  http_health_check {
+    port         = 8080
+    request_path = "/health"
+  }
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_compute_http_health_check" "cf-public-health-check" {
+  name         = "${var.env_id}-cf-${count.index}"
+  port         = 8080
+  request_path = "/health"
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_compute_firewall" "cf-health-check" {
+  name       = "${var.env_id}-cf-health-check"
+  depends_on = ["google_compute_network.bbl-network"]
+  network    = "${google_compute_network.bbl-network.name}"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["8080", "80"]
+  }
+
+  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
+  target_tags   = ["${google_compute_backend_service.router-lb-backend-service.*.name}"]
+}
+
+output "ssh_proxy_target_pool" {
+  value = "${google_compute_target_pool.cf-ssh-proxy.0.name}"
+}
+
+output "ssh_proxy_target_pools" {
+  value = "${google_compute_target_pool.cf-ssh-proxy.*.name}"
+}
+
+resource "google_compute_address" "cf-ssh-proxy" {
+  name = "${var.env_id}-cf-ssh-proxy-${count.index}"
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_compute_firewall" "cf-ssh-proxy" {
+  name       = "${var.env_id}-cf-ssh-proxy-open"
+  depends_on = ["google_compute_network.bbl-network"]
+  network    = "${google_compute_network.bbl-network.name}"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["2222"]
+  }
+
+  target_tags = ["${google_compute_target_pool.cf-ssh-proxy.*.name}"]
+}
+
+resource "google_compute_target_pool" "cf-ssh-proxy" {
+  name = "${var.env_id}-cf-ssh-proxy-${count.index}"
+
+  session_affinity = "NONE"
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_compute_forwarding_rule" "cf-ssh-proxy" {
+  name        = "${var.env_id}-cf-ssh-proxy-${count.index}"
+  target      = "${element(google_compute_target_pool.cf-ssh-proxy.*.self_link, count.index)}"
+  port_range  = "2222"
+  ip_protocol = "TCP"
+  ip_address  = "${element(google_compute_address.cf-ssh-proxy.*.address, count.index)}"
+
+  count = "${var.cf_env_count}"
+}
+
+output "tcp_router_target_pool" {
+  value = "${google_compute_target_pool.cf-tcp-router.0.name}"
+}
+
+output "tcp_router_target_pools" {
+  value = "${google_compute_target_pool.cf-tcp-router.*.name}"
+}
+
+resource "google_compute_firewall" "cf-tcp-router" {
+  name       = "${var.env_id}-cf-tcp-router"
+  depends_on = ["google_compute_network.bbl-network"]
+  network    = "${google_compute_network.bbl-network.name}"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["1024-32768"]
+  }
+
+  target_tags = ["${google_compute_target_pool.cf-tcp-router.*.name}"]
+}
+
+resource "google_compute_address" "cf-tcp-router" {
+  name = "${var.env_id}-cf-tcp-router-${count.index}"
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_compute_http_health_check" "cf-tcp-router" {
+  name         = "${var.env_id}-cf-tcp-router-${count.index}"
+  port         = 80
+  request_path = "/health"
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_compute_target_pool" "cf-tcp-router" {
+  name = "${var.env_id}-cf-tcp-router-${count.index}"
+
+  session_affinity = "NONE"
+
+  health_checks = [
+    "${element(google_compute_http_health_check.cf-tcp-router.*.name, count.index)}",
+  ]
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_compute_forwarding_rule" "cf-tcp-router" {
+  name        = "${var.env_id}-cf-tcp-router-${count.index}"
+  target      = "${element(google_compute_target_pool.cf-tcp-router.*.self_link, count.index)}"
+  port_range  = "1024-32768"
+  ip_protocol = "TCP"
+  ip_address  = "${element(google_compute_address.cf-tcp-router.*.address, count.index)}"
+
+  count = "${var.cf_env_count}"
+}
+
+output "ws_target_pool" {
+  value = "${google_compute_target_pool.cf-ws.0.name}"
+}
+
+output "ws_target_pools" {
+  value = "${google_compute_target_pool.cf-ws.*.name}"
+}
+
+resource "google_compute_address" "cf-ws" {
+  name = "${var.env_id}-cf-ws-${count.index}"
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_compute_target_pool" "cf-ws" {
+  name = "${var.env_id}-cf-ws-${count.index}"
+  session_affinity = "NONE"
+  health_checks = ["${element(google_compute_http_health_check.cf-public-health-check.*.name, count.index)}"]
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_compute_forwarding_rule" "cf-ws-https" {
+  name        = "${var.env_id}-cf-ws-https-${count.index}"
+  target      = "${element(google_compute_target_pool.cf-ws.*.self_link, count.index)}"
+  port_range  = "443"
+  ip_protocol = "TCP"
+  ip_address  = "${element(google_compute_address.cf-ws.*.address, count.index)}"
+
+  count = "${var.cf_env_count}"
+}
+
+resource "google_compute_forwarding_rule" "cf-ws-http" {
+  name        = "${var.env_id}-cf-ws-http-${count.index}"
+  target      = "${element(google_compute_target_pool.cf-ws.*.self_link, count.index)}"
+  port_range  = "80"
+  ip_protocol = "TCP"
+  ip_address  = "${element(google_compute_address.cf-ws.*.address, count.index)}"
+
+  count = "${var.cf_env_count}"
+}

--- a/plan-patches/n-cf-gcp/update-configs.sh
+++ b/plan-patches/n-cf-gcp/update-configs.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+generate_config() {
+  local index=$1
+
+  cat > /tmp/config$index.yml <<EOF
+vm_extensions:
+- name: cf-router-network-properties-${index}
+  cloud_properties:
+    backend_service: ((router_backend_service))
+    target_pool: ((ws_target_pool))
+    tags:
+    - ((router_backend_service))
+    - ((ws_target_pool))
+
+- name: diego-ssh-proxy-network-properties-${index}
+  cloud_properties:
+    target_pool: ((ssh_proxy_target_pool))
+    tags:
+    - ((ssh_proxy_target_pool))
+
+- name: cf-tcp-router-network-properties-${index}
+  cloud_properties:
+    target_pool: ((tcp_router_target_pool))
+    tags:
+    - ((tcp_router_target_pool))
+EOF
+}
+
+vars() {
+  bosh int vars/cloud-config-vars.yml --path /$1/$2
+}
+
+main() {
+  local cf_env_count=${TF_VAR_cf_env_count}
+
+  for i in `seq 0 $((cf_env_count-1))`; do
+    generate_config $i
+
+    bosh update-config -n \
+      --type cloud \
+      --name "cf$i" \
+      /tmp/config$i.yml \
+      -v router_backend_service=$(vars router_backend_services $i) \
+      -v ws_target_pool=$(vars ws_target_pools $i) \
+      -v ssh_proxy_target_pool=$(vars ssh_proxy_target_pools $i) \
+      -v tcp_router_target_pool=$(vars tcp_router_target_pools $i)
+  done
+}
+
+main "$@"


### PR DESCRIPTION
I've noticed that a few teams, including ours (Release Integration), use multiple environments on GCP and for each one of them they create a whole bbl environment which includes jumpbox and director for each.
Since most of these teams are testing their releases with CF context. Having one bbl environment with support for multiple CF deployments makes it easier to manage all these deployments.
This plan patch adds support for multiple CF load balancers and DNS entries which can each be used by its own CF deployment.