### PR TITLE
Traffic on 4443 to gorouter is no longer required

### DIFF
--- a/docs/cf-lbs.md
+++ b/docs/cf-lbs.md
@@ -22,7 +22,6 @@
     * It forwards:
         - `HTTP:80`   to `HTTP:80`
         - `HTTPS:443` to `HTTP:80`
-        - `TLS:4443`  to `TCP:80`
 
 ## GCP
 `bbl` creates 4 load balancers on GCP.

--- a/plan-patches/bosh-lite-aws/terraform/bosh-lite_override.tf
+++ b/plan-patches/bosh-lite-aws/terraform/bosh-lite_override.tf
@@ -16,12 +16,3 @@ resource "aws_security_group_rule" "bosh_security_group_rule_https" {
   to_port                  = 443
   cidr_blocks = ["${var.bosh_inbound_cidr}"]
 }
-
-resource "aws_security_group_rule" "bosh_security_group_rule_https_alt" {
-  security_group_id        = "${aws_security_group.bosh_security_group.id}"
-  type                     = "ingress"
-  protocol                 = "tcp"
-  from_port                = 4443
-  to_port                  = 4443
-  cidr_blocks = ["${var.bosh_inbound_cidr}"]
-}

--- a/terraform/aws/templates/cf_lb.tf
+++ b/terraform/aws/templates/cf_lb.tf
@@ -94,13 +94,6 @@ resource "aws_security_group" "cf_router" {
     to_port     = 443
   }
 
-  ingress {
-    cidr_blocks = ["0.0.0.0/0"]
-    protocol    = "tcp"
-    from_port   = 4443
-    to_port     = 4443
-  }
-
   egress {
     from_port   = 0
     to_port     = 0
@@ -151,17 +144,6 @@ resource "aws_lb_listener" "cf_router_443" {
   }
 }
 
-resource "aws_lb_listener" "cf_router_4443" {
-  load_balancer_arn = "${aws_lb.cf_router.arn}"
-  port              = 4443
-  protocol          = "TCP"
-
-  default_action {
-    type             = "forward"
-    target_group_arn = "${aws_lb_target_group.cf_router_4443.arn}"
-  }
-}
-
 resource "aws_lb_target_group" "cf_router_80" {
   name     = "${var.short_env_id}-routertg-80"
   port     = 80
@@ -184,17 +166,6 @@ resource "aws_lb_target_group" "cf_router_443" {
   }
 }
 
-resource "aws_lb_target_group" "cf_router_4443" {
-  name     = "${var.short_env_id}-routertg-4443"
-  port     = 4443
-  protocol = "TCP"
-  vpc_id   = "${local.vpc_id}"
-
-  health_check {
-    protocol = "TCP"
-  }
-}
-
 output "cf_router_lb_name" {
   value = "${aws_lb.cf_router.name}"
 }
@@ -207,7 +178,6 @@ output "cf_router_target_group_names" {
   value = [
     "${aws_lb_target_group.cf_router_80.name}",
     "${aws_lb_target_group.cf_router_443.name}",
-    "${aws_lb_target_group.cf_router_4443.name}",
   ]
 }
 

--- a/terraform/aws/templates/iso_segments.tf
+++ b/terraform/aws/templates/iso_segments.tf
@@ -11,7 +11,7 @@ variable "iso_to_bosh_ports" {
 
 variable "iso_to_shared_tcp_ports" {
   type    = "list"
-  default = [9090, 9091, 8082, 8300, 8301, 8889, 8443, 3000, 4443, 8080, 3457, 9023, 9022, 4222]
+  default = [9090, 9091, 8082, 8300, 8301, 8889, 8443, 3000, 8080, 3457, 9023, 9022, 4222]
 }
 
 variable "iso_to_shared_udp_ports" {
@@ -73,18 +73,6 @@ resource "aws_lb_listener" "iso_router_lb_443" {
   }
 }
 
-resource "aws_lb_listener" "iso_router_lb_4443" {
-  count = "${var.isolation_segments}"
-  load_balancer_arn = "${aws_lb.iso_router_lb.arn}"
-  port              = 4443
-  protocol          = "TCP"
-
-  default_action {
-    type             = "forward"
-    target_group_arn = "${aws_lb_target_group.iso_router_lb_4443.arn}"
-  }
-}
-
 resource "aws_lb_target_group" "iso_router_lb_80" {
   count = "${var.isolation_segments}"
   name     = "${var.short_env_id}-isotg-80"
@@ -101,18 +89,6 @@ resource "aws_lb_target_group" "iso_router_lb_443" {
   count = "${var.isolation_segments}"
   name     = "${var.short_env_id}-isotg-443"
   port     = 443
-  protocol = "TCP"
-  vpc_id   = "${local.vpc_id}"
-
-  health_check {
-    protocol = "TCP"
-  }
-}
-
-resource "aws_lb_target_group" "iso_router_lb_4443" {
-  count = "${var.isolation_segments}"
-  name     = "${var.short_env_id}-isotg-4443"
-  port     = 4443
   protocol = "TCP"
   vpc_id   = "${local.vpc_id}"
 
@@ -235,7 +211,6 @@ output "cf_iso_router_target_group_names" {
   value = [
     "${element(concat(aws_lb_target_group.iso_router_lb_80.*.name, list("")), 0)}",
     "${element(concat(aws_lb_target_group.iso_router_lb_443.*.name, list("")), 0)}",
-    "${element(concat(aws_lb_target_group.iso_router_lb_4443.*.name, list("")), 0)}",
   ]
 }
 


### PR DESCRIPTION
- traffic on 4443 used to be necessary to circumvent a limitation
  of AWS classic load balancers where wouldn't allow traffic on
  443 for web sockets.
- bbl now uses Network Load Balancers which no longer needs traffic on 4443

plan-patches were not modified