### PR TITLE
Lockdown external ports after director creation

### DIFF
--- a/commands/interfaces.go
+++ b/commands/interfaces.go
@@ -29,6 +29,7 @@ type terraformManager interface {
 	Validate(storage.State) (storage.State, error)
 	Destroy(storage.State) (storage.State, error)
 	IsPaved() (bool, error)
+	Lockdown(storage.State) error
 }
 
 type boshManager interface {

--- a/commands/up.go
+++ b/commands/up.go
@@ -107,6 +107,21 @@ func (u Up) Execute(args []string, state storage.State) error {
 		return fmt.Errorf("Update runtime config: %s", err)
 	}
 
+	err = u.terraformManager.Lockdown(state)
+	if err != nil {
+		return fmt.Errorf("Lockdown: %s", err)
+	}
+
+	state, err = u.terraformManager.Apply(state)
+	if err != nil {
+		return handleTerraformError(err, state, u.stateStore)
+	}
+
+	err = u.stateStore.Set(state)
+	if err != nil {
+		return fmt.Errorf("Save state after lockdown: %s", err)
+	}
+
 	return nil
 }
 

--- a/fakes/template_generator.go
+++ b/fakes/template_generator.go
@@ -14,7 +14,7 @@ type TemplateGenerator struct {
 	}
 }
 
-func (t *TemplateGenerator) Generate(state storage.State) string {
+func (t *TemplateGenerator) Generate(state storage.State, withBootstrap bool) string {
 	t.GenerateCall.CallCount++
 	t.GenerateCall.Receives.State = state
 	return t.GenerateCall.Returns.Template

--- a/fakes/terraform_manager.go
+++ b/fakes/terraform_manager.go
@@ -26,10 +26,10 @@ type TerraformManager struct {
 	}
 	ApplyCall struct {
 		CallCount int
-		Receives  struct {
+		Receives  []struct {
 			BBLState storage.State
 		}
-		Returns struct {
+		Returns []struct {
 			BBLState storage.State
 			Error    error
 		}
@@ -92,6 +92,15 @@ type TerraformManager struct {
 			Error   error
 		}
 	}
+	LockdownCall struct {
+		CallCount int
+		Receives  struct {
+			BBLState storage.State
+		}
+		Returns   struct {
+			Error error
+		}
+	}
 }
 
 func (t *TerraformManager) Setup(bblState storage.State) error {
@@ -110,9 +119,9 @@ func (t *TerraformManager) Init(bblState storage.State) error {
 
 func (t *TerraformManager) Apply(bblState storage.State) (storage.State, error) {
 	t.ApplyCall.CallCount++
-	t.ApplyCall.Receives.BBLState = bblState
+	t.ApplyCall.Receives = append(t.ApplyCall.Receives, struct {BBLState storage.State}{bblState})
 
-	return t.ApplyCall.Returns.BBLState, t.ApplyCall.Returns.Error
+	return t.ApplyCall.Returns[t.ApplyCall.CallCount - 1].BBLState, t.ApplyCall.Returns[t.ApplyCall.CallCount - 1].Error
 }
 
 func (t *TerraformManager) Destroy(bblState storage.State) (storage.State, error) {
@@ -155,4 +164,10 @@ func (t *TerraformManager) ValidateVersion() error {
 func (t *TerraformManager) IsPaved() (bool, error) {
 	t.IsPavedCall.CallCount++
 	return t.IsPavedCall.Returns.IsPaved, t.IsPavedCall.Returns.Error
+}
+
+func (t *TerraformManager) Lockdown(bblState storage.State) error {
+	t.LockdownCall.CallCount++
+	t.LockdownCall.Receives.BBLState = bblState
+	return t.LockdownCall.Returns.Error
 }

--- a/terraform/aws/template_generator.go
+++ b/terraform/aws/template_generator.go
@@ -31,7 +31,7 @@ func NewTemplateGenerator() TemplateGenerator {
 	}
 }
 
-func (tg TemplateGenerator) Generate(state storage.State) string {
+func (tg TemplateGenerator) Generate(state storage.State, _ bool) string {
 	tmpls := tg.readTemplates()
 	template := strings.Join([]string{tmpls.base, tmpls.iam, tmpls.vpc}, "\n")
 

--- a/terraform/aws/template_generator_test.go
+++ b/terraform/aws/template_generator_test.go
@@ -31,7 +31,7 @@ var _ = Describe("TemplateGenerator", func() {
 			})
 
 			It("uses the base template", func() {
-				template := templateGenerator.Generate(storage.State{})
+				template := templateGenerator.Generate(storage.State{}, true)
 				checkTemplate(template, expectedTemplate)
 			})
 		})
@@ -44,7 +44,7 @@ var _ = Describe("TemplateGenerator", func() {
 				}
 			})
 			It("adds the lb subnet and concourse lb to the base template", func() {
-				template := templateGenerator.Generate(storage.State{LB: lb})
+				template := templateGenerator.Generate(storage.State{LB: lb}, true)
 				checkTemplate(template, expectedTemplate)
 			})
 		})
@@ -57,7 +57,7 @@ var _ = Describe("TemplateGenerator", func() {
 				}
 			})
 			It("adds the lb subnet, cf lb, ssl cert and iso seg to the base template", func() {
-				template := templateGenerator.Generate(storage.State{LB: lb})
+				template := templateGenerator.Generate(storage.State{LB: lb}, true)
 				checkTemplate(template, expectedTemplate)
 			})
 		})
@@ -71,7 +71,7 @@ var _ = Describe("TemplateGenerator", func() {
 				}
 			})
 			It("adds the domain", func() {
-				template := templateGenerator.Generate(storage.State{LB: lb})
+				template := templateGenerator.Generate(storage.State{LB: lb}, true)
 				checkTemplate(template, expectedTemplate)
 			})
 		})

--- a/terraform/azure/template_generator.go
+++ b/terraform/azure/template_generator.go
@@ -32,7 +32,7 @@ func NewTemplateGenerator() TemplateGenerator {
 	}
 }
 
-func (t TemplateGenerator) Generate(state storage.State) string {
+func (t TemplateGenerator) Generate(state storage.State, _ bool) string {
 	tmpls := t.readTemplates()
 
 	template := strings.Join([]string{tmpls.vars, tmpls.resourceGroup, tmpls.network, tmpls.storage, tmpls.networkSecurityGroup, tmpls.output, tmpls.tls}, "\n")

--- a/terraform/azure/template_generator_test.go
+++ b/terraform/azure/template_generator_test.go
@@ -29,7 +29,7 @@ var _ = Describe("TemplateGenerator", func() {
 				expectedTemplate = expectTemplate("vars", "resource_group", "network", "storage", "network_security_group", "output", "tls")
 			})
 			It("uses the base template", func() {
-				template := templateGenerator.Generate(storage.State{})
+				template := templateGenerator.Generate(storage.State{}, true)
 				checkTemplate(template, expectedTemplate)
 			})
 		})
@@ -42,7 +42,7 @@ var _ = Describe("TemplateGenerator", func() {
 				}
 			})
 			It("adds the lb subnet, cf lb, ssl cert and iso seg to the base template", func() {
-				template := templateGenerator.Generate(storage.State{LB: lb})
+				template := templateGenerator.Generate(storage.State{LB: lb}, true)
 				checkTemplate(template, expectedTemplate)
 			})
 		})
@@ -56,7 +56,7 @@ var _ = Describe("TemplateGenerator", func() {
 			})
 
 			It("adds the lb subnet, concourse lb and iso seg to the base template", func() {
-				template := templateGenerator.Generate(storage.State{LB: lb})
+				template := templateGenerator.Generate(storage.State{LB: lb}, true)
 				checkTemplate(template, expectedTemplate)
 			})
 		})

--- a/terraform/gcp/template_generator.go
+++ b/terraform/gcp/template_generator.go
@@ -11,12 +11,13 @@ import (
 const templatesPath = "./templates"
 
 type templates struct {
-	vars         string
-	jumpbox      string
-	boshDirector string
-	cfLB         string
-	cfDNS        string
-	concourseLB  string
+	vars          string
+	jumpbox       string
+	boshBootstrap string
+	boshDirector  string
+	cfLB          string
+	cfDNS         string
+	concourseLB   string
 }
 
 type TemplateGenerator struct {
@@ -29,10 +30,14 @@ func NewTemplateGenerator() TemplateGenerator {
 	}
 }
 
-func (t TemplateGenerator) Generate(state storage.State) string {
+func (t TemplateGenerator) Generate(state storage.State, withBootstrap bool) string {
 	tmpls := t.readTemplates()
 
-	template := strings.Join([]string{tmpls.vars, tmpls.boshDirector, tmpls.jumpbox}, "\n")
+	templateContent := []string{tmpls.vars, tmpls.boshDirector, tmpls.jumpbox}
+	if withBootstrap {
+		templateContent = append(templateContent, tmpls.boshBootstrap)
+	}
+	template := strings.Join(templateContent, "\n")
 
 	switch state.LB.Type {
 	case "concourse":
@@ -99,12 +104,13 @@ func (t TemplateGenerator) GenerateInstanceGroups(zoneList []string) string {
 
 func (t TemplateGenerator) readTemplates() templates {
 	listings := map[string]string{
-		"vars.tf":          "",
-		"jumpbox.tf":       "",
-		"bosh_director.tf": "",
-		"cf_lb.tf":         "",
-		"cf_dns.tf":        "",
-		"concourse_lb.tf":  "",
+		"vars.tf":           "",
+		"jumpbox.tf":        "",
+		"bosh_bootstrap.tf": "",
+		"bosh_director.tf":  "",
+		"cf_lb.tf":          "",
+		"cf_dns.tf":         "",
+		"concourse_lb.tf":   "",
 	}
 
 	var errors []error
@@ -123,11 +129,12 @@ func (t TemplateGenerator) readTemplates() templates {
 	}
 
 	return templates{
-		vars:         listings["vars.tf"],
-		jumpbox:      listings["jumpbox.tf"],
-		boshDirector: listings["bosh_director.tf"],
-		cfLB:         listings["cf_lb.tf"],
-		cfDNS:        listings["cf_dns.tf"],
-		concourseLB:  listings["concourse_lb.tf"],
+		vars:          listings["vars.tf"],
+		jumpbox:       listings["jumpbox.tf"],
+		boshBootstrap: listings["bosh_bootstrap.tf"],
+		boshDirector:  listings["bosh_director.tf"],
+		cfLB:          listings["cf_lb.tf"],
+		cfDNS:         listings["cf_dns.tf"],
+		concourseLB:   listings["concourse_lb.tf"],
 	}
 }

--- a/terraform/gcp/template_generator_test.go
+++ b/terraform/gcp/template_generator_test.go
@@ -81,44 +81,85 @@ resource "google_compute_instance_group" "router-lb-2" {
 
 	Describe("Generate", func() {
 		Context("when no lb type is provided", func() {
-			BeforeEach(func() {
-				expectedTemplate = expectTemplate("vars", "bosh_director", "jumpbox")
+			Context("when bootstrap is provided", func() {
+				BeforeEach(func() {
+					expectedTemplate = expectTemplate("vars", "bosh_director", "jumpbox", "bosh_bootstrap")
+				})
+				It("uses the base template", func() {
+					template := templateGenerator.Generate(storage.State{}, true)
+					checkTemplate(template, expectedTemplate)
+				})
 			})
-			It("uses the base template", func() {
-				template := templateGenerator.Generate(storage.State{})
-				checkTemplate(template, expectedTemplate)
+
+			Context("when bootstrap is not provided", func() {
+				BeforeEach(func() {
+					expectedTemplate = expectTemplate("vars", "bosh_director", "jumpbox")
+				})
+				It("uses the base template", func() {
+					template := templateGenerator.Generate(storage.State{}, false)
+					checkTemplate(template, expectedTemplate)
+				})
 			})
 		})
 
 		Context("when a concourse LB is provided", func() {
-			BeforeEach(func() {
-				expectedTemplate = expectTemplate("vars", "bosh_director", "jumpbox", "concourse_lb")
+			JustBeforeEach(func() {
 				state = storage.State{LB: storage.LB{Type: "concourse"}}
 			})
-			It("adds the concourse lb template", func() {
-				template := templateGenerator.Generate(state)
-				checkTemplate(template, expectedTemplate)
+
+			Context("when bootstrap is provided", func() {
+				BeforeEach(func() {
+					expectedTemplate = expectTemplate("vars", "bosh_director", "jumpbox", "bosh_bootstrap", "concourse_lb")
+				})
+				It("adds the concourse lb template", func() {
+					template := templateGenerator.Generate(state, true)
+					checkTemplate(template, expectedTemplate)
+				})
+			})
+
+			Context("when bootstrap is not provided", func() {
+				BeforeEach(func() {
+					expectedTemplate = expectTemplate("vars", "bosh_director", "jumpbox", "concourse_lb")
+				})
+				It("adds the concourse lb template", func() {
+					template := templateGenerator.Generate(state, false)
+					checkTemplate(template, expectedTemplate)
+				})
 			})
 		})
 
 		Context("when a CF LB is provided", func() {
-			BeforeEach(func() {
-				expectedTemplate = expectTemplate("vars", "bosh_director", "jumpbox", "cf_lb")
+			JustBeforeEach(func() {
 				expectedTemplate += "\n" + instanceGroups + "\n" + backendService
 				state = storage.State{
 					GCP: storage.GCP{Zones: []string{"z1", "z2", "z3"}},
 					LB:  storage.LB{Type: "cf"},
 				}
 			})
-			It("adds the cf lb template with instance groups and backend service", func() {
-				template := templateGenerator.Generate(state)
-				checkTemplate(template, expectedTemplate)
+
+			Context("when bootstrap is provided", func() {
+				BeforeEach(func() {
+					expectedTemplate = expectTemplate("vars", "bosh_director", "jumpbox", "bosh_bootstrap", "cf_lb")
+				})
+				It("adds the cf lb template with instance groups and backend service", func() {
+					template := templateGenerator.Generate(state, true)
+					checkTemplate(template, expectedTemplate)
+				})
+			})
+
+			Context("when bootstrap is not provided", func() {
+				BeforeEach(func() {
+					expectedTemplate = expectTemplate("vars", "bosh_director", "jumpbox", "cf_lb")
+				})
+				It("adds the cf lb template with instance groups and backend service", func() {
+					template := templateGenerator.Generate(state, false)
+					checkTemplate(template, expectedTemplate)
+				})
 			})
 		})
 
 		Context("when a CF LB is provided with a domain", func() {
-			BeforeEach(func() {
-				expectedTemplate = expectTemplate("vars", "bosh_director", "jumpbox", "cf_lb")
+			JustBeforeEach(func() {
 				dns := expectTemplate("cf_dns")
 				expectedTemplate += "\n" + instanceGroups + "\n" + backendService + "\n" + dns
 
@@ -130,9 +171,25 @@ resource "google_compute_instance_group" "router-lb-2" {
 					},
 				}
 			})
-			It("adds the cf lb template with instance groups and backend service", func() {
-				template := templateGenerator.Generate(state)
-				checkTemplate(template, expectedTemplate)
+
+			Context("when bootstrap is provided", func() {
+				BeforeEach(func() {
+					expectedTemplate = expectTemplate("vars", "bosh_director", "jumpbox", "bosh_bootstrap", "cf_lb")
+				})
+				It("adds the cf lb template with instance groups and backend service", func() {
+					template := templateGenerator.Generate(state, true)
+					checkTemplate(template, expectedTemplate)
+				})
+			})
+
+			Context("when bootstrap is not provided", func() {
+				BeforeEach(func() {
+					expectedTemplate = expectTemplate("vars", "bosh_director", "jumpbox", "cf_lb")
+				})
+				It("adds the cf lb template with instance groups and backend service", func() {
+					template := templateGenerator.Generate(state, false)
+					checkTemplate(template, expectedTemplate)
+				})
 			})
 		})
 	})

--- a/terraform/gcp/templates/bosh_bootstrap.tf
+++ b/terraform/gcp/templates/bosh_bootstrap.tf
@@ -1,0 +1,13 @@
+resource "google_compute_firewall" "external" {
+  name    = "${var.env_id}-external"
+  network = "${google_compute_network.bbl-network.name}"
+
+  source_ranges = ["0.0.0.0/0"]
+
+  allow {
+    ports    = ["22", "6868", "25555"]
+    protocol = "tcp"
+  }
+
+  target_tags = ["${var.env_id}-bosh-open"]
+}

--- a/terraform/gcp/templates/bosh_director.tf
+++ b/terraform/gcp/templates/bosh_director.tf
@@ -14,14 +14,14 @@ resource "google_compute_subnetwork" "bbl-subnet" {
   network       = "${google_compute_network.bbl-network.self_link}"
 }
 
-resource "google_compute_firewall" "external" {
-  name    = "${var.env_id}-external"
+resource "google_compute_firewall" "external-ssh" {
+  name    = "${var.env_id}-external-ssh"
   network = "${google_compute_network.bbl-network.name}"
 
   source_ranges = ["0.0.0.0/0"]
 
   allow {
-    ports    = ["22", "6868", "25555"]
+    ports    = ["22"]
     protocol = "tcp"
   }
 

--- a/terraform/openstack/template_generator.go
+++ b/terraform/openstack/template_generator.go
@@ -27,7 +27,7 @@ func NewTemplateGenerator() TemplateGenerator {
 	}
 }
 
-func (t TemplateGenerator) Generate(state storage.State) string {
+func (t TemplateGenerator) Generate(state storage.State, _ bool) string {
 	tmpls := t.readTemplates()
 	template := strings.Join([]string{tmpls.providerVars, tmpls.provider, tmpls.resourcesOutputs, tmpls.resourcesVars, tmpls.resources}, "\n")
 	return template

--- a/terraform/openstack/template_generator_test.go
+++ b/terraform/openstack/template_generator_test.go
@@ -27,7 +27,7 @@ var _ = Describe("TemplateGenerator", func() {
 			expectedTemplate = expectTemplate("provider-vars", "provider", "resources-outputs", "resources-vars", "resources")
 		})
 		It("uses openstack templates", func() {
-			template := templateGenerator.Generate(storage.State{})
+			template := templateGenerator.Generate(storage.State{}, true)
 			checkTemplate(template, expectedTemplate)
 		})
 	})

--- a/terraform/vsphere/template_generator.go
+++ b/terraform/vsphere/template_generator.go
@@ -12,7 +12,7 @@ func NewTemplateGenerator() TemplateGenerator {
 	return TemplateGenerator{}
 }
 
-func (t TemplateGenerator) Generate(state storage.State) string {
+func (t TemplateGenerator) Generate(state storage.State, _ bool) string {
 	return fmt.Sprint(`
 variable "env_id" {}
 variable "director_internal_ip" {}


### PR DESCRIPTION
Signed-off-by: Denny Hoang dhoang@pivotal.io
Signed-off-by: Conor Nosal cnosal@pivotal.io

This pr addresses: #417

We noticed that port 6868 and 25555 was exposed publicly on the jumpbox. According to the git issue, it is only required during bootstrapping the director.

This pr introduce a "Lockdown" step after the director creation in bbl up.

The lockdown step generates a new bbl_template.tf file without port 6868 and 25555.

It does this by putting all of the bootstrapping rules under terraform/gcp/templates/bosh_bootstrap.tf

During "Setup" the bbl_template.tf is included and during "Lockdown" it is not included.