### PR TITLE
Add a plan-patch to add support for an OpenVPN server

### DIFF
--- a/plan-patches/README.md
+++ b/plan-patches/README.md
@@ -18,6 +18,7 @@ Many of these have additional prep steps or specific downstream bosh deployments
 | [cfcr-aws](cfcr-aws/) | Deploy a CFCR with a kubeapi load balancer and aws cloud-provider |
 | [iso-segs-aws](iso-segs-aws/) | Add Isolation Segments |
 | [1-az-aws](1-az-aws/) | Only create resources in a single availability zone |
+| [openvpn-aws](openvpn-aws/) | Create an internet-accessible subnet for use by an [openvpn](https://github.com/dpb587/openvpn-bosh-release) server |
 | [tf-backend-aws](tf-backend-aws/) | Store your terraform state in S3 |
 | [prometheus-lb-aws](prometheus-lb-aws/) | Deploy a dedicated AWS network load balancer for your prometheus cluster |
 | [s3-blobstore-aws](s3-blobstore-aws/) | Create S3 and IAM resources for an external blobstore |

--- a/plan-patches/openvpn-aws/cloud-config/openvpn_vip.yml
+++ b/plan-patches/openvpn-aws/cloud-config/openvpn_vip.yml
@@ -1,0 +1,24 @@
+- path: /networks/-
+  type: replace
+  value:
+    name: vip
+    type: vip
+
+- path: /networks/-
+  type: replace
+  value:
+    name: openvpn
+    subnets:
+    - az: z1
+      cloud_properties:
+        security_groups:
+        - ((openvpn_security_group))
+        subnet: ((openvpn_subnet_id))
+      gateway: 10.0.144.1
+      range: 10.0.144.0/24
+      reserved:
+      - 10.0.144.2-10.0.144.3
+      - 10.0.144.255
+      static:
+      - 10.0.144.190-10.0.144.254
+    type: manual

--- a/plan-patches/openvpn-aws/terraform/openvpn_override.tf
+++ b/plan-patches/openvpn-aws/terraform/openvpn_override.tf
@@ -22,6 +22,11 @@ resource "aws_route" "openvpn_route_table" {
   route_table_id         = "${aws_route_table.openvpn_route_table.id}"
 }
 
+resource "aws_route_table_association" "openvpn_route_table_association" {
+  subnet_id      = "${aws_subnet.openvpn_subnet.id}"
+  route_table_id = "${aws_route_table.openvpn_route_table.id}"
+}
+
 resource "aws_security_group" "openvpn_security_group" {
   name        = "${var.env_id}-openvpn-security-group"
   description = "OpenVPN"

--- a/plan-patches/openvpn-aws/terraform/openvpn_override.tf
+++ b/plan-patches/openvpn-aws/terraform/openvpn_override.tf
@@ -16,7 +16,7 @@ resource "aws_route_table" "openvpn_route_table" {
   vpc_id = "${local.vpc_id}"
 }
 
-resource "aws_route" "openvpn_route_table" {
+resource "aws_route" "openvpn_route" {
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.ig.id}"
   route_table_id         = "${aws_route_table.openvpn_route_table.id}"

--- a/plan-patches/openvpn-aws/terraform/openvpn_override.tf
+++ b/plan-patches/openvpn-aws/terraform/openvpn_override.tf
@@ -1,0 +1,147 @@
+resource "aws_subnet" "openvpn_subnet" {
+  vpc_id            = "${local.vpc_id}"
+  cidr_block        = "${cidrsubnet(var.vpc_cidr, 8, 144)}"
+  availability_zone = "${element(var.availability_zones, 0)}"
+
+  tags {
+    Name = "${var.env_id}-openvpn-subnet"
+  }
+
+  lifecycle {
+    ignore_changes = ["cidr_block", "availability_zone"]
+  }
+}
+
+resource "aws_route_table" "openvpn_route_table" {
+  vpc_id = "${local.vpc_id}"
+}
+
+resource "aws_route" "openvpn_route_table" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = "${aws_internet_gateway.ig.id}"
+  route_table_id         = "${aws_route_table.openvpn_route_table.id}"
+}
+
+resource "aws_security_group" "openvpn_security_group" {
+  name        = "${var.env_id}-openvpn-security-group"
+  description = "OpenVPN"
+  vpc_id      = "${local.vpc_id}"
+
+  tags {
+    Name = "${var.env_id}-openvpn-security-group"
+  }
+
+  lifecycle {
+    ignore_changes = ["name"]
+  }
+}
+
+resource "aws_security_group_rule" "openvpn_security_group_rule_tcp" {
+  security_group_id = "${aws_security_group.openvpn_security_group.id}"
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = 0
+  to_port           = 65535
+  self              = true
+}
+
+resource "aws_security_group_rule" "openvpn_security_group_rule_udp" {
+  security_group_id = "${aws_security_group.openvpn_security_group.id}"
+  type              = "ingress"
+  protocol          = "udp"
+  from_port         = 0
+  to_port           = 65535
+  self              = true
+}
+
+resource "aws_security_group_rule" "openvpn_security_group_rule_icmp" {
+  security_group_id = "${aws_security_group.openvpn_security_group.id}"
+  type              = "ingress"
+  protocol          = "icmp"
+  from_port         = -1
+  to_port           = -1
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "openvpn_security_group_rule_openvpn" {
+  security_group_id = "${aws_security_group.openvpn_security_group.id}"
+  type              = "ingress"
+  protocol          = "TCP"
+  from_port         = 1194
+  to_port           = 1194
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "openvpn_security_group_rule_allow_internet" {
+  security_group_id = "${aws_security_group.openvpn_security_group.id}"
+  type              = "egress"
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 0
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "openvpn_security_group_rule_ssh" {
+  security_group_id        = "${aws_security_group.openvpn_security_group.id}"
+  type                     = "ingress"
+  protocol                 = "TCP"
+  from_port                = 22
+  to_port                  = 22
+  source_security_group_id = "${aws_security_group.jumpbox.id}"
+}
+
+resource "aws_security_group_rule" "bosh_openvpn_security_group_rule_tcp" {
+  security_group_id        = "${aws_security_group.openvpn_security_group.id}"
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 0
+  to_port                  = 65535
+  source_security_group_id = "${aws_security_group.bosh_security_group.id}"
+}
+
+resource "aws_security_group_rule" "bosh_openvpn_security_group_rule_udp" {
+  security_group_id        = "${aws_security_group.openvpn_security_group.id}"
+  type                     = "ingress"
+  protocol                 = "udp"
+  from_port                = 0
+  to_port                  = 65535
+  source_security_group_id = "${aws_security_group.bosh_security_group.id}"
+}
+
+resource "aws_security_group_rule" "openvpn_bosh_security_group_rule_tcp" {
+  security_group_id        = "${aws_security_group.bosh_security_group.id}"
+  type                     = "ingress"
+  protocol                 = "tcp"
+  from_port                = 0
+  to_port                  = 65535
+  source_security_group_id = "${aws_security_group.openvpn_security_group.id}"
+}
+
+resource "aws_security_group_rule" "openvpn_bosh_security_group_rule_udp" {
+  security_group_id        = "${aws_security_group.bosh_security_group.id}"
+  type                     = "ingress"
+  protocol                 = "udp"
+  from_port                = 0
+  to_port                  = 65535
+  source_security_group_id = "${aws_security_group.openvpn_security_group.id}"
+}
+
+resource "aws_eip" "openvpn_eip" {
+  vpc = true
+}
+
+output "openvpn_ip" {
+  value = "${aws_eip.openvpn_eip.public_ip}"
+}
+
+output "openvpn_security_group" {
+  value = "${aws_security_group.openvpn_security_group.id}"
+}
+
+output "openvpn_subnet_cidr" {
+  value = "${aws_subnet.openvpn_subnet.cidr_block}"
+}
+
+output "openvpn_subnet_id" {
+  value = "${aws_subnet.openvpn_subnet.id}"
+}


### PR DESCRIPTION
Hi,

This PR adds support for a BOSH deployed OpenVPN server on AWS. It adds a new public subnet with a security group to allow VPN traffic on TCP port 1194. It also adds a `vip` network to the cloud-config so that the openvpn server can have a public IP assigned. To keep things simple, we are only utilizing the first availability zone. We are open to supporting multiple AZs, but couldn't find a way to craft an ops-file to update the cloud-config based on the terraform outputs non-programatically.  See [this post](https://cloudfoundry.slack.com/archives/C0FA9UNAH/p1552513669015400).

[#164386432](https://www.pivotaltracker.com/story/show/164386432)

_Paul
cc @davewalter @julian-hj