### PR TITLE
Restore CF AWS LB health check settings

### DIFF
--- a/terraform/aws/templates/cf_lb.tf
+++ b/terraform/aws/templates/cf_lb.tf
@@ -57,7 +57,10 @@ resource "aws_lb_target_group" "cf_ssh" {
   vpc_id   = "${local.vpc_id}"
 
   health_check {
-    protocol = "TCP"
+    protocol            = "TCP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    interval            = 10
   }
 }
 
@@ -151,7 +154,10 @@ resource "aws_lb_target_group" "cf_router_80" {
   vpc_id   = "${local.vpc_id}"
 
   health_check {
-    protocol = "TCP"
+    protocol            = "TCP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    interval            = 10
   }
 }
 
@@ -162,7 +168,10 @@ resource "aws_lb_target_group" "cf_router_443" {
   vpc_id   = "${local.vpc_id}"
 
   health_check {
-    protocol = "TCP"
+    protocol            = "TCP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    interval            = 10
   }
 }
 
@@ -257,6 +266,9 @@ resource "aws_lb_target_group" "cf_tcp_router" {
 
   health_check {
     protocol = "TCP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    interval            = 10
   }
 }
 

--- a/terraform/aws/templates/iso_segments.tf
+++ b/terraform/aws/templates/iso_segments.tf
@@ -81,7 +81,10 @@ resource "aws_lb_target_group" "iso_router_lb_80" {
   vpc_id   = "${local.vpc_id}"
 
   health_check {
-    protocol = "TCP"
+    protocol            = "TCP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    interval            = 10
   }
 }
 
@@ -93,7 +96,10 @@ resource "aws_lb_target_group" "iso_router_lb_443" {
   vpc_id   = "${local.vpc_id}"
 
   health_check {
-    protocol = "TCP"
+    protocol            = "TCP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    interval            = 10
   }
 }
 


### PR DESCRIPTION
- we noticed the health check settings were changed when
  bbl started using Network LBs for AWS
- before used to be more sensitive to unhealthy instances, we want that
- changes isolation segment plan patch to use same values

Signed-off-by: Chris Dutra <cdutra@pivotal.io>