### PR TITLE
Add iam:CreateServiceLinkedRole permission to iam role policy

### DIFF
--- a/terraform/aws/templates/iam.tf
+++ b/terraform/aws/templates/iam.tf
@@ -86,7 +86,8 @@ resource "aws_iam_policy" "bosh" {
     },
 	{
 	  "Action": [
-	    "iam:PassRole"
+            "iam:PassRole",
+            "iam:CreateServiceLinkedRole"
 	  ],
 	  "Effect": "Allow",
 	  "Resource": "*"


### PR DESCRIPTION
With the current IAM role BOSH will fail to lodge spot instance request since the provided credentials do not have permission to create the service-linked role.

```
Task 148298 | 08:46:25 | Updating instance nats: nats/ec00fc7f-556c-424b-812e-5eddbf5077d5 (0) (canary) (00:00:52)
                      L Error: CPI error 'Bosh::Clouds::VMCreationFailed' with message 'Spot instance creation failed: #<Bosh::Clouds::VMCreationFailed: Failed to get spot instance request: #<Aws::EC2::Errors::AuthFailureServiceLinkedRoleCreationNotPermitted: The provided credentials do not have permission to create the service-linked role for EC2 Spot Instances.>>' in 'create_vm' CPI method (CPI request ID: 'cpi-457896')
```

When creating a Spot Request **AWSServiceRoleForEC2Spot** service-linked role needs to be created or exist already in IAM. If the role does not exist, AWS will attempt to create it automatically:

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-requests.html#service-linked-roles-spot-instance-requests