### PR TITLE
Revert "Exclude the 'd' availablity zone from aws"

### DIFF
--- a/aws/client.go
+++ b/aws/client.go
@@ -81,7 +81,7 @@ func (c Client) RetrieveDNS(url string) string {
 	return parentDomain
 }
 
-// Return the AWS Availability Zones for a given region in sorted order.
+// Return the AWS Availability Zones for a given region.
 func (c Client) RetrieveAZs(region string) ([]string, error) {
 	output, err := c.ec2Client.DescribeAvailabilityZones(&awsec2.DescribeAvailabilityZonesInput{
 		Filters: []*awsec2.Filter{{

--- a/cloudconfig/aws/ops_generator.go
+++ b/cloudconfig/aws/ops_generator.go
@@ -74,8 +74,6 @@ type lbCloudProperties struct {
 
 var marshal func(interface{}) ([]byte, error) = yaml.Marshal
 
-const azLimit = 3
-
 func NewOpsGenerator(terraformManager terraformManager, availabilityZones availabilityZones) OpsGenerator {
 	return OpsGenerator{
 		terraformManager:  terraformManager,
@@ -220,10 +218,6 @@ func (o OpsGenerator) generateOps(state storage.State) ([]op, error) {
 	azs, err := o.availabilityZones.RetrieveAZs(state.AWS.Region)
 	if err != nil {
 		return []op{}, fmt.Errorf("Retrieve availability zones: %s", err)
-	}
-
-	if len(azs) > azLimit {
-		azs = azs[:len(azs)-1]
 	}
 
 	for i := range azs {

--- a/cloudconfig/aws/ops_generator_test.go
+++ b/cloudconfig/aws/ops_generator_test.go
@@ -229,16 +229,6 @@ iso_az_subnet_id_mapping:
 
 				Expect(opsYAML).To(MatchYAML(expectedOpsYAML))
 			})
-
-			Context("when more than 3 azs are available in the region", func() {
-				It("returns an ops file that only includes the first 3 azs", func() {
-					availabilityZones.RetrieveAZsCall.Returns.AZs = []string{"us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d"}
-					opsYAML, err := opsGenerator.Generate(incomingState)
-					Expect(err).NotTo(HaveOccurred())
-
-					Expect(opsYAML).To(MatchYAML(expectedOpsYAML))
-				})
-			})
 		})
 
 		Context("when there are cf lbs", func() {

--- a/terraform/aws/input_generator.go
+++ b/terraform/aws/input_generator.go
@@ -18,7 +18,6 @@ type awsClient interface {
 }
 
 const terraformNameCharLimit = 18
-const azLimit = 3
 
 func NewInputGenerator(awsClient awsClient) InputGenerator {
 	return InputGenerator{
@@ -30,10 +29,6 @@ func (i InputGenerator) Generate(state storage.State) (map[string]interface{}, e
 	azs, err := i.awsClient.RetrieveAZs(state.AWS.Region)
 	if err != nil {
 		return map[string]interface{}{}, err
-	}
-
-	if len(azs) > azLimit {
-		azs = azs[:len(azs)-1]
 	}
 
 	shortEnvID := state.EnvID

--- a/terraform/aws/input_generator_test.go
+++ b/terraform/aws/input_generator_test.go
@@ -43,32 +43,6 @@ var _ = Describe("InputGenerator", func() {
 			})
 		})
 
-		Context("when more than 3 azs are available in the region", func() {
-			It("uses the first 3 azs for availability_zones", func() {
-				awsClient.RetrieveAZsCall.Returns.AZs = []string{"z1", "z2", "z3", "z4"}
-
-				inputs, err := inputGenerator.Generate(storage.State{
-					EnvID: "some-env-id",
-					AWS: storage.AWS{
-						AccessKeyID:     "some-access-key-id",
-						SecretAccessKey: "some-secret-access-key",
-						Region:          "some-region",
-					},
-					LB: storage.LB{
-						Type: "concourse",
-					},
-				})
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(inputs).To(Equal(map[string]interface{}{
-					"env_id":             "some-env-id",
-					"short_env_id":       "some-env-id",
-					"region":             "some-region",
-					"availability_zones": []string{"z1", "z2", "z3"},
-				}))
-			})
-		})
-
 		It("receives BBL state and returns a map of terraform variables", func() {
 			inputs, err := inputGenerator.Generate(storage.State{
 				EnvID: "some-env-id",

--- a/terraform/aws/templates/base.tf
+++ b/terraform/aws/templates/base.tf
@@ -358,9 +358,8 @@ resource "aws_security_group_rule" "bosh_internal_security_rule_udp" {
 }
 
 resource "aws_subnet" "bosh_subnet" {
-  vpc_id            = "${local.vpc_id}"
-  cidr_block        = "${cidrsubnet(var.vpc_cidr, 8, 0)}"
-  availability_zone = "${element(var.availability_zones, 0)}"
+  vpc_id     = "${local.vpc_id}"
+  cidr_block = "${cidrsubnet(var.vpc_cidr, 8, 0)}"
 
   tags {
     Name = "${var.env_id}-bosh-subnet"


### PR DESCRIPTION
This reverts commit b91a39b73665f19d4ad9a29394746b8339388bc6.

This fixes an issue of version v8.0.0 where it was triggering a recreation of the `bosh_subnet` which will fail because the bosh director and jumpbox live in that subnet.