### PR TITLE
Replace 4443 ingress rule to allow websocket traffic on aws elb

### DIFF
--- a/terraform/aws/templates/cf_lb.tf
+++ b/terraform/aws/templates/cf_lb.tf
@@ -112,6 +112,13 @@ resource "aws_security_group" "cf_router_lb_security_group" {
     to_port     = 443
   }
 
+  ingress {
+    cidr_blocks = ["0.0.0.0/0"]
+    protocol    = "tcp"
+    from_port   = 4443
+    to_port     = 4443
+  }
+
   egress {
     from_port   = 0
     to_port     = 0


### PR DESCRIPTION
We noticed that with the revert back to ELB's on AWS, the listener on port 4443 was replaced, but not the corresponding security group ingress rule. This replaces the rule and again allows for log streaming, which is required for smoke tests to pass.

Appears to fix https://github.com/cloudfoundry/bosh-bootloader/issues/470.

Thanks,
Andrew and @davewalter 

cc/ @DennisDenuto @paulcwarren @julian-hj @Syerram @vitreuz @Changdrew 