### PR TITLE
Don't set BOSH_LOG_LEVEL to debug in bosh-lite-aws override script

### DIFF
--- a/plan-patches/bosh-lite-aws/create-director-override.sh
+++ b/plan-patches/bosh-lite-aws/create-director-override.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 bosh create-env \
  ${BBL_STATE_DIR}/bosh-deployment/bosh.yml \
- --state=state.json \
+ --state  ${BBL_STATE_DIR}/vars/bosh-state.json \
  --vars-store  ${BBL_STATE_DIR}/vars/director-vars-store.yml \
  --vars-file  ${BBL_STATE_DIR}/vars/director-vars-file.yml \
  -o ${BBL_STATE_DIR}/bosh-deployment/aws/cpi.yml \

--- a/plan-patches/bosh-lite-aws/create-director-override.sh
+++ b/plan-patches/bosh-lite-aws/create-director-override.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-BOSH_LOG_LEVEL=debug bosh create-env \
+bosh create-env \
  ${BBL_STATE_DIR}/bosh-deployment/bosh.yml \
  --state=state.json \
  --vars-store  ${BBL_STATE_DIR}/vars/director-vars-store.yml \

--- a/plan-patches/bosh-lite-aws/delete-director-override.sh
+++ b/plan-patches/bosh-lite-aws/delete-director-override.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-bosh delete-env
+bosh delete-env \
  ${BBL_STATE_DIR}/bosh-deployment/bosh.yml \
- --state=state.json \
- --vars-store  ${BBL_STATE_DIR}/vars/director-vars-store.yml \
- --vars-file  ${BBL_STATE_DIR}/vars/director-vars-file.yml \
+ --state ${BBL_STATE_DIR}/vars/bosh-state.json \
+ --vars-store ${BBL_STATE_DIR}/vars/director-vars-store.yml \
+ --vars-file ${BBL_STATE_DIR}/vars/director-vars-file.yml \
  -o ${BBL_STATE_DIR}/bosh-deployment/aws/cpi.yml \
  -o ${BBL_STATE_DIR}/bosh-deployment/bosh-lite.yml \
  -o ${BBL_STATE_DIR}/bosh-deployment/bosh-lite-runc.yml \


### PR DESCRIPTION
This change makes the `create-director-override.sh` script consistent with its GCP counterpart, and also prevents users of this ops-file from accidentally sharing secrets (debug log level will show vars-file/vars-store content, among other things.)