### PR TITLE
cf_dns.tf: name servers as a list instead of csv

### DIFF
--- a/terraform/aws/templates/cf_dns.tf
+++ b/terraform/aws/templates/cf_dns.tf
@@ -15,12 +15,13 @@ data "aws_route53_zone" "parent" {
 }
 
 output "env_dns_zone_name_servers" {
-  value = ["${split(",", local.name_servers)}"]
+  value = "${formatlist("%s.", compact(local.name_servers))}"
 }
 
 locals {
-  zone_id      = "${var.parent_zone == "" ? element(concat(aws_route53_zone.env_dns_zone.*.zone_id, list("")), 0) : element(concat(data.aws_route53_zone.parent.*.zone_id, list("")), 0)}"
-  name_servers = "${var.parent_zone == "" ? join(",", flatten(concat(aws_route53_zone.env_dns_zone.*.name_servers, list(list(""))))) :  join(",", flatten(concat(data.aws_route53_zone.env_dns_zone.*.name_servers, list(list("")))))}"
+  zone_id = "${var.parent_zone == "" ?  element(concat(aws_route53_zone.env_dns_zone.*.zone_id, list("")), 0) : element(concat(data.aws_route53_zone.parent.*.zone_id, list("")), 0)}"
+
+  name_servers = "${split(",", var.parent_zone == "" ? join(",", flatten(aws_route53_zone.env_dns_zone.*.name_servers)) :  join(",", flatten(data.aws_route53_zone.parent.*.name_servers)))}"
 }
 
 resource "aws_route53_zone" "env_dns_zone" {


### PR DESCRIPTION
This PR is an attempt to fix the NS servers created by terraform to use a list instead of a comma separated string as per AWS documentation: 

This was previously PR'ed here: https://github.com/cloudfoundry/bosh-bootloader/pull/388 but since the OP couldn't reproduce I'm submitting the fix again with the suggested fix from @cdutra.
I believe the output was correctly split but the NS records were still recorded as a single comma separated string.

Another fix included in this PR is related to when var.parent_zone is not defined, then the name_servers list should come from the parent_zone instead of the aws_route53_zone.env_dns_zone.*.name_servers (which won't be created when var.parent_zone is defined)