### PR TITLE
nmap-netcat without connect-proxy detection fix

### DIFF
--- a/commands/ssh.go
+++ b/commands/ssh.go
@@ -159,10 +159,10 @@ func (s SSH) Execute(args []string, state storage.State) error {
 	if !s.pathFinder.CommandExists("connect-proxy") {
 		ncHelpOutBytes, err := exec.Command("nc", "-h").Output()
 		outStr := string(ncHelpOutBytes)
-		if err == nil && strings.Contains(outStr,"-x addr[:port]") {
+		if err == nil && strings.Contains(outStr,"netcat-openbsd") {
 			proxyCommandPrefix = "nc -x"
 		} else {
-			return fmt.Errorf("neither `connect-proxy` nor openbsd-`nc` (with proxy support: `-x addr[:port]`) can be executed")
+			return fmt.Errorf("neither `connect-proxy` nor openbsd `nc` (with proxy support) can be executed")
 		}
 	}
 	


### PR DESCRIPTION
Before this change the BBL generated command worked only if there was the openbsd-netcat or the connect-proxy installed on machine where the bbl is executed, nmap-netcat was used incorrectly - issue: https://github.com/cloudfoundry/bosh-bootloader/issues/339
This code should give users a chance to solve the problem with the nmap-netcat without connect-proxy installation.