### PR TITLE
Security groups openstack fix

### DIFF
--- a/terraform/openstack/templates/resources-outputs.tf
+++ b/terraform/openstack/templates/resources-outputs.tf
@@ -20,7 +20,7 @@ output "jumpbox__default_security_groups" {
 }
 
 output "director__default_security_groups" {
-  value = ["${openstack_networking_secgroup_v2.bosh.name}"]
+  value = ["${openstack_networking_secgroup_v2.dir.name}"]
 }
 
 output "internal_cidr" {

--- a/terraform/openstack/templates/resources.tf
+++ b/terraform/openstack/templates/resources.tf
@@ -80,7 +80,7 @@ resource "openstack_networking_secgroup_v2" "dir" {
   region = "${var.region_name}"
   name = "${var.env_id}-dir"
 }
-resource "openstack_networking_secgroup_rule_v2" "bosh_rule_1" {
+resource "openstack_networking_secgroup_rule_v2" "dir_rule_1" {
   description = "Jumpbox to Director NGINX"
   region = "${var.region_name}"
   direction = "ingress"
@@ -91,7 +91,7 @@ resource "openstack_networking_secgroup_rule_v2" "bosh_rule_1" {
   remote_group_id = "${openstack_networking_secgroup_v2.jb.id}"
   security_group_id = "${openstack_networking_secgroup_v2.dir.id}"
 }
-resource "openstack_networking_secgroup_rule_v2" "bosh_rule_2" {
+resource "openstack_networking_secgroup_rule_v2" "dir_rule_2" {
   description = "Jumpbox to Director MBUS"
   region = "${var.region_name}"
   direction = "ingress"
@@ -102,7 +102,7 @@ resource "openstack_networking_secgroup_rule_v2" "bosh_rule_2" {
   remote_group_id = "${openstack_networking_secgroup_v2.jb.id}"
   security_group_id = "${openstack_networking_secgroup_v2.dir.id}"
 }
-resource "openstack_networking_secgroup_rule_v2" "bosh_rule_3" {
+resource "openstack_networking_secgroup_rule_v2" "dir_rule_3" {
   description = "Jumpbox to Director SSH"
   region = "${var.region_name}"
   direction = "ingress"
@@ -113,7 +113,7 @@ resource "openstack_networking_secgroup_rule_v2" "bosh_rule_3" {
   remote_group_id = "${openstack_networking_secgroup_v2.jb.id}"
   security_group_id = "${openstack_networking_secgroup_v2.dir.id}"
 }
-resource "openstack_networking_secgroup_rule_v2" "bosh_rule_4" {
+resource "openstack_networking_secgroup_rule_v2" "dir_rule_4" {
   description = "Jumpbox to Director UAA"
   region = "${var.region_name}"
   direction = "ingress"
@@ -124,7 +124,7 @@ resource "openstack_networking_secgroup_rule_v2" "bosh_rule_4" {
   remote_group_id = "${openstack_networking_secgroup_v2.jb.id}"
   security_group_id = "${openstack_networking_secgroup_v2.dir.id}"
 }
-resource "openstack_networking_secgroup_rule_v2" "bosh_rule_5" {
+resource "openstack_networking_secgroup_rule_v2" "dir_rule_5" {
   description = "Jumpbox to Director Credhub"
   region = "${var.region_name}"
   direction = "ingress"
@@ -135,7 +135,7 @@ resource "openstack_networking_secgroup_rule_v2" "bosh_rule_5" {
   remote_group_id = "${openstack_networking_secgroup_v2.jb.id}"
   security_group_id = "${openstack_networking_secgroup_v2.dir.id}"
 }
-resource "openstack_networking_secgroup_rule_v2" "bosh_rule_6" {
+resource "openstack_networking_secgroup_rule_v2" "dir_rule_6" {
   description = "BOSH deployed VMs to Director NATS"
   region = "${var.region_name}"
   direction = "ingress"
@@ -146,7 +146,7 @@ resource "openstack_networking_secgroup_rule_v2" "bosh_rule_6" {
   remote_group_id = "${openstack_networking_secgroup_v2.vms.id}"
   security_group_id = "${openstack_networking_secgroup_v2.dir.id}"
 }
-resource "openstack_networking_secgroup_rule_v2" "bosh_rule_7" {
+resource "openstack_networking_secgroup_rule_v2" "dir_rule_7" {
   description = "BOSH deployed VMs to Director Registry"
   region = "${var.region_name}"
   direction = "ingress"
@@ -157,7 +157,7 @@ resource "openstack_networking_secgroup_rule_v2" "bosh_rule_7" {
   remote_group_id = "${openstack_networking_secgroup_v2.vms.id}"
   security_group_id = "${openstack_networking_secgroup_v2.dir.id}"
 }
-resource "openstack_networking_secgroup_rule_v2" "bosh_rule_8" {
+resource "openstack_networking_secgroup_rule_v2" "dir_rule_8" {
   description = "BOSH deployed VMs to Director Blobstore"
   region = "${var.region_name}"
   direction = "ingress"

--- a/terraform/openstack/templates/resources.tf
+++ b/terraform/openstack/templates/resources.tf
@@ -75,10 +75,10 @@ resource "openstack_networking_secgroup_rule_v2" "jb_rule_2" {
   security_group_id = "${openstack_networking_secgroup_v2.jb.id}"
 }
 
-resource "openstack_networking_secgroup_v2" "bosh" {
+resource "openstack_networking_secgroup_v2" "dir" {
   description = "BOSH Director Security Group"
   region = "${var.region_name}"
-  name = "${var.env_id}-bosh"
+  name = "${var.env_id}-dir"
 }
 resource "openstack_networking_secgroup_rule_v2" "bosh_rule_1" {
   description = "Jumpbox to Director NGINX"
@@ -89,7 +89,7 @@ resource "openstack_networking_secgroup_rule_v2" "bosh_rule_1" {
   port_range_min = 25555
   port_range_max = 25555
   remote_group_id = "${openstack_networking_secgroup_v2.jb.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.bosh.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.dir.id}"
 }
 resource "openstack_networking_secgroup_rule_v2" "bosh_rule_2" {
   description = "Jumpbox to Director MBUS"
@@ -100,7 +100,7 @@ resource "openstack_networking_secgroup_rule_v2" "bosh_rule_2" {
   port_range_min = 6868
   port_range_max = 6868
   remote_group_id = "${openstack_networking_secgroup_v2.jb.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.bosh.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.dir.id}"
 }
 resource "openstack_networking_secgroup_rule_v2" "bosh_rule_3" {
   description = "Jumpbox to Director SSH"
@@ -111,7 +111,7 @@ resource "openstack_networking_secgroup_rule_v2" "bosh_rule_3" {
   port_range_min = 22
   port_range_max = 22
   remote_group_id = "${openstack_networking_secgroup_v2.jb.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.bosh.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.dir.id}"
 }
 resource "openstack_networking_secgroup_rule_v2" "bosh_rule_4" {
   description = "Jumpbox to Director UAA"
@@ -122,7 +122,7 @@ resource "openstack_networking_secgroup_rule_v2" "bosh_rule_4" {
   port_range_min = 8443
   port_range_max = 8443
   remote_group_id = "${openstack_networking_secgroup_v2.jb.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.bosh.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.dir.id}"
 }
 resource "openstack_networking_secgroup_rule_v2" "bosh_rule_5" {
   description = "Jumpbox to Director Credhub"
@@ -133,7 +133,7 @@ resource "openstack_networking_secgroup_rule_v2" "bosh_rule_5" {
   port_range_min = 8844
   port_range_max = 8844
   remote_group_id = "${openstack_networking_secgroup_v2.jb.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.bosh.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.dir.id}"
 }
 resource "openstack_networking_secgroup_rule_v2" "bosh_rule_6" {
   description = "BOSH deployed VMs to Director NATS"
@@ -144,7 +144,7 @@ resource "openstack_networking_secgroup_rule_v2" "bosh_rule_6" {
   port_range_min = 4222
   port_range_max = 4222
   remote_group_id = "${openstack_networking_secgroup_v2.vms.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.bosh.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.dir.id}"
 }
 resource "openstack_networking_secgroup_rule_v2" "bosh_rule_7" {
   description = "BOSH deployed VMs to Director Registry"
@@ -155,7 +155,7 @@ resource "openstack_networking_secgroup_rule_v2" "bosh_rule_7" {
   port_range_min = 25777
   port_range_max = 25777
   remote_group_id = "${openstack_networking_secgroup_v2.vms.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.bosh.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.dir.id}"
 }
 resource "openstack_networking_secgroup_rule_v2" "bosh_rule_8" {
   description = "BOSH deployed VMs to Director Blobstore"
@@ -166,7 +166,7 @@ resource "openstack_networking_secgroup_rule_v2" "bosh_rule_8" {
   port_range_min = 25250
   port_range_max = 25250
   remote_group_id = "${openstack_networking_secgroup_v2.vms.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.bosh.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.dir.id}"
 }
 
 resource "openstack_networking_secgroup_v2" "vms" {
@@ -200,7 +200,7 @@ resource "openstack_networking_secgroup_rule_v2" "vms_rule_3" {
   protocol = "tcp"
   port_range_min = 22
   port_range_max = 22
-  remote_group_id = "${openstack_networking_secgroup_v2.jb.id}"
+  remote_group_id = "${openstack_networking_secgroup_v2.dir.id}"
   security_group_id = "${openstack_networking_secgroup_v2.vms.id}"
 }
 


### PR DESCRIPTION
- The last `vms_rule_3` rule have to give access the director to the vms machine using SSH - am I right?
- I changed `-bosh` suffix to the `-dir` (director) suffix, this is in line with the convention: `-jb`, `-bosh`, `-vms`
