### PR TITLE
Be consistent for director_name across all IaaS systems

### DIFF
--- a/terraform/openstack/templates/resources-outputs.tf
+++ b/terraform/openstack/templates/resources-outputs.tf
@@ -80,5 +80,5 @@ output "env_id" {
 }
 
 output "director_name" {
-  value = "${var.env_id}"
+  value = "bosh-${var.env_id}"
 }


### PR DESCRIPTION
Use the same pattern for director name as for other IaaS platforms.

On Azure, AWS and vSphere it is called "bosh-${env_id}" but on OpenStack it simply "${env_id}". This makes the resulting deployments unnecessary different.