### PR TITLE
Add yaml renderer for bbl print-env

### DIFF
--- a/renderers/factory.go
+++ b/renderers/factory.go
@@ -38,6 +38,8 @@ func (f *factory) createFromType(shellType string) (Renderer, error) {
 		return NewPowershell(), nil
 	case ShellTypePosix:
 		return NewPosix(), nil
+	case ShellTypeYaml:
+		return NewYaml(), nil
 	default:
 		return nil, fmt.Errorf("unrecognized type '%s'", shellType)
 	}

--- a/renderers/factory_test.go
+++ b/renderers/factory_test.go
@@ -41,5 +41,17 @@ var _ = Describe("Factory", func() {
 				Expect(renderer.Type()).To(Equal(renderers.ShellTypePosix))
 			})
 		})
+		Context("When passed 'yaml'", func() {
+			BeforeEach(func() {
+				envGetter := &fakes.EnvGetter{Values: vars}
+				factory = renderers.NewFactory(envGetter)
+			})
+			It("creates yaml renderer", func() {
+				shellType := "yaml"
+				renderer, err := factory.Create(shellType)
+				Expect(err).To(BeNil())
+				Expect(renderer.Type()).To(Equal(renderers.ShellTypeYaml))
+			})
+		})
 	})
 })

--- a/renderers/shell_types.go
+++ b/renderers/shell_types.go
@@ -3,4 +3,5 @@ package renderers
 const (
 	ShellTypePowershell = "powershell"
 	ShellTypePosix      = "posix"
+	ShellTypeYaml       = "yaml"
 )

--- a/renderers/yaml.go
+++ b/renderers/yaml.go
@@ -1,0 +1,30 @@
+package renderers
+
+import (
+	"fmt"
+	"strings"
+)
+
+type yaml struct {
+}
+
+// NewYaml defines a new yaml renderer
+func NewYaml() Renderer {
+	return &yaml{}
+}
+
+func (renderer *yaml) RenderEnvironmentVariable(variable string, value string) string {
+	if strings.ContainsAny(value, "\n") {
+		value = strings.ReplaceAll(value, "\n", "\\n")
+		suffix := ""
+		if !strings.HasSuffix(value, "\\n") {
+			suffix = "\\n"
+		}
+		return fmt.Sprintf("%s: \"%s%s\"", strings.ToLower(variable), value, suffix)
+	}
+	return fmt.Sprintf("%s: \"%s\"", strings.ToLower(variable), value)
+}
+
+func (renderer *yaml) Type() string {
+	return ShellTypeYaml
+}

--- a/renderers/yaml_test.go
+++ b/renderers/yaml_test.go
@@ -1,0 +1,49 @@
+package renderers_test
+
+import (
+	"github.com/cloudfoundry/bosh-bootloader/renderers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe(renderers.ShellTypeYaml, func() {
+	var (
+		renderer renderers.Renderer
+	)
+
+	BeforeEach(func() {
+		renderer = renderers.NewYaml()
+	})
+
+	Describe("RenderEnvironmentVariable", func() {
+		Context("WhenSingleLine", func() {
+			It("prints env statement properly", func() {
+				key := "KEY"
+				value := "value"
+				result := renderer.RenderEnvironmentVariable(key, value)
+				Expect(result).To(Equal(`key: "value"`))
+			})
+		})
+		Context("WhenMultiLine", func() {
+			It("prints env statement with enclosing quotes", func() {
+				key := "KEY"
+				value := "1\n2\n3\n4\n"
+				result := renderer.RenderEnvironmentVariable(key, value)
+				Expect(result).To(Equal(`key: "1\n2\n3\n4\n"`))
+			})
+			It("appends newline if not present", func() {
+				key := "KEY"
+				value := "1\n2\n3\n4"
+				result := renderer.RenderEnvironmentVariable(key, value)
+				Expect(result).To(Equal(`key: "1\n2\n3\n4\n"`))
+			})
+		})
+	})
+
+	Describe("Type", func() {
+		It("is yaml", func() {
+			shellType := renderer.Type()
+			Expect(shellType).To(Equal(renderers.ShellTypeYaml))
+		})
+	})
+})


### PR DESCRIPTION
We (the CF-Toolsmiths team) are building automation around creating environments using bbl and cf-deployment. In order to provide to our users the metadata required to target their BOSH director and use their new environments, we need to programmatically parse the output of bbl print-env. Seems like the easiest way to do this was to add a YAML renderer (JSON would have been our first choice, but was more complicated due to having to add trailing commas, starting and ending braces, etc.). This will hopefully also make it easier for all users to programmatically interact with bbl.

cc @rowanjacobs @nhsieh 