### PR TITLE
Add missing yaml renderer shell type for print-env help message

### DIFF
--- a/commands/commands_usage.go
+++ b/commands/commands_usage.go
@@ -111,7 +111,7 @@ const (
 
 	PrintEnvCommandUsage = `Prints required BOSH environment variables.
 
-  --shell-type             Prints for the given shell (posix|powershell)
+  --shell-type             Prints for the given shell (posix|powershell|yaml)
 `
 	LatestErrorCommandUsage = "Prints the output from the latest call to terraform"
 )

--- a/commands/commands_usage_test.go
+++ b/commands/commands_usage_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Commands Usage", func() {
 				usageText := command.Usage()
 				Expect(usageText).To(Equal(`Prints required BOSH environment variables.
 
-  --shell-type             Prints for the given shell (posix|powershell)
+  --shell-type             Prints for the given shell (posix|powershell|yaml)
 `))
 			})
 		})


### PR DESCRIPTION
This PR adds YAML renderer shell type to `bbl print-env` help message.

YAML render support was added in https://github.com/cloudfoundry/bosh-bootloader/pull/487 PR. 