### PR TITLE
Print-env can take Toolsmiths metadata file

### DIFF
--- a/commands/commands_usage.go
+++ b/commands/commands_usage.go
@@ -112,7 +112,7 @@ const (
 	PrintEnvCommandUsage = `Prints required BOSH environment variables.
 
   --shell-type             Prints for the given shell (posix|powershell|yaml)
-  --file                   Read from Toolsmiths metadata file instead of bbl state
+  --metadata-file          Read from Toolsmiths metadata file instead of bbl state
 `
 	LatestErrorCommandUsage = "Prints the output from the latest call to terraform"
 )

--- a/commands/commands_usage.go
+++ b/commands/commands_usage.go
@@ -112,6 +112,7 @@ const (
 	PrintEnvCommandUsage = `Prints required BOSH environment variables.
 
   --shell-type             Prints for the given shell (posix|powershell|yaml)
+  --file                   Read from Toolsmiths metadata file instead of bbl state
 `
 	LatestErrorCommandUsage = "Prints the output from the latest call to terraform"
 )

--- a/commands/commands_usage_test.go
+++ b/commands/commands_usage_test.go
@@ -145,6 +145,7 @@ var _ = Describe("Commands Usage", func() {
 				Expect(usageText).To(Equal(`Prints required BOSH environment variables.
 
   --shell-type             Prints for the given shell (posix|powershell|yaml)
+  --file                   Read from Toolsmiths metadata file instead of bbl state
 `))
 			})
 		})

--- a/commands/commands_usage_test.go
+++ b/commands/commands_usage_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Commands Usage", func() {
 				Expect(usageText).To(Equal(`Prints required BOSH environment variables.
 
   --shell-type             Prints for the given shell (posix|powershell|yaml)
-  --file                   Read from Toolsmiths metadata file instead of bbl state
+  --metadata-file          Read from Toolsmiths metadata file instead of bbl state
 `))
 			})
 		})

--- a/commands/print_env.go
+++ b/commands/print_env.go
@@ -85,7 +85,7 @@ func (p PrintEnv) ParseArgs(args []string, state storage.State) (PrintEnvConfig,
 
 	printEnvFlags := flags.New("print-env")
 	printEnvFlags.String(&config.shellType, "shell-type", "")
-	printEnvFlags.String(&config.metadataFile, "file", "")
+	printEnvFlags.String(&config.metadataFile, "metadata-file", "")
 
 	err := printEnvFlags.Parse(args)
 	if err != nil {

--- a/commands/print_env.go
+++ b/commands/print_env.go
@@ -72,11 +72,9 @@ func NewPrintEnv(
 }
 
 func (p PrintEnv) CheckFastFails(subcommandFlags []string, state storage.State) error {
-	err := p.stateValidator.Validate()
-	if err != nil {
-		return err
-	}
-
+	// We don't do any validation here, because at this point, we don't know if we're using
+	// a bbl-state or a metadata file. Once we know that we're using a bbl-state, in Execute,
+	// we validate that the state exists.
 	return nil
 }
 
@@ -158,6 +156,11 @@ func (p PrintEnv) Execute(args []string, state storage.State) error {
 
 		p.renderVariables(renderer, variables)
 		return nil
+	}
+
+	err = p.stateValidator.Validate()
+	if err != nil {
+		return err
 	}
 
 	variables["BOSH_CLIENT"] = state.BOSH.DirectorUsername

--- a/commands/print_env.go
+++ b/commands/print_env.go
@@ -109,13 +109,8 @@ func (p PrintEnv) Execute(args []string, state storage.State) error {
 		return err
 	}
 
-	useMetadata := false
 	metadataFile := config.metadataFile
 	if metadataFile != "" {
-		useMetadata = true
-	}
-
-	if useMetadata {
 		var metadata struct {
 			Name     string            `json:"name"`
 			IaasType string            `json:"iaas_type"`

--- a/commands/print_env_test.go
+++ b/commands/print_env_test.go
@@ -175,7 +175,7 @@ var _ = Describe("PrintEnv", func() {
 			})
 
 			It("prints the correct environment variables for the bosh cli", func() {
-				err := printEnv.Execute([]string{"--file", fmt.Sprintf("%s/metadata.json", tmpDir)}, storage.State{})
+				err := printEnv.Execute([]string{"--metadata-file", fmt.Sprintf("%s/metadata.json", tmpDir)}, storage.State{})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(logger.PrintlnCall.Messages).To(ContainElement("export BOSH_CLIENT=some-director-username"))
@@ -205,7 +205,7 @@ var _ = Describe("PrintEnv", func() {
 				})
 
 				It("does not return an error", func() {
-					err := printEnv.Execute([]string{"--file", fmt.Sprintf("%s/metadata.json", tmpDir)}, storage.State{})
+					err := printEnv.Execute([]string{"--metadata-file", fmt.Sprintf("%s/metadata.json", tmpDir)}, storage.State{})
 					Expect(err).NotTo(HaveOccurred())
 				})
 			})
@@ -213,7 +213,7 @@ var _ = Describe("PrintEnv", func() {
 			Context("failure cases", func() {
 				Context("when fails to read metadata file", func() {
 					It("logs an error", func() {
-						err := printEnv.Execute([]string{"--file", "does_not_exist.json"}, storage.State{})
+						err := printEnv.Execute([]string{"--metadata-file", "does_not_exist.json"}, storage.State{})
 						Expect(err).To(HaveOccurred())
 						Expect(stderrLogger.PrintlnCall.Messages).To(ContainElement(MatchRegexp("Failed to read does_not_exist.json")))
 					})
@@ -227,7 +227,7 @@ var _ = Describe("PrintEnv", func() {
 					})
 
 					It("logs an error", func() {
-						err := printEnv.Execute([]string{"--file", fmt.Sprintf("%s/bad.json", tmpDir)}, storage.State{})
+						err := printEnv.Execute([]string{"--metadata-file", fmt.Sprintf("%s/bad.json", tmpDir)}, storage.State{})
 						Expect(err).To(HaveOccurred())
 						Expect(stderrLogger.PrintlnCall.Messages).To(ContainElement(MatchRegexp(fmt.Sprintf("Failed to unmarshal %s/bad.json", tmpDir))))
 					})


### PR DESCRIPTION
In order to allow the new Toolsmiths pooled cf-deployment environments to work with cf-deployment-concourse-tasks, we would like to provide a metadata file, in the [format](https://pivotal.github.io/cf-toolsmiths-docs/pivotal-cf-experimental/toolsmiths-envs/cf-deployment/) that the Toolsmiths API provides, to `bbl` in lieu of a traditional bbl-state directory.

This change should not affect `bbl` usage at all for those who are using the traditional bbl-state workflow.