### PR TITLE
Remove consul from cf-azure patches

### DIFF
--- a/plan-patches/cf-azure/ops/rename-network-and-deployment.yml
+++ b/plan-patches/cf-azure/ops/rename-network-and-deployment.yml
@@ -5,10 +5,6 @@
   value: ((network_name))
 
 - type: replace
-  path: /instance_groups/name=consul/networks/name=default/name
-  value: ((network_name))
-
-- type: replace
   path: /instance_groups/name=nats/networks/name=default/name
   value: ((network_name))
 
@@ -131,13 +127,6 @@
     targets:
     - query: '*'
       instance_group: api
-      deployment: ((deployment_name))
-      network: ((network_name))
-      domain: bosh
-  - domain: consul.service.cf.internal
-    targets:
-    - query: '*'
-      instance_group: consul
       deployment: ((deployment_name))
       network: ((network_name))
       domain: bosh

--- a/plan-patches/cf-azure/ops/scale-to-one-az.yml
+++ b/plan-patches/cf-azure/ops/scale-to-one-az.yml
@@ -3,9 +3,6 @@
 # Use this override to only deploy single instance of each job,
 # in a single Availability Zone.
 - type: replace
-  path: /instance_groups/name=consul/instances
-  value: 1
-- type: replace
   path: /instance_groups/name=nats/instances
   value: 1
 - type: replace
@@ -13,9 +10,6 @@
   value: 1
 - type: replace
   path: /instance_groups/name=uaa/instances
-  value: 1
-- type: replace
-  path: /instance_groups/name=consul/instances
   value: 1
 - type: replace
   path: /instance_groups/name=scheduler/instances
@@ -56,9 +50,6 @@
   value: [ z1 ]
 - type: replace
   path: /instance_groups/name=uaa/azs
-  value: [ z1 ]
-- type: replace
-  path: /instance_groups/name=consul/azs
   value: [ z1 ]
 - type: replace
   path: /instance_groups/name=scheduler/azs

--- a/plan-patches/cf-azure/ops/use-cf-resource-group.yml
+++ b/plan-patches/cf-azure/ops/use-cf-resource-group.yml
@@ -4,10 +4,6 @@
   value: cf-resource-group-properties
 
 - type: replace
-  path: /instance_groups/name=consul/vm_extensions?/-
-  value: cf-resource-group-properties
-
-- type: replace
   path: /instance_groups/name=nats/vm_extensions?/-
   value: cf-resource-group-properties
 

--- a/plan-patches/cf-azure/ops/use-cf-subnet.yml
+++ b/plan-patches/cf-azure/ops/use-cf-subnet.yml
@@ -4,10 +4,6 @@
   value: cf
 
 - type: replace
-  path: /instance_groups/name=consul/networks/0/name
-  value: cf
-
-- type: replace
   path: /instance_groups/name=nats/networks/0/name
   value: cf
 


### PR DESCRIPTION
Since consul was deleted in cf-deployment v5.0.0, it was deleted from azure patches.

cf-deployment v5.0.0: https://github.com/cloudfoundry/cf-deployment/releases/tag/v5.0.0