### PR TITLE
Tag resources that use short_env_id so that leftovers can delete them.

### DIFF
--- a/terraform/aws/templates/cf_lb.tf
+++ b/terraform/aws/templates/cf_lb.tf
@@ -83,6 +83,10 @@ resource "aws_elb" "cf_ssh_lb" {
 
   security_groups = ["${aws_security_group.cf_ssh_lb_security_group.id}"]
   subnets         = ["${aws_subnet.lb_subnets.*.id}"]
+
+  tags {
+    Name = "${var.env_id}"
+  }
 }
 
 output "cf_ssh_lb_name" {
@@ -208,6 +212,10 @@ resource "aws_elb" "cf_router_lb" {
 
   security_groups = ["${aws_security_group.cf_router_lb_security_group.id}"]
   subnets         = ["${aws_subnet.lb_subnets.*.id}"]
+
+  tags {
+    Name = "${var.env_id}"
+  }
 }
 
 resource "aws_lb_target_group" "cf_router_4443" {
@@ -218,6 +226,10 @@ resource "aws_lb_target_group" "cf_router_4443" {
 
   health_check {
     protocol = "TCP"
+  }
+
+  tags {
+    Name = "${var.env_id}"
   }
 }
 
@@ -1014,6 +1026,10 @@ resource "aws_elb" "cf_tcp_lb" {
 
   security_groups = ["${aws_security_group.cf_tcp_lb_security_group.id}"]
   subnets         = ["${aws_subnet.lb_subnets.*.id}"]
+
+  tags {
+    Name = "${var.env_id}"
+  }
 }
 
 output "cf_tcp_lb_name" {

--- a/terraform/aws/templates/concourse_lb.tf
+++ b/terraform/aws/templates/concourse_lb.tf
@@ -56,6 +56,10 @@ resource "aws_lb" "concourse_lb" {
   name               = "${var.short_env_id}-concourse-lb"
   load_balancer_type = "network"
   subnets            = ["${aws_subnet.lb_subnets.*.id}"]
+
+  tags {
+    Name = "${var.env_id}"
+  }
 }
 
 resource "aws_lb_listener" "concourse_lb_80" {
@@ -81,6 +85,10 @@ resource "aws_lb_target_group" "concourse_lb_80" {
     interval            = 30
     protocol            = "TCP"
   }
+
+  tags {
+    Name = "${var.env_id}"
+  }
 }
 
 resource "aws_lb_listener" "concourse_lb_2222" {
@@ -99,6 +107,10 @@ resource "aws_lb_target_group" "concourse_lb_2222" {
   port     = 2222
   protocol = "TCP"
   vpc_id   = "${local.vpc_id}"
+
+  tags {
+    Name = "${var.env_id}"
+  }
 }
 
 resource "aws_lb_listener" "concourse_lb_443" {
@@ -117,6 +129,10 @@ resource "aws_lb_target_group" "concourse_lb_443" {
   port     = 443
   protocol = "TCP"
   vpc_id   = "${local.vpc_id}"
+
+  tags {
+    Name = "${var.env_id}"
+  }
 }
 
 resource "aws_security_group_rule" "concourse_lb_internal_8844" {
@@ -155,6 +171,10 @@ resource "aws_lb_target_group" "concourse_lb_8844" {
   port     = 8844
   protocol = "TCP"
   vpc_id   = "${local.vpc_id}"
+
+  tags {
+    Name = "${var.env_id}"
+  }
 }
 
 resource "aws_lb_listener" "concourse_lb_8443" {
@@ -173,6 +193,10 @@ resource "aws_lb_target_group" "concourse_lb_8443" {
   port     = 8443
   protocol = "TCP"
   vpc_id   = "${local.vpc_id}"
+
+  tags {
+    Name = "${var.env_id}"
+  }
 }
 
 output "concourse_lb_internal_security_group" {

--- a/terraform/aws/templates/iam.tf
+++ b/terraform/aws/templates/iam.tf
@@ -3,7 +3,7 @@ variable "bosh_iam_instance_profile" {
 }
 
 locals {
-  iamProfileProvided = "${var.bosh_iam_instance_profile == "" ? 0 : 1 }"
+  iamProfileProvided = "${var.bosh_iam_instance_profile == "" ? 0 : 1}"
 }
 
 data "aws_iam_instance_profile" "bosh" {
@@ -142,6 +142,10 @@ resource "aws_flow_log" "bbl" {
 
 resource "aws_cloudwatch_log_group" "bbl" {
   name_prefix = "${var.short_env_id}-log-group"
+
+  tags {
+    Name = "${var.env_id}"
+  }
 }
 
 resource "aws_iam_role" "flow_logs" {

--- a/terraform/aws/templates/iso_segments.tf
+++ b/terraform/aws/templates/iso_segments.tf
@@ -79,6 +79,10 @@ resource "aws_elb" "iso_router_lb" {
 
   security_groups = ["${aws_security_group.cf_router_lb_security_group.id}"]
   subnets         = ["${aws_subnet.lb_subnets.*.id}"]
+
+  tags {
+    Name = "${var.env_id}"
+  }
 }
 
 resource "aws_lb_target_group" "iso_router_lb_4443" {
@@ -90,6 +94,10 @@ resource "aws_lb_target_group" "iso_router_lb_4443" {
 
   health_check {
     protocol = "TCP"
+  }
+
+  tags {
+    Name = "${var.env_id}"
   }
 }
 

--- a/terraform/aws/templates/ssl_certificate.tf
+++ b/terraform/aws/templates/ssl_certificate.tf
@@ -20,4 +20,8 @@ resource "aws_iam_server_certificate" "lb_cert" {
   lifecycle {
     create_before_destroy = true
   }
+
+  tags {
+    Name = "${var.env_id}"
+  }
 }


### PR DESCRIPTION
Resolves https://github.com/genevieve/leftovers/issues/86

See CI: https://infra.ci.cf-app.com/teams/main/pipelines/bosh-bootloader/jobs/bbl-aws-concourse-bump-deployments/builds/122