### PR TITLE
Update .tf templates to support Terraform 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ on an IaaS. `bbl` currently supports AWS, GCP, Microsoft Azure, Openstack and vS
 The following should be installed on your local machine
 - [bosh-cli](https://bosh.io/docs/cli-v2.html)
 - [bosh create-env dependencies](https://bosh.io/docs/cli-env-deps.html)
-- [terraform](https://www.terraform.io/downloads.html) >= 0.11.0
+- [terraform](https://www.terraform.io/downloads.html) >= 0.12.0
 - ruby (necessary for bosh create-env)
 
 ### Install bosh-bootloader using a package manager

--- a/plan-patches/acm-aws/terraform/cert_override.tf
+++ b/plan-patches/acm-aws/terraform/cert_override.tf
@@ -8,18 +8,18 @@ resource "aws_acm_certificate" "cert" {
 }
 
 resource "aws_route53_record" "cert_validation" {
-  name    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_name}"
-  type    = "${aws_acm_certificate.cert.domain_validation_options.0.resource_record_type}"
-  zone_id = "${data.aws_route53_zone.env_dns_zone.id}"
-  records = ["${aws_acm_certificate.cert.domain_validation_options.0.resource_record_value}"]
+  name    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_type
+  zone_id = data.aws_route53_zone.env_dns_zone.id
+  records = [aws_acm_certificate.cert.domain_validation_options.0.resource_record_value]
   ttl     = 60
 }
 
 resource "aws_acm_certificate_validation" "cert" {
-  certificate_arn         = "${aws_acm_certificate.cert.arn}"
-  validation_record_fqdns = ["${aws_route53_record.cert_validation.fqdn}"]
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [aws_route53_record.cert_validation.fqdn]
 }
 
 output "certificate_arn" {
-  value = "${aws_acm_certificate.cert.arn}"
+  value = aws_acm_certificate.cert.arn
 }

--- a/plan-patches/acm-aws/terraform/dns_override.tf
+++ b/plan-patches/acm-aws/terraform/dns_override.tf
@@ -3,7 +3,7 @@ resource "aws_route53_zone" "env_dns_zone" {
 }
 
 data "aws_route53_zone" "env_dns_zone" {
-  name = "${var.system_domain}"
+  name = var.system_domain
 }
 
 output "env_dns_zone_name_servers" {
@@ -11,17 +11,17 @@ output "env_dns_zone_name_servers" {
 }
 
 resource "aws_route53_record" "wildcard_dns" {
-  zone_id = "${data.aws_route53_zone.env_dns_zone.id}"
+  zone_id = data.aws_route53_zone.env_dns_zone.id
 }
 
 resource "aws_route53_record" "ssh" {
-  zone_id = "${data.aws_route53_zone.env_dns_zone.id}"
+  zone_id = data.aws_route53_zone.env_dns_zone.id
 }
 
 resource "aws_route53_record" "bosh" {
-  zone_id = "${data.aws_route53_zone.env_dns_zone.id}"
+  zone_id = data.aws_route53_zone.env_dns_zone.id
 }
 
 resource "aws_route53_record" "tcp" {
-  zone_id = "${data.aws_route53_zone.env_dns_zone.id}"
+  zone_id = data.aws_route53_zone.env_dns_zone.id
 }

--- a/plan-patches/acm-aws/terraform/lb_override.tf
+++ b/plan-patches/acm-aws/terraform/lb_override.tf
@@ -11,7 +11,7 @@ resource "aws_elb" "cf_router_lb" {
     instance_protocol  = "http"
     lb_port            = 443
     lb_protocol        = "https"
-    ssl_certificate_id = "${aws_acm_certificate.cert.arn}"
+    ssl_certificate_id = aws_acm_certificate.cert.arn
   }
 
   listener {
@@ -19,7 +19,7 @@ resource "aws_elb" "cf_router_lb" {
     instance_protocol  = "tcp"
     lb_port            = 4443
     lb_protocol        = "ssl"
-    ssl_certificate_id = "${aws_acm_certificate.cert.arn}"
+    ssl_certificate_id = aws_acm_certificate.cert.arn
   }
 }
 
@@ -29,7 +29,7 @@ resource "aws_elb" "iso_router_lb" {
     instance_protocol  = "http"
     lb_port            = 443
     lb_protocol        = "https"
-    ssl_certificate_id = "${aws_acm_certificate.cert.arn}"
+    ssl_certificate_id = aws_acm_certificate.cert.arn
   }
 
   listener {
@@ -37,6 +37,6 @@ resource "aws_elb" "iso_router_lb" {
     instance_protocol  = "tcp"
     lb_port            = 4443
     lb_protocol        = "ssl"
-    ssl_certificate_id = "${aws_acm_certificate.cert.arn}"
+    ssl_certificate_id = aws_acm_certificate.cert.arn
   }
 }

--- a/plan-patches/alb-aws/terraform/cf-lb_override.tf
+++ b/plan-patches/alb-aws/terraform/cf-lb_override.tf
@@ -2,19 +2,19 @@ resource "aws_lb" "cf_router" {
   name               = "${var.short_env_id}-cf-router-lb"
   load_balancer_type = "application"
 
-  security_groups = ["${aws_security_group.cf_router_lb_security_group.id}"]
-  subnets         = ["${aws_subnet.lb_subnets.*.id}"]
+  security_groups = [aws_security_group.cf_router_lb_security_group.id]
+  subnets         = aws_subnet.lb_subnets.*.ids
 }
 
 resource "aws_lb_listener" "cf_router_443" {
-  load_balancer_arn = "${aws_lb.cf_router.arn}"
+  load_balancer_arn = aws_lb.cf_router.arn
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2015-05"
-  certificate_arn   = "${aws_iam_server_certificate.lb_cert.arn}"
+  certificate_arn   = aws_iam_server_certificate.lb_cert.arn
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.cf_router_443.arn}"
+    target_group_arn = aws_lb_target_group.cf_router_443.arn
     type             = "forward"
   }
 }
@@ -23,7 +23,7 @@ resource "aws_lb_target_group" "cf_router_443" {
   name     = "${var.short_env_id}-routertg-443"
   port     = 443
   protocol = "HTTPS"
-  vpc_id   = "${local.vpc_id}"
+  vpc_id   = local.vpc_id
 
   health_check {
     path = "/health"
@@ -32,14 +32,14 @@ resource "aws_lb_target_group" "cf_router_443" {
 }
 
 resource "aws_lb_listener" "cf_router_4443" {
-  load_balancer_arn = "${aws_lb.cf_router.arn}"
+  load_balancer_arn = aws_lb.cf_router.arn
   port              = "4443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2015-05"
-  certificate_arn   = "${aws_iam_server_certificate.lb_cert.arn}"
+  certificate_arn   = aws_iam_server_certificate.lb_cert.arn
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.cf_router_4443.arn}"
+    target_group_arn = aws_lb_target_group.cf_router_4443.arn
     type             = "forward"
   }
 }
@@ -48,7 +48,7 @@ resource "aws_lb_target_group" "cf_router_4443" {
   name     = "${var.short_env_id}-routertg-4443"
   port     = 4443
   protocol = "HTTPS"
-  vpc_id   = "${local.vpc_id}"
+  vpc_id   = local.vpc_id
 
   health_check {
     path = "/health"
@@ -57,12 +57,12 @@ resource "aws_lb_target_group" "cf_router_4443" {
 }
 
 resource "aws_lb_listener" "cf_router_80" {
-  load_balancer_arn = "${aws_lb.cf_router.arn}"
+  load_balancer_arn = aws_lb.cf_router.arn
   port              = "80"
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.cf_router_80.arn}"
+    target_group_arn = aws_lb_target_group.cf_router_80.arn
     type             = "forward"
   }
 }
@@ -71,7 +71,7 @@ resource "aws_lb_target_group" "cf_router_80" {
   name     = "${var.short_env_id}-routertg-80"
   port     = 80
   protocol = "HTTP"
-  vpc_id   = "${local.vpc_id}"
+  vpc_id   = local.vpc_id
 
   health_check {
     path = "/health"
@@ -82,31 +82,31 @@ resource "aws_lb_target_group" "cf_router_80" {
 resource "aws_security_group" "cf_router_lb_internal_security_group" {
   name        = "${var.env_id}-cf-router-lb-internal-security-group"
   description = "CF Router Internal"
-  vpc_id      = "${local.vpc_id}"
+  vpc_id      = local.vpc_id
 
   ingress {
-    security_groups = ["${aws_security_group.cf_router_lb_security_group.id}"]
+    security_groups = [aws_security_group.cf_router_lb_security_group.id]
     protocol        = "tcp"
     from_port       = 80
     to_port         = 80
   }
 
   ingress {
-    security_groups = ["${aws_security_group.cf_router_lb_security_group.id}"]
+    security_groups = [aws_security_group.cf_router_lb_security_group.id]
     protocol        = "tcp"
     from_port       = 8080
     to_port         = 8080
   }
 
   ingress {
-    security_groups = ["${aws_security_group.cf_router_lb_security_group.id}"]
+    security_groups = [aws_security_group.cf_router_lb_security_group.id]
     protocol        = "tcp"
     from_port       = 443
     to_port         = 443
   }
 
   ingress {
-    security_groups = ["${aws_security_group.cf_router_lb_security_group.id}"]
+    security_groups = [aws_security_group.cf_router_lb_security_group.id]
     protocol        = "tcp"
     from_port       = 4443
     to_port         = 4443
@@ -119,7 +119,7 @@ resource "aws_security_group" "cf_router_lb_internal_security_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.env_id}-cf-router-lb-internal-security-group"
   }
 
@@ -129,18 +129,18 @@ resource "aws_security_group" "cf_router_lb_internal_security_group" {
 }
 
 output "cf_router_lb_name" {
-  value = "${aws_lb.cf_router.name}"
+  value = aws_lb.cf_router.name
 }
 
 output "cf_router_lb_url" {
-  value = "${aws_lb.cf_router.dns_name}"
+  value = aws_lb.cf_router.dns_name
 }
 
 resource "aws_route53_record" "wildcard_dns" {
-  zone_id = "${aws_route53_zone.env_dns_zone.id}"
+  zone_id = aws_route53_zone.env_dns_zone.id
   name    = "*.${var.system_domain}"
   type    = "CNAME"
   ttl     = 300
 
-  records = ["${aws_lb.cf_router.dns_name}"]
+  records = [aws_lb.cf_router.dns_name]
 }

--- a/plan-patches/bosh-lite-aws/terraform/bosh-lite_override.tf
+++ b/plan-patches/bosh-lite-aws/terraform/bosh-lite_override.tf
@@ -1,27 +1,27 @@
 
 resource "aws_security_group_rule" "bosh_security_group_rule_http" {
-  security_group_id        = "${aws_security_group.bosh_security_group.id}"
-  type                     = "ingress"
-  protocol                 = "tcp"
-  from_port                = 80
-  to_port                  = 80
-  cidr_blocks = ["${var.bosh_inbound_cidr}"]
+  security_group_id = aws_security_group.bosh_security_group.id
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_blocks       = [var.bosh_inbound_cidr]
 }
 
 resource "aws_security_group_rule" "bosh_security_group_rule_https" {
-  security_group_id        = "${aws_security_group.bosh_security_group.id}"
-  type                     = "ingress"
-  protocol                 = "tcp"
-  from_port                = 443
-  to_port                  = 443
-  cidr_blocks = ["${var.bosh_inbound_cidr}"]
+  security_group_id = aws_security_group.bosh_security_group.id
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = [var.bosh_inbound_cidr]
 }
 
 resource "aws_security_group_rule" "bosh_security_group_rule_https_alt" {
-  security_group_id        = "${aws_security_group.bosh_security_group.id}"
-  type                     = "ingress"
-  protocol                 = "tcp"
-  from_port                = 4443
-  to_port                  = 4443
-  cidr_blocks = ["${var.bosh_inbound_cidr}"]
+  security_group_id = aws_security_group.bosh_security_group.id
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = 4443
+  to_port           = 4443
+  cidr_blocks       = [var.bosh_inbound_cidr]
 }

--- a/plan-patches/bosh-lite-gcp/terraform/bosh-lite_override.tf
+++ b/plan-patches/bosh-lite-gcp/terraform/bosh-lite_override.tf
@@ -1,10 +1,10 @@
 locals {
-  short_env_id = "${substr(var.env_id, 0, min(20, length(var.env_id)))}"
+  short_env_id = substr(var.env_id, 0, min(20, length(var.env_id)))
 }
 
 resource "google_compute_firewall" "bosh-director-lite" {
   name    = "${local.short_env_id}-bosh-director-lite"
-  network = "${google_compute_network.bbl-network.name}"
+  network = google_compute_network.bbl-network.name
 
   source_ranges = ["0.0.0.0/0"]
 
@@ -23,16 +23,16 @@ resource "google_compute_address" "bosh-director-ip" {
 resource "google_compute_route" "bosh-lite-vms" {
   name        = "${var.env_id}-bosh-lite-vms"
   dest_range  = "10.244.0.0/16"
-  network     = "${google_compute_network.bbl-network.name}"
+  network     = google_compute_network.bbl-network.name
   next_hop_ip = "10.0.0.6"
   priority    = 1
 
-  depends_on = ["google_compute_subnetwork.bbl-subnet"]
+  depends_on = [google_compute_subnetwork.bbl-subnet]
 }
 
 resource "google_compute_firewall" "bosh-director-lite-tcp-routing" {
   name    = "${local.short_env_id}-bosh-director-lite-tcp-routing"
-  network = "${google_compute_network.bbl-network.name}"
+  network = google_compute_network.bbl-network.name
 
   source_ranges = ["0.0.0.0/0"]
 
@@ -45,13 +45,13 @@ resource "google_compute_firewall" "bosh-director-lite-tcp-routing" {
 }
 
 output "director__external_ip" {
-  value = "${google_compute_address.bosh-director-ip.address}"
+  value = google_compute_address.bosh-director-ip.address
 }
 
 output "external_ip" {
-  value = "${google_compute_address.jumpbox-ip.address}"
+  value = google_compute_address.jumpbox-ip.address
 }
 
 output "jumpbox__external_ip" {
-  value = "${google_compute_address.jumpbox-ip.address}"
+  value = google_compute_address.jumpbox-ip.address
 }

--- a/plan-patches/byobastion-gcp/terraform/bastion_override.tf
+++ b/plan-patches/byobastion-gcp/terraform/bastion_override.tf
@@ -1,13 +1,13 @@
 variable "existing-bbl-network" {
-  type = "string"
+  type = string
 }
 
 variable "existing-bbl-subnet" {
-  type = "string"
+  type = string
 }
 
 variable "existing-bastion-address" {
-  type = "string"
+  type = string
 }
 
 resource "google_compute_network" "bbl-network" {
@@ -23,23 +23,23 @@ resource "google_compute_address" "jumpbox-ip" {
 }
 
 data "google_compute_network" "bbl-network" {
-  name = "${var.existing-bbl-network}"
+  name = var.existing-bbl-network
 }
 
 data "google_compute_subnetwork" "bbl-subnet" {
-  name = "${var.existing-bbl-subnet}"
+  name = var.existing-bbl-subnet
 }
 
 data "google_compute_address" "jumpbox-ip" {
-  name = "${var.existing-bastion-address}"
+  name = var.existing-bastion-address
 }
 
 resource "google_compute_firewall" "external" {
-  network = "${data.google_compute_network.bbl-network.name}"
+  network = data.google_compute_network.bbl-network.name
 }
 
 resource "google_compute_firewall" "bosh-open" {
-  network       = "${data.google_compute_network.bbl-network.name}"
+  network       = data.google_compute_network.bbl-network.name
   source_ranges = ["${data.google_compute_address.jumpbox-ip.address}/32"]
 
   allow {
@@ -51,31 +51,31 @@ resource "google_compute_firewall" "bosh-open" {
 }
 
 resource "google_compute_firewall" "bosh-director" {
-  network = "${data.google_compute_network.bbl-network.name}"
+  network = data.google_compute_network.bbl-network.name
 }
 
 resource "google_compute_firewall" "internal-to-director" {
-  network = "${data.google_compute_network.bbl-network.name}"
+  network = data.google_compute_network.bbl-network.name
 }
 
 resource "google_compute_firewall" "jumpbox-to-all" {
-  network = "${data.google_compute_network.bbl-network.name}"
+  network = data.google_compute_network.bbl-network.name
 }
 
 resource "google_compute_firewall" "internal" {
-  network = "${data.google_compute_network.bbl-network.name}"
+  network = data.google_compute_network.bbl-network.name
 }
 
 output "network" {
-  value = "${data.google_compute_network.bbl-network.name}"
+  value = data.google_compute_network.bbl-network.name
 }
 
 output "subnetwork" {
-  value = "${data.google_compute_subnetwork.bbl-subnet.name}"
+  value = data.google_compute_subnetwork.bbl-subnet.name
 }
 
 output "jumpbox_url" {
-  value = "${data.google_compute_address.jumpbox-ip.address}"
+  value = data.google_compute_address.jumpbox-ip.address
 }
 
 output "director_address" {
@@ -83,5 +83,5 @@ output "director_address" {
 }
 
 output "external_ip" {
-  value = "${data.google_compute_address.jumpbox-ip.address}"
+  value = data.google_compute_address.jumpbox-ip.address
 }

--- a/plan-patches/byoresource-group-azure/terraform/resource_group_override.tf
+++ b/plan-patches/byoresource-group-azure/terraform/resource_group_override.tf
@@ -1,7 +1,7 @@
 variable "existing_resource_group" {}
 
 data "azurerm_resource_group" "bosh" {
-  name = "${var.existing_resource_group}"
+  name = var.existing_resource_group
 }
 
 resource "azurerm_resource_group" "bosh" {
@@ -9,53 +9,53 @@ resource "azurerm_resource_group" "bosh" {
 }
 
 resource "azurerm_public_ip" "bosh" {
-  resource_group_name = "${data.azurerm_resource_group.bosh.name}"
+  resource_group_name = data.azurerm_resource_group.bosh.name
 }
 
 resource "azurerm_virtual_network" "bosh" {
-  resource_group_name = "${data.azurerm_resource_group.bosh.name}"
+  resource_group_name = data.azurerm_resource_group.bosh.name
 }
 
 resource "azurerm_subnet" "bosh" {
-  resource_group_name = "${data.azurerm_resource_group.bosh.name}"
+  resource_group_name = data.azurerm_resource_group.bosh.name
 }
 
 resource "azurerm_storage_account" "bosh" {
-  resource_group_name = "${data.azurerm_resource_group.bosh.name}"
+  resource_group_name = data.azurerm_resource_group.bosh.name
 }
 
 resource "azurerm_storage_container" "bosh" {
-  resource_group_name = "${data.azurerm_resource_group.bosh.name}"
+  resource_group_name = data.azurerm_resource_group.bosh.name
 }
 
 resource "azurerm_storage_container" "stemcell" {
-  resource_group_name = "${data.azurerm_resource_group.bosh.name}"
+  resource_group_name = data.azurerm_resource_group.bosh.name
 }
 
 resource "azurerm_network_security_group" "bosh" {
-  resource_group_name = "${data.azurerm_resource_group.bosh.name}"
+  resource_group_name = data.azurerm_resource_group.bosh.name
 }
 
 resource "azurerm_network_security_rule" "ssh" {
-  resource_group_name = "${data.azurerm_resource_group.bosh.name}"
+  resource_group_name = data.azurerm_resource_group.bosh.name
 }
 
 resource "azurerm_network_security_rule" "bosh-agent" {
-  resource_group_name = "${data.azurerm_resource_group.bosh.name}"
+  resource_group_name = data.azurerm_resource_group.bosh.name
 }
 
 resource "azurerm_network_security_rule" "bosh-director" {
-  resource_group_name = "${data.azurerm_resource_group.bosh.name}"
+  resource_group_name = data.azurerm_resource_group.bosh.name
 }
 
 resource "azurerm_network_security_rule" "dns" {
-  resource_group_name = "${data.azurerm_resource_group.bosh.name}"
+  resource_group_name = data.azurerm_resource_group.bosh.name
 }
 
 resource "azurerm_network_security_rule" "credhub" {
-  resource_group_name = "${data.azurerm_resource_group.bosh.name}"
+  resource_group_name = data.azurerm_resource_group.bosh.name
 }
 
 output "resource_group_name" {
-  value = "${data.azurerm_resource_group.bosh.name}"
+  value = data.azurerm_resource_group.bosh.name
 }

--- a/plan-patches/cf-azure/terraform/cf_lb_override.tf
+++ b/plan-patches/cf-azure/terraform/cf_lb_override.tf
@@ -1,33 +1,33 @@
 resource "azurerm_public_ip" "cf-balancer-ip" {
   name                         = "${var.env_id}-cf-lb-ip"
-  location                     = "${var.region}"
-  resource_group_name          = "${azurerm_resource_group.bosh.name}"
+  location                     = var.region
+  resource_group_name          = azurerm_resource_group.bosh.name
   public_ip_address_allocation = "static"
   sku                          = "Standard"
 }
 
 resource "azurerm_lb" "cf-balancer" {
   name                = "${var.env_id}-cf-lb"
-  location            = "${var.region}"
+  location            = var.region
   sku                 = "Standard"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
+  resource_group_name = azurerm_resource_group.bosh.name
 
   frontend_ip_configuration {
-    name                 = "${azurerm_public_ip.cf-balancer-ip.name}"
-    public_ip_address_id = "${azurerm_public_ip.cf-balancer-ip.id}"
+    name                 = azurerm_public_ip.cf-balancer-ip.name
+    public_ip_address_id = azurerm_public_ip.cf-balancer-ip.id
   }
 }
 
 resource "azurerm_lb_backend_address_pool" "cf-balancer-backend-pool" {
   name                = "${var.env_id}-cf-backend-pool"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
-  loadbalancer_id     = "${azurerm_lb.cf-balancer.id}"
+  resource_group_name = azurerm_resource_group.bosh.name
+  loadbalancer_id     = azurerm_lb.cf-balancer.id
 }
 
 resource "azurerm_lb_probe" "health-probe" {
   name                = "${var.env_id}-health-probe"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
-  loadbalancer_id     = "${azurerm_lb.cf-balancer.id}"
+  resource_group_name = azurerm_resource_group.bosh.name
+  loadbalancer_id     = azurerm_lb.cf-balancer.id
   protocol            = "HTTP"
   request_path        = "/health"
   interval_in_seconds = 5
@@ -37,24 +37,24 @@ resource "azurerm_lb_probe" "health-probe" {
 
 resource "azurerm_lb_rule" "cf-balancer-rule-https" {
   name                           = "${var.env_id}-https-rule"
-  resource_group_name            = "${azurerm_resource_group.bosh.name}"
-  loadbalancer_id                = "${azurerm_lb.cf-balancer.id}"
+  resource_group_name            = azurerm_resource_group.bosh.name
+  loadbalancer_id                = azurerm_lb.cf-balancer.id
   protocol                       = "Tcp"
   frontend_port                  = 443
   backend_port                   = 443
-  frontend_ip_configuration_name = "${azurerm_public_ip.cf-balancer-ip.name}"
-  probe_id                       = "${azurerm_lb_probe.health-probe.id}"
-  backend_address_pool_id        = "${azurerm_lb_backend_address_pool.cf-balancer-backend-pool.id}"
+  frontend_ip_configuration_name = azurerm_public_ip.cf-balancer-ip.name
+  probe_id                       = azurerm_lb_probe.health-probe.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.cf-balancer-backend-pool.id
 }
 
 resource "azurerm_lb_rule" "cf-balancer-rule-http" {
   name                           = "${var.env_id}-http-rule"
-  resource_group_name            = "${azurerm_resource_group.bosh.name}"
-  loadbalancer_id                = "${azurerm_lb.cf-balancer.id}"
+  resource_group_name            = azurerm_resource_group.bosh.name
+  loadbalancer_id                = azurerm_lb.cf-balancer.id
   protocol                       = "Tcp"
   frontend_port                  = 80
   backend_port                   = 80
-  frontend_ip_configuration_name = "${azurerm_public_ip.cf-balancer-ip.name}"
-  probe_id                       = "${azurerm_lb_probe.health-probe.id}"
-  backend_address_pool_id        = "${azurerm_lb_backend_address_pool.cf-balancer-backend-pool.id}"
+  frontend_ip_configuration_name = azurerm_public_ip.cf-balancer-ip.name
+  probe_id                       = azurerm_lb_probe.health-probe.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.cf-balancer-backend-pool.id
 }

--- a/plan-patches/cf-azure/terraform/cf_outputs_override.tf
+++ b/plan-patches/cf-azure/terraform/cf_outputs_override.tf
@@ -1,17 +1,17 @@
 output "vnet_name" {
-  value = "${azurerm_virtual_network.bosh.name}"
+  value = azurerm_virtual_network.bosh.name
 }
 
 output "cf_internal_gw" {
-  value = "${cidrhost(cidrsubnet(var.network_cidr, 4, 1), 1)}"
+  value = cidrhost(cidrsubnet(var.network_cidr, 4, 1), 1)
 }
 
 output "cf_subnet_cidr" {
-  value = "${cidrsubnet(var.network_cidr, 4, 1)}"
+  value = cidrsubnet(var.network_cidr, 4, 1)
 }
 
 output "cf_subnet" {
-  value = "${azurerm_subnet.cf-subnet.name}"
+  value = azurerm_subnet.cf-subnet.name
 }
 
 output "cf_loadbalancer_name" {
@@ -19,15 +19,15 @@ output "cf_loadbalancer_name" {
 }
 
 output "cf_balancer_pub_ip" {
-  value = "${azurerm_public_ip.cf-balancer-ip.ip_address}"
+  value = azurerm_public_ip.cf-balancer-ip.ip_address
 }
 
 output "cf_security_group" {
-  value = "${azurerm_network_security_group.cf.name}"
+  value = azurerm_network_security_group.cf.name
 }
 
 output "cf_resource_group_name" {
-  value = "${azurerm_resource_group.cf.name}"
+  value = azurerm_resource_group.cf.name
 }
 
 output "network_name" {

--- a/plan-patches/cf-azure/terraform/cf_resource_group_override.tf
+++ b/plan-patches/cf-azure/terraform/cf_resource_group_override.tf
@@ -1,9 +1,9 @@
 
 resource "azurerm_resource_group" "cf" {
   name     = "${var.env_id}-cf"
-  location = "${var.region}"
+  location = var.region
 
-  tags {
-    environment = "${var.env_id}"
+  tags = {
+    environment = var.env_id
   }
 }

--- a/plan-patches/cf-azure/terraform/cf_sg_override.tf
+++ b/plan-patches/cf-azure/terraform/cf_sg_override.tf
@@ -1,8 +1,8 @@
 // Security Group For CF
 resource "azurerm_network_security_group" "cf" {
   name                = "${var.env_id}-cf-sg"
-  location            = "${var.region}"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
+  location            = var.region
+  resource_group_name = azurerm_resource_group.bosh.name
 
   security_rule {
     name                       = "cf-https"

--- a/plan-patches/cf-azure/terraform/cf_storage_account.tf
+++ b/plan-patches/cf-azure/terraform/cf_storage_account.tf
@@ -1,7 +1,7 @@
 
 output "blobstore_storage_account_name" {
-  value="${azurerm_storage_account.bosh.name}"
+  value = azurerm_storage_account.bosh.name
 }
 output "blobstore_storage_access_key" {
-  value="${azurerm_storage_account.bosh.primary_access_key}"
+  value = azurerm_storage_account.bosh.primary_access_key
 }

--- a/plan-patches/cf-azure/terraform/cf_subnet.tf
+++ b/plan-patches/cf-azure/terraform/cf_subnet.tf
@@ -1,7 +1,7 @@
 // Subnet for CFCR
 resource "azurerm_subnet" "cf-subnet" {
   name                 = "${var.env_id}-cf-sn"
-  resource_group_name  = "${azurerm_resource_group.bosh.name}"
-  virtual_network_name = "${azurerm_virtual_network.bosh.name}"
-  address_prefix       = "${cidrsubnet(var.network_cidr, 4, 1)}"
+  resource_group_name  = azurerm_resource_group.bosh.name
+  virtual_network_name = azurerm_virtual_network.bosh.name
+  address_prefix       = cidrsubnet(var.network_cidr, 4, 1)
 }

--- a/plan-patches/cf-lite-azure/terraform/cf_lb_override.tf
+++ b/plan-patches/cf-lite-azure/terraform/cf_lb_override.tf
@@ -1,33 +1,33 @@
 resource "azurerm_public_ip" "cf-balancer-ip" {
   name                         = "${var.env_id}-cf-lb-ip"
-  location                     = "${var.region}"
-  resource_group_name          = "${azurerm_resource_group.bosh.name}"
+  location                     = var.region
+  resource_group_name          = azurerm_resource_group.bosh.name
   public_ip_address_allocation = "static"
   sku                          = "Standard"
 }
 
 resource "azurerm_lb" "cf-balancer" {
   name                = "${var.env_id}-cf-lb"
-  location            = "${var.region}"
+  location            = var.region
   sku                 = "Standard"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
+  resource_group_name = azurerm_resource_group.bosh.name
 
   frontend_ip_configuration {
-    name                 = "${azurerm_public_ip.cf-balancer-ip.name}"
-    public_ip_address_id = "${azurerm_public_ip.cf-balancer-ip.id}"
+    name                 = azurerm_public_ip.cf-balancer-ip.name
+    public_ip_address_id = azurerm_public_ip.cf-balancer-ip.id
   }
 }
 
 resource "azurerm_lb_backend_address_pool" "cf-balancer-backend-pool" {
   name                = "${var.env_id}-cf-backend-pool"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
-  loadbalancer_id     = "${azurerm_lb.cf-balancer.id}"
+  resource_group_name = azurerm_resource_group.bosh.name
+  loadbalancer_id     = azurerm_lb.cf-balancer.id
 }
 
 resource "azurerm_lb_probe" "health-probe" {
   name                = "${var.env_id}-health-probe"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
-  loadbalancer_id     = "${azurerm_lb.cf-balancer.id}"
+  resource_group_name = azurerm_resource_group.bosh.name
+  loadbalancer_id     = azurerm_lb.cf-balancer.id
   protocol            = "HTTP"
   request_path        = "/health"
   interval_in_seconds = 5
@@ -37,24 +37,24 @@ resource "azurerm_lb_probe" "health-probe" {
 
 resource "azurerm_lb_rule" "cf-balancer-rule-https" {
   name                           = "${var.env_id}-https-rule"
-  resource_group_name            = "${azurerm_resource_group.bosh.name}"
-  loadbalancer_id                = "${azurerm_lb.cf-balancer.id}"
+  resource_group_name            = azurerm_resource_group.bosh.name
+  loadbalancer_id                = azurerm_lb.cf-balancer.id
   protocol                       = "Tcp"
   frontend_port                  = 443
   backend_port                   = 443
-  frontend_ip_configuration_name = "${azurerm_public_ip.cf-balancer-ip.name}"
-  probe_id                       = "${azurerm_lb_probe.health-probe.id}"
-  backend_address_pool_id        = "${azurerm_lb_backend_address_pool.cf-balancer-backend-pool.id}"
+  frontend_ip_configuration_name = azurerm_public_ip.cf-balancer-ip.name
+  probe_id                       = azurerm_lb_probe.health-probe.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.cf-balancer-backend-pool.id
 }
 
 resource "azurerm_lb_rule" "cf-balancer-rule-http" {
   name                           = "${var.env_id}-http-rule"
-  resource_group_name            = "${azurerm_resource_group.bosh.name}"
-  loadbalancer_id                = "${azurerm_lb.cf-balancer.id}"
+  resource_group_name            = azurerm_resource_group.bosh.name
+  loadbalancer_id                = azurerm_lb.cf-balancer.id
   protocol                       = "Tcp"
   frontend_port                  = 80
   backend_port                   = 80
-  frontend_ip_configuration_name = "${azurerm_public_ip.cf-balancer-ip.name}"
-  probe_id                       = "${azurerm_lb_probe.health-probe.id}"
-  backend_address_pool_id        = "${azurerm_lb_backend_address_pool.cf-balancer-backend-pool.id}"
+  frontend_ip_configuration_name = azurerm_public_ip.cf-balancer-ip.name
+  probe_id                       = azurerm_lb_probe.health-probe.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.cf-balancer-backend-pool.id
 }

--- a/plan-patches/cf-lite-azure/terraform/cf_outputs_override.tf
+++ b/plan-patches/cf-lite-azure/terraform/cf_outputs_override.tf
@@ -1,17 +1,17 @@
 output "vnet_name" {
-  value = "${azurerm_virtual_network.bosh.name}"
+  value = azurerm_virtual_network.bosh.name
 }
 
 output "cf_internal_gw" {
-  value = "${cidrhost(cidrsubnet(var.network_cidr, 4, 1), 1)}"
+  value = cidrhost(cidrsubnet(var.network_cidr, 4, 1), 1)
 }
 
 output "cf_subnet_cidr" {
-  value = "${cidrsubnet(var.network_cidr, 4, 1)}"
+  value = cidrsubnet(var.network_cidr, 4, 1)
 }
 
 output "cf_subnet" {
-  value = "${azurerm_subnet.cf-subnet.name}"
+  value = azurerm_subnet.cf-subnet.name
 }
 
 output "cf_loadbalancer_name" {
@@ -19,13 +19,13 @@ output "cf_loadbalancer_name" {
 }
 
 output "cf_balancer_pub_ip" {
-  value = "${azurerm_public_ip.cf-balancer-ip.ip_address}"
+  value = azurerm_public_ip.cf-balancer-ip.ip_address
 }
 
 output "cf_security_group" {
-  value = "${azurerm_network_security_group.cf.name}"
+  value = azurerm_network_security_group.cf.name
 }
 
 output "cf_resource_group_name" {
-  value = "${azurerm_resource_group.cf.name}"
+  value = azurerm_resource_group.cf.name
 }

--- a/plan-patches/cf-lite-azure/terraform/cf_resource_group_override.tf
+++ b/plan-patches/cf-lite-azure/terraform/cf_resource_group_override.tf
@@ -1,9 +1,9 @@
 
 resource "azurerm_resource_group" "cf" {
   name     = "${var.env_id}-cf"
-  location = "${var.region}"
+  location = var.region
 
-  tags {
-    environment = "${var.env_id}"
+  tags = {
+    environment = var.env_id
   }
 }

--- a/plan-patches/cf-lite-azure/terraform/cf_sg_override.tf
+++ b/plan-patches/cf-lite-azure/terraform/cf_sg_override.tf
@@ -1,8 +1,8 @@
 // Security Group For CF
 resource "azurerm_network_security_group" "cf" {
   name                = "${var.env_id}-cf-sg"
-  location            = "${var.region}"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
+  location            = var.region
+  resource_group_name = azurerm_resource_group.bosh.name
 
   security_rule {
     name                       = "cf-https"

--- a/plan-patches/cf-lite-azure/terraform/cf_storage_account.tf
+++ b/plan-patches/cf-lite-azure/terraform/cf_storage_account.tf
@@ -1,7 +1,7 @@
 
 output "blobstore_storage_account_name" {
-  value="${azurerm_storage_account.bosh.name}"
+  value = azurerm_storage_account.bosh.name
 }
 output "blobstore_storage_access_key" {
-  value="${azurerm_storage_account.bosh.primary_access_key}"
+  value = azurerm_storage_account.bosh.primary_access_key
 }

--- a/plan-patches/cf-lite-azure/terraform/cf_subnet.tf
+++ b/plan-patches/cf-lite-azure/terraform/cf_subnet.tf
@@ -1,7 +1,7 @@
 // Subnet for CFCR
 resource "azurerm_subnet" "cf-subnet" {
   name                 = "${var.env_id}-cf-sn"
-  resource_group_name  = "${azurerm_resource_group.bosh.name}"
-  virtual_network_name = "${azurerm_virtual_network.bosh.name}"
-  address_prefix       = "${cidrsubnet(var.network_cidr, 4, 1)}"
+  resource_group_name  = azurerm_resource_group.bosh.name
+  virtual_network_name = azurerm_virtual_network.bosh.name
+  address_prefix       = cidrsubnet(var.network_cidr, 4, 1)
 }

--- a/plan-patches/cfcr-aws/terraform/cfcr_dns_override.tf
+++ b/plan-patches/cfcr-aws/terraform/cfcr_dns_override.tf
@@ -1,20 +1,20 @@
 variable "kubernetes_master_host" {
-  type = "string"
+  type = string
 }
 
 resource "aws_route53_zone" "cfcr_dns_zone" {
-  name = "${var.kubernetes_master_host}"
+  name = var.kubernetes_master_host
 
-  tags {
+  tags = {
     Name = "${var.env_id}-cfcr-hosted-zone"
   }
 }
 
 resource "aws_route53_record" "cfcr_api" {
-  zone_id = "${aws_route53_zone.cfcr_dns_zone.id}"
+  zone_id = aws_route53_zone.cfcr_dns_zone.id
   name    = "api.${var.kubernetes_master_host}"
   type    = "CNAME"
   ttl     = 300
 
-  records = ["${aws_elb.cfcr_api.dns_name}"]
+  records = [aws_elb.cfcr_api.dns_name]
 }

--- a/plan-patches/cfcr-aws/terraform/cfcr_iam_override.tf
+++ b/plan-patches/cfcr-aws/terraform/cfcr_iam_override.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_role_policy" "cfcr_master" {
   name = "${var.env_id}-cfcr-master"
-  role = "${aws_iam_role.cfcr_master.id}"
+  role = aws_iam_role.cfcr_master.id
 
   policy = <<EOF
 {
@@ -87,7 +87,7 @@ EOF
 
 resource "aws_iam_instance_profile" "cfcr_master" {
   name = "${var.env_id}-cfcr-master"
-  role = "${aws_iam_role.cfcr_master.name}"
+  role = aws_iam_role.cfcr_master.name
 }
 
 resource "aws_iam_role" "cfcr_master" {
@@ -112,7 +112,7 @@ EOF
 
 resource "aws_iam_role_policy" "cfcr_worker" {
   name = "${var.env_id}-cfcr-worker"
-  role = "${aws_iam_role.cfcr_worker.id}"
+  role = aws_iam_role.cfcr_worker.id
 
   policy = <<EOF
 {
@@ -135,7 +135,7 @@ EOF
 
 resource "aws_iam_instance_profile" "cfcr_worker" {
   name = "${var.env_id}-cfcr-worker"
-  role = "${aws_iam_role.cfcr_worker.name}"
+  role = aws_iam_role.cfcr_worker.name
 }
 
 resource "aws_iam_role" "cfcr_worker" {

--- a/plan-patches/cfcr-aws/terraform/cfcr_lb_override.tf
+++ b/plan-patches/cfcr-aws/terraform/cfcr_lb_override.tf
@@ -3,28 +3,28 @@ resource "random_id" "kubernetes_cluster_tag" {
 }
 
 resource "aws_subnet" "bosh_subnet" {
-  tags {
+  tags = {
     Name              = "${var.env_id}-bosh-subnet"
-    KubernetesCluster = "${random_id.kubernetes_cluster_tag.b64}"
+    KubernetesCluster = random_id.kubernetes_cluster_tag.b64
   }
 }
 
 resource "aws_subnet" "internal_subnets" {
-  tags {
+  tags = {
     Name              = "${var.env_id}-internal-subnet${count.index}"
-    KubernetesCluster = "${random_id.kubernetes_cluster_tag.b64}"
+    KubernetesCluster = random_id.kubernetes_cluster_tag.b64
   }
 }
 
 resource "aws_subnet" "k8s_lb_subnets" {
-  count             = "${length(var.availability_zones)}"
-  vpc_id            = "${local.vpc_id}"
-  cidr_block        = "${cidrsubnet(var.vpc_cidr, 8, count.index+5)}"
-  availability_zone = "${element(var.availability_zones, count.index)}"
+  count             = length(var.availability_zones)
+  vpc_id            = local.vpc_id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index + 5)
+  availability_zone = element(var.availability_zones, count.index)
 
-  tags {
+  tags = {
     Name              = "${var.env_id}-lb-subnet${count.index}"
-    KubernetesCluster = "${random_id.kubernetes_cluster_tag.b64}"
+    KubernetesCluster = random_id.kubernetes_cluster_tag.b64
   }
 
   lifecycle {
@@ -33,24 +33,24 @@ resource "aws_subnet" "k8s_lb_subnets" {
 }
 
 resource "aws_route_table" "lb_route_table" {
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 }
 
 resource "aws_route" "lb_route_table" {
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.ig.id}"
-  route_table_id         = "${aws_route_table.lb_route_table.id}"
+  gateway_id             = aws_internet_gateway.ig.id
+  route_table_id         = aws_route_table.lb_route_table.id
 }
 
 resource "aws_route_table_association" "route_k8s_lb_subnets" {
-  count          = "${length(var.availability_zones)}"
-  subnet_id      = "${element(aws_subnet.k8s_lb_subnets.*.id, count.index)}"
-  route_table_id = "${aws_route_table.lb_route_table.id}"
+  count          = length(var.availability_zones)
+  subnet_id      = element(aws_subnet.k8s_lb_subnets.*.id, count.index)
+  route_table_id = aws_route_table.lb_route_table.id
 }
 
 resource "aws_security_group" "cfcr_api" {
   name   = "${var.short_env_id}-cfcr-api-access"
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 
   ingress {
     from_port   = "8443"
@@ -68,18 +68,18 @@ resource "aws_security_group" "cfcr_api" {
 }
 
 resource "aws_security_group_rule" "cfcr_api_to_internal" {
-  security_group_id        = "${aws_security_group.internal_security_group.id}"
+  security_group_id        = aws_security_group.internal_security_group.id
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 8443
   to_port                  = 8443
-  source_security_group_id = "${aws_security_group.cfcr_api.id}"
+  source_security_group_id = aws_security_group.cfcr_api.id
 }
 
 resource "aws_elb" "cfcr_api" {
   name            = "${var.short_env_id}-cfcr-api"
-  subnets         = ["${aws_subnet.k8s_lb_subnets.*.id}"]
-  security_groups = ["${aws_security_group.cfcr_api.id}"]
+  subnets         = aws_subnet.k8s_lb_subnets.*.id
+  security_groups = [aws_security_group.cfcr_api.id]
 
   listener {
     instance_port     = "8443"

--- a/plan-patches/cfcr-aws/terraform/cfcr_outputs_override.tf
+++ b/plan-patches/cfcr-aws/terraform/cfcr_outputs_override.tf
@@ -1,19 +1,19 @@
 output "kubernetes_cluster_tag" {
-  value = "${random_id.kubernetes_cluster_tag.b64}"
+  value = random_id.kubernetes_cluster_tag.b64
 }
 
 output "cfcr_master_target_pool" {
-   value = "${aws_elb.cfcr_api.name}"
+  value = aws_elb.cfcr_api.name
 }
 
 output "api-hostname" {
-  value = "${aws_elb.cfcr_api.dns_name}"
+  value = aws_elb.cfcr_api.dns_name
 }
 
 output "master_iam_instance_profile" {
-  value = "${aws_iam_instance_profile.cfcr_master.name}"
+  value = aws_iam_instance_profile.cfcr_master.name
 }
 
 output "worker_iam_instance_profile" {
-  value = "${aws_iam_instance_profile.cfcr_worker.name}"
+  value = aws_iam_instance_profile.cfcr_worker.name
 }

--- a/plan-patches/cfcr-azure/terraform/cfcr_lb_override.tf
+++ b/plan-patches/cfcr-azure/terraform/cfcr_lb_override.tf
@@ -1,33 +1,33 @@
 resource "azurerm_public_ip" "cfcr-balancer-ip" {
   name                         = "${var.env_id}-cfcr-lb-ip"
-  location                     = "${var.region}"
-  resource_group_name          = "${azurerm_resource_group.cfcr.name}"
+  location                     = var.region
+  resource_group_name          = azurerm_resource_group.cfcr.name
   public_ip_address_allocation = "static"
   sku                          = "Standard"
 }
 
 resource "azurerm_lb" "cfcr-balancer" {
   name                = "${var.env_id}-cfcr-lb"
-  location            = "${var.region}"
+  location            = var.region
   sku                 = "Standard"
-  resource_group_name = "${azurerm_resource_group.cfcr.name}"
+  resource_group_name = azurerm_resource_group.cfcr.name
 
   frontend_ip_configuration {
-    name                 = "${azurerm_public_ip.cfcr-balancer-ip.name}"
-    public_ip_address_id = "${azurerm_public_ip.cfcr-balancer-ip.id}"
+    name                 = azurerm_public_ip.cfcr-balancer-ip.name
+    public_ip_address_id = azurerm_public_ip.cfcr-balancer-ip.id
   }
 }
 
 resource "azurerm_lb_backend_address_pool" "cfcr-balancer-backend-pool" {
   name                = "${var.env_id}-cfcr-backend-pool"
-  resource_group_name = "${azurerm_resource_group.cfcr.name}"
-  loadbalancer_id     = "${azurerm_lb.cfcr-balancer.id}"
+  resource_group_name = azurerm_resource_group.cfcr.name
+  loadbalancer_id     = azurerm_lb.cfcr-balancer.id
 }
 
 resource "azurerm_lb_probe" "api-health-probe" {
   name                = "${var.env_id}-api-health-probe"
-  resource_group_name = "${azurerm_resource_group.cfcr.name}"
-  loadbalancer_id     = "${azurerm_lb.cfcr-balancer.id}"
+  resource_group_name = azurerm_resource_group.cfcr.name
+  loadbalancer_id     = azurerm_lb.cfcr-balancer.id
   protocol            = "Tcp"
   interval_in_seconds = 5
   number_of_probes    = 2
@@ -36,12 +36,12 @@ resource "azurerm_lb_probe" "api-health-probe" {
 
 resource "azurerm_lb_rule" "cfcr-balancer-api-rule" {
   name                           = "${var.env_id}-api-rule"
-  resource_group_name            = "${azurerm_resource_group.cfcr.name}"
-  loadbalancer_id                = "${azurerm_lb.cfcr-balancer.id}"
+  resource_group_name            = azurerm_resource_group.cfcr.name
+  loadbalancer_id                = azurerm_lb.cfcr-balancer.id
   protocol                       = "Tcp"
   frontend_port                  = 8443
   backend_port                   = 8443
-  frontend_ip_configuration_name = "${azurerm_public_ip.cfcr-balancer-ip.name}"
-  probe_id                       = "${azurerm_lb_probe.api-health-probe.id}"
-  backend_address_pool_id        = "${azurerm_lb_backend_address_pool.cfcr-balancer-backend-pool.id}"
+  frontend_ip_configuration_name = azurerm_public_ip.cfcr-balancer-ip.name
+  probe_id                       = azurerm_lb_probe.api-health-probe.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.cfcr-balancer-backend-pool.id
 }

--- a/plan-patches/cfcr-azure/terraform/cfcr_outputs_override.tf
+++ b/plan-patches/cfcr-azure/terraform/cfcr_outputs_override.tf
@@ -6,67 +6,67 @@ output "cfcr_master_loadbalancer_name" {
 }
 
 output "api-hostname" {
-  value = "${azurerm_public_ip.cfcr-balancer-ip.ip_address}"
+  value = azurerm_public_ip.cfcr-balancer-ip.ip_address
 }
 
 output "vnet_resource_group_name" {
-  value = "${azurerm_resource_group.bosh.name}"
+  value = azurerm_resource_group.bosh.name
 }
 
 // CFCR Subnet
 output "cfcr_subnet" {
-  value = "${azurerm_subnet.cfcr-subnet.name}"
+  value = azurerm_subnet.cfcr-subnet.name
 }
 
 output "cfcr_subnet_cidr" {
-  value = "${cidrsubnet(var.network_cidr, 4, 1)}"
+  value = cidrsubnet(var.network_cidr, 4, 1)
 }
 
 output "cfcr_internal_gw" {
-  value = "${cidrhost(var.cfcr_internal_cidr, 1)}"
+  value = cidrhost(var.cfcr_internal_cidr, 1)
 }
 
 output "cfcr_master_security_group" {
-  value = "${azurerm_network_security_group.cfcr-master.name}"
+  value = azurerm_network_security_group.cfcr-master.name
 }
 
 // Cloud Providers
 output "azure_cloud_name" {
-    value = "AzurePublicCloud"
+  value = "AzurePublicCloud"
 }
 
 output "subscription_id" {
-    value = "${var.subscription_id}"
+  value = var.subscription_id
 }
 
 output "tenant_id" {
-    value = "${var.tenant_id}"
+  value = var.tenant_id
 }
 
 output "client_id" {
-    value = "${var.client_id}"
+  value = var.client_id
 }
 
 output "client_secret" {
-    value = "${var.client_secret}"
+  value = var.client_secret
 }
 
 output "cfcr_resource_group_name" {
-    value = "${azurerm_resource_group.cfcr.name}"
+  value = azurerm_resource_group.cfcr.name
 }
 
 output "cfcr_vnet_resource_group_name" {
-    value = "${azurerm_resource_group.bosh.name}"
+  value = azurerm_resource_group.bosh.name
 }
 
 output "cfcr_vnet_name" {
-    value = "${azurerm_virtual_network.bosh.name}"
+  value = azurerm_virtual_network.bosh.name
 }
 
 output "cfcr_subnet_name" {
-    value = "${azurerm_subnet.cfcr-subnet.name}"
+  value = azurerm_subnet.cfcr-subnet.name
 }
 
 output "primary_availability_set" {
-    value = "bosh-${var.env_id}-azurecfcr-worker"
+  value = "bosh-${var.env_id}-azurecfcr-worker"
 }

--- a/plan-patches/cfcr-azure/terraform/cfcr_resource_group_override.tf
+++ b/plan-patches/cfcr-azure/terraform/cfcr_resource_group_override.tf
@@ -1,9 +1,9 @@
 
 resource "azurerm_resource_group" "cfcr" {
   name     = "${var.env_id}-cfcr"
-  location = "${var.region}"
+  location = var.region
 
-  tags {
-    environment = "${var.env_id}"
+  tags = {
+    environment = var.env_id
   }
 }

--- a/plan-patches/cfcr-azure/terraform/cfcr_sg_override.tf
+++ b/plan-patches/cfcr-azure/terraform/cfcr_sg_override.tf
@@ -2,8 +2,8 @@
 // Security Group For CFCR Nodes
 resource "azurerm_network_security_group" "cfcr-master" {
   name                = "${var.env_id}-cfcr-master-sg"
-  location            = "${var.region}"
-  resource_group_name          = "${azurerm_resource_group.cfcr.name}"
+  location            = var.region
+  resource_group_name = azurerm_resource_group.cfcr.name
 
   security_rule {
     name                       = "master"

--- a/plan-patches/cfcr-azure/terraform/cfcr_subnet.tf
+++ b/plan-patches/cfcr-azure/terraform/cfcr_subnet.tf
@@ -1,8 +1,8 @@
 // Subnet for CFCR
 resource "azurerm_subnet" "cfcr-subnet" {
-  name                 = "${var.env_id}-cfcr-sn"
-  resource_group_name  = "${azurerm_resource_group.bosh.name}"
-  virtual_network_name = "${azurerm_virtual_network.bosh.name}"
-  address_prefix       = "${cidrsubnet(var.network_cidr, 4, 1)}"
-  network_security_group_id = "${azurerm_network_security_group.cfcr-master.id}"
+  name                      = "${var.env_id}-cfcr-sn"
+  resource_group_name       = azurerm_resource_group.bosh.name
+  virtual_network_name      = azurerm_virtual_network.bosh.name
+  address_prefix            = cidrsubnet(var.network_cidr, 4, 1)
+  network_security_group_id = azurerm_network_security_group.cfcr-master.id
 }

--- a/plan-patches/cfcr-gcp/terraform/cfcr_iam_override.tf
+++ b/plan-patches/cfcr-gcp/terraform/cfcr_iam_override.tf
@@ -9,67 +9,67 @@ resource "google_service_account" "worker" {
 }
 
 resource "google_project_iam_member" "storageAdminMaster" {
-  project     = "${var.project_id}"
-  role = "roles/compute.storageAdmin"
-  member = "serviceAccount:${google_service_account.master.email}"
+  project = var.project_id
+  role    = "roles/compute.storageAdmin"
+  member  = "serviceAccount:${google_service_account.master.email}"
 }
 resource "google_project_iam_member" "storageAdminWorker" {
-  project     = "${var.project_id}"
-  role = "roles/compute.storageAdmin"
-  member = "serviceAccount:${google_service_account.worker.email}"
+  project = var.project_id
+  role    = "roles/compute.storageAdmin"
+  member  = "serviceAccount:${google_service_account.worker.email}"
 }
 
 resource "google_project_iam_member" "objectViewerMaster" {
-  project     = "${var.project_id}"
-  role = "roles/storage.objectViewer"
-  member = "serviceAccount:${google_service_account.master.email}"
+  project = var.project_id
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${google_service_account.master.email}"
 }
 resource "google_project_iam_member" "objectViewerWorker" {
-  project     = "${var.project_id}"
-  role = "roles/storage.objectViewer"
-  member = "serviceAccount:${google_service_account.worker.email}"
+  project = var.project_id
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${google_service_account.worker.email}"
 }
 
 resource "google_project_iam_member" "networkAdminMaster" {
-  project     = "${var.project_id}"
-  role = "roles/compute.networkAdmin"
-  member = "serviceAccount:${google_service_account.master.email}"
+  project = var.project_id
+  role    = "roles/compute.networkAdmin"
+  member  = "serviceAccount:${google_service_account.master.email}"
 }
 resource "google_project_iam_member" "networkAdminWorker" {
-  project     = "${var.project_id}"
-  role = "roles/compute.networkAdmin"
-  member = "serviceAccount:${google_service_account.worker.email}"
+  project = var.project_id
+  role    = "roles/compute.networkAdmin"
+  member  = "serviceAccount:${google_service_account.worker.email}"
 }
 
 resource "google_project_iam_member" "securityAdminMaster" {
-  project     = "${var.project_id}"
-  role = "roles/compute.securityAdmin"
-  member = "serviceAccount:${google_service_account.master.email}"
+  project = var.project_id
+  role    = "roles/compute.securityAdmin"
+  member  = "serviceAccount:${google_service_account.master.email}"
 }
 resource "google_project_iam_member" "securityAdminWorker" {
-  project     = "${var.project_id}"
-  role = "roles/compute.securityAdmin"
-  member = "serviceAccount:${google_service_account.worker.email}"
+  project = var.project_id
+  role    = "roles/compute.securityAdmin"
+  member  = "serviceAccount:${google_service_account.worker.email}"
 }
 
 resource "google_project_iam_member" "instanceAdminMaster" {
-  project     = "${var.project_id}"
-  role = "roles/compute.instanceAdmin.v1"
-  member = "serviceAccount:${google_service_account.master.email}"
+  project = var.project_id
+  role    = "roles/compute.instanceAdmin.v1"
+  member  = "serviceAccount:${google_service_account.master.email}"
 }
 resource "google_project_iam_member" "instanceAdminWorker" {
-  project     = "${var.project_id}"
-  role = "roles/compute.instanceAdmin.v1"
-  member = "serviceAccount:${google_service_account.worker.email}"
+  project = var.project_id
+  role    = "roles/compute.instanceAdmin.v1"
+  member  = "serviceAccount:${google_service_account.worker.email}"
 }
 
 resource "google_project_iam_member" "serviceAccountActorMaster" {
-  project     = "${var.project_id}"
-  role = "roles/iam.serviceAccountActor"
-  member = "serviceAccount:${google_service_account.master.email}"
+  project = var.project_id
+  role    = "roles/iam.serviceAccountActor"
+  member  = "serviceAccount:${google_service_account.master.email}"
 }
 resource "google_project_iam_member" "serviceAccountActorWorker" {
-  project     = "${var.project_id}"
-  role = "roles/iam.serviceAccountActor"
-  member = "serviceAccount:${google_service_account.worker.email}"
+  project = var.project_id
+  role    = "roles/iam.serviceAccountActor"
+  member  = "serviceAccount:${google_service_account.worker.email}"
 }

--- a/plan-patches/cfcr-gcp/terraform/cfcr_lb_override.tf
+++ b/plan-patches/cfcr-gcp/terraform/cfcr_lb_override.tf
@@ -3,21 +3,21 @@ resource "google_compute_address" "cfcr_tcp" {
 }
 
 resource "google_compute_target_pool" "cfcr_tcp_public" {
-    region = "${var.region}"
-    name = "${var.env_id}-cfcr-tcp-public"
+  region = var.region
+  name   = "${var.env_id}-cfcr-tcp-public"
 }
 
 resource "google_compute_forwarding_rule" "cfcr_tcp" {
   name        = "${var.env_id}-cfcr-tcp"
-  target      = "${google_compute_target_pool.cfcr_tcp_public.self_link}"
+  target      = google_compute_target_pool.cfcr_tcp_public.self_link
   port_range  = "8443"
   ip_protocol = "TCP"
-  ip_address  = "${google_compute_address.cfcr_tcp.address}"
+  ip_address  = google_compute_address.cfcr_tcp.address
 }
 
 resource "google_compute_firewall" "cfcr_tcp_public" {
   name    = "${var.env_id}-cfcr-tcp-public"
-  network       = "${google_compute_network.bbl-network.name}"
+  network = google_compute_network.bbl-network.name
 
   allow {
     protocol = "tcp"

--- a/plan-patches/cfcr-gcp/terraform/cfcr_outputs_override.tf
+++ b/plan-patches/cfcr-gcp/terraform/cfcr_outputs_override.tf
@@ -1,19 +1,19 @@
 output "cfcr_master_target_pool" {
-  value = "${google_compute_target_pool.cfcr_tcp_public.name}"
+  value = google_compute_target_pool.cfcr_tcp_public.name
 }
 
 output "cfcr_master_service_account_address" {
-  value = "${google_service_account.master.email}"
+  value = google_service_account.master.email
 }
 
 output "cfcr_worker_service_account_address" {
-  value = "${google_service_account.worker.email}"
+  value = google_service_account.worker.email
 }
 
 output "api-hostname" {
-  value = "${google_compute_address.cfcr_tcp.address}"
+  value = google_compute_address.cfcr_tcp.address
 }
 
 output "project_id" {
-  value = "${var.project_id}"
+  value = var.project_id
 }

--- a/plan-patches/cfcr-vsphere/terraform/outputs-override.tf
+++ b/plan-patches/cfcr-vsphere/terraform/outputs-override.tf
@@ -1,8 +1,8 @@
 output "vcenter_master_user" {
-  value = "${var.vcenter_user}"
+  value = var.vcenter_user
 }
 
 output "vcenter_master_password" {
-  value = "${var.vcenter_password}"
+  value = var.vcenter_password
 }
 

--- a/plan-patches/colocate-gorouter-ssh-proxy-gcp/terraform/colocated-gorouter-ssh-proxy_override.tf
+++ b/plan-patches/colocate-gorouter-ssh-proxy-gcp/terraform/colocated-gorouter-ssh-proxy_override.tf
@@ -3,33 +3,33 @@ resource "google_compute_target_pool" "cf-ws-ssh-proxy" {
 
   session_affinity = "NONE"
 
-  health_checks = ["${google_compute_http_health_check.cf-public-health-check.name}"]
+  health_checks = [google_compute_http_health_check.cf-public-health-check.name]
 }
 
 resource "google_compute_forwarding_rule" "cf-ws-https" {
   name        = "${var.env_id}-cf-ws-https"
-  target      = "${google_compute_target_pool.cf-ws-ssh-proxy.self_link}"
+  target      = google_compute_target_pool.cf-ws-ssh-proxy.self_link
   port_range  = "443"
   ip_protocol = "TCP"
-  ip_address  = "${google_compute_address.cf-ws.address}"
+  ip_address  = google_compute_address.cf-ws.address
 }
 
 resource "google_compute_forwarding_rule" "cf-ws-http" {
   name        = "${var.env_id}-cf-ws-http"
-  target      = "${google_compute_target_pool.cf-ws-ssh-proxy.self_link}"
+  target      = google_compute_target_pool.cf-ws-ssh-proxy.self_link
   port_range  = "80"
   ip_protocol = "TCP"
-  ip_address  = "${google_compute_address.cf-ws.address}"
+  ip_address  = google_compute_address.cf-ws.address
 }
 
 resource "google_compute_forwarding_rule" "cf-ssh-proxy" {
   name        = "${var.env_id}-cf-ssh-proxy"
-  target      = "${google_compute_target_pool.cf-ws-ssh-proxy.self_link}"
+  target      = google_compute_target_pool.cf-ws-ssh-proxy.self_link
   port_range  = "2222"
   ip_protocol = "TCP"
-  ip_address  = "${google_compute_address.cf-ssh-proxy.address}"
+  ip_address  = google_compute_address.cf-ssh-proxy.address
 }
 
 output "ws_ssh_proxy_target_pool" {
-  value = "${google_compute_target_pool.cf-ws-ssh-proxy.name}"
+  value = google_compute_target_pool.cf-ws-ssh-proxy.name
 }

--- a/plan-patches/credhub-lb-aws/terraform/credhub_lb.tf
+++ b/plan-patches/credhub-lb-aws/terraform/credhub_lb.tf
@@ -1,10 +1,10 @@
 resource "aws_subnet" "credhub_lb_subnets" {
-  count             = "${length(var.availability_zones)}"
-  vpc_id            = "${local.vpc_id}"
-  cidr_block        = "${cidrsubnet(var.vpc_cidr, 8, count.index+5)}"
-  availability_zone = "${element(var.availability_zones, count.index)}"
+  count             = length(var.availability_zones)
+  vpc_id            = local.vpc_id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index + 5)
+  availability_zone = element(var.availability_zones, count.index)
 
-  tags {
+  tags = {
     Name = "${var.env_id}-lb-subnet${count.index}"
   }
 
@@ -14,39 +14,39 @@ resource "aws_subnet" "credhub_lb_subnets" {
 }
 
 resource "aws_route_table" "credhub_lb_route_table" {
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 }
 
 resource "aws_route" "credhub_lb_route_table" {
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.ig.id}"
-  route_table_id         = "${aws_route_table.credhub_lb_route_table.id}"
+  gateway_id             = aws_internet_gateway.ig.id
+  route_table_id         = aws_route_table.credhub_lb_route_table.id
 }
 
 resource "aws_route_table_association" "route_credhub_lb_subnets" {
-  count          = "${length(var.availability_zones)}"
-  subnet_id      = "${element(aws_subnet.credhub_lb_subnets.*.id, count.index)}"
-  route_table_id = "${aws_route_table.credhub_lb_route_table.id}"
+  count          = length(var.availability_zones)
+  subnet_id      = element(aws_subnet.credhub_lb_subnets.*.id, count.index)
+  route_table_id = aws_route_table.credhub_lb_route_table.id
 }
 
 output "credhub_lb_subnet_ids" {
-  value = ["${aws_subnet.credhub_lb_subnets.*.id}"]
+  value = aws_subnet.credhub_lb_subnets.*.id
 }
 
 output "credhub_lb_subnet_availability_zones" {
-  value = ["${aws_subnet.credhub_lb_subnets.*.availability_zone}"]
+  value = aws_subnet.credhub_lb_subnets.*.availability_zone
 }
 
 output "credhub_lb_subnet_cidrs" {
-  value = ["${aws_subnet.credhub_lb_subnets.*.cidr_block}"]
+  value = aws_subnet.credhub_lb_subnets.*.cidr_block
 }
 
 resource "aws_security_group" "credhub_lb_internal_security_group" {
   name        = "${var.env_id}-credhub-lb-internal-security-group"
   description = "Credhub Internal"
-  vpc_id      = "${local.vpc_id}"
+  vpc_id      = local.vpc_id
 
-  tags {
+  tags = {
     Name = "${var.env_id}-credhub-lb-internal-security-group"
   }
 
@@ -62,7 +62,7 @@ resource "aws_security_group_rule" "credhub_lb_internal_8844" {
   to_port     = 8844
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.credhub_lb_internal_security_group.id}"
+  security_group_id = aws_security_group.credhub_lb_internal_security_group.id
 }
 
 resource "aws_security_group_rule" "credhub_lb_internal_egress" {
@@ -72,27 +72,27 @@ resource "aws_security_group_rule" "credhub_lb_internal_egress" {
   to_port     = 0
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.credhub_lb_internal_security_group.id}"
+  security_group_id = aws_security_group.credhub_lb_internal_security_group.id
 }
 
 output "credhub_lb_internal_security_group" {
-  value = "${aws_security_group.credhub_lb_internal_security_group.name}"
+  value = aws_security_group.credhub_lb_internal_security_group.name
 }
 
 resource "aws_lb" "credhub_lb" {
   name               = "${var.short_env_id}-credhub-lb"
   load_balancer_type = "network"
-  subnets            = ["${aws_subnet.credhub_lb_subnets.*.id}"]
+  subnets            = aws_subnet.credhub_lb_subnets.*.id
 }
 
 resource "aws_lb_listener" "credhub_lb_8844" {
-  load_balancer_arn = "${aws_lb.credhub_lb.arn}"
+  load_balancer_arn = aws_lb.credhub_lb.arn
   protocol          = "TCP"
   port              = 8844
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.credhub_lb_8844.arn}"
+    target_group_arn = aws_lb_target_group.credhub_lb_8844.arn
   }
 }
 
@@ -100,7 +100,7 @@ resource "aws_lb_target_group" "credhub_lb_8844" {
   name     = "${var.short_env_id}-credhub8844"
   port     = 8844
   protocol = "TCP"
-  vpc_id   = "${local.vpc_id}"
+  vpc_id   = local.vpc_id
 
   health_check {
     healthy_threshold   = 10
@@ -111,13 +111,13 @@ resource "aws_lb_target_group" "credhub_lb_8844" {
 }
 
 output "credhub_lb_target_group" {
-  value = ["${aws_lb_target_group.credhub_lb_8844.name}"]
+  value = [aws_lb_target_group.credhub_lb_8844.name]
 }
 
 output "credhub_lb_name" {
-  value = "${aws_lb.credhub_lb.name}"
+  value = aws_lb.credhub_lb.name
 }
 
 output "credhub_lb_url" {
-  value = "${aws_lb.credhub_lb.dns_name}"
+  value = aws_lb.credhub_lb.dns_name
 }

--- a/plan-patches/iso-segs-gcp/terraform/routing-iso-segs.tf
+++ b/plan-patches/iso-segs-gcp/terraform/routing-iso-segs.tf
@@ -1,5 +1,5 @@
 output "iso_router_backend_service" {
-  value = "${google_compute_backend_service.iso-router-lb-backend-service.name}"
+  value = google_compute_backend_service.iso-router-lb-backend-service.name
 }
 
 resource "google_compute_global_address" "iso-cf-address" {
@@ -8,35 +8,35 @@ resource "google_compute_global_address" "iso-cf-address" {
 
 resource "google_compute_global_forwarding_rule" "iso-cf-http-forwarding-rule" {
   name       = "${var.env_id}-iso-cf-http"
-  ip_address = "${google_compute_global_address.iso-cf-address.address}"
-  target     = "${google_compute_target_http_proxy.iso-cf-http-lb-proxy.self_link}"
+  ip_address = google_compute_global_address.iso-cf-address.addresss
+  target     = google_compute_target_http_proxy.iso-cf-http-lb-proxy.self_links
   port_range = "80"
 }
 
 resource "google_compute_global_forwarding_rule" "iso-cf-https-forwarding-rule" {
   name       = "${var.env_id}-iso-cf-https"
-  ip_address = "${google_compute_global_address.iso-cf-address.address}"
-  target     = "${google_compute_target_https_proxy.iso-cf-https-lb-proxy.self_link}"
+  ip_address = google_compute_global_address.iso-cf-address.address
+  target     = google_compute_target_https_proxy.iso-cf-https-lb-proxy.self_link
   port_range = "443"
 }
 
 resource "google_compute_target_http_proxy" "iso-cf-http-lb-proxy" {
   name        = "${var.env_id}-iso-http-proxy"
   description = "really a load balancer but listed as an http proxy"
-  url_map     = "${google_compute_url_map.iso-cf-https-lb-url-map.self_link}"
+  url_map     = google_compute_url_map.iso-cf-https-lb-url-map.self_link
 }
 
 resource "google_compute_target_https_proxy" "iso-cf-https-lb-proxy" {
   name             = "${var.env_id}-iso-https-proxy"
   description      = "really a load balancer but listed as an https proxy"
-  url_map          = "${google_compute_url_map.iso-cf-https-lb-url-map.self_link}"
-  ssl_certificates = ["${google_compute_ssl_certificate.cf-cert.self_link}"]
+  url_map          = google_compute_url_map.iso-cf-https-lb-url-map.self_link
+  ssl_certificates = [google_compute_ssl_certificate.cf-cert.self_link]
 }
 
 resource "google_compute_url_map" "iso-cf-https-lb-url-map" {
   name = "${var.env_id}-iso-cf-http"
 
-  default_service = "${google_compute_backend_service.iso-router-lb-backend-service.self_link}"
+  default_service = google_compute_backend_service.iso-router-lb-backend-service.self_link
 }
 
 resource "google_compute_backend_service" "iso-router-lb-backend-service" {
@@ -47,18 +47,18 @@ resource "google_compute_backend_service" "iso-router-lb-backend-service" {
   enable_cdn  = false
 
   backend {
-    group = "${google_compute_instance_group.iso-router-lb-0.self_link}"
+    group = google_compute_instance_group.iso-router-lb-0.self_link
   }
 
   backend {
-    group = "${google_compute_instance_group.iso-router-lb-1.self_link}"
+    group = google_compute_instance_group.iso-router-lb-1.self_link
   }
 
   backend {
-    group = "${google_compute_instance_group.iso-router-lb-2.self_link}"
+    group = google_compute_instance_group.iso-router-lb-2.self_link
   }
 
-  health_checks = ["${google_compute_health_check.cf-public-health-check.self_link}"]
+  health_checks = [google_compute_health_check.cf-public-health-check.self_link]
 }
 
 resource "google_compute_instance_group" "iso-router-lb-0" {
@@ -95,7 +95,7 @@ resource "google_compute_instance_group" "iso-router-lb-2" {
 }
 
 output "iso_ws_target_pool" {
-  value = "${google_compute_target_pool.iso-cf-ws.name}"
+  value = google_compute_target_pool.iso-cf-ws.name
 }
 
 resource "google_compute_address" "iso-cf-ws" {
@@ -107,40 +107,40 @@ resource "google_compute_target_pool" "iso-cf-ws" {
 
   session_affinity = "NONE"
 
-  health_checks = ["${google_compute_http_health_check.cf-public-health-check.name}"]
+  health_checks = [google_compute_http_health_check.cf-public-health-check.name]
 }
 
 resource "google_compute_forwarding_rule" "iso-cf-ws-https" {
   name        = "${var.env_id}-iso-cf-ws-https"
-  target      = "${google_compute_target_pool.iso-cf-ws.self_link}"
+  target      = google_compute_target_pool.iso-cf-ws.self_link
   port_range  = "443"
   ip_protocol = "TCP"
-  ip_address  = "${google_compute_address.iso-cf-ws.address}"
+  ip_address  = google_compute_address.iso-cf-ws.address
 }
 
 resource "google_compute_forwarding_rule" "cf-iso-ws-http" {
   name        = "${var.env_id}-iso-cf-ws-http"
-  target      = "${google_compute_target_pool.iso-cf-ws.self_link}"
+  target      = google_compute_target_pool.iso-cf-ws.self_link
   port_range  = "80"
   ip_protocol = "TCP"
-  ip_address  = "${google_compute_address.iso-cf-ws.address}"
+  ip_address  = google_compute_address.iso-cf-ws.address
 }
 
 resource "google_dns_record_set" "iso-wildcard-dns" {
   name       = "*.iso-seg.${google_dns_managed_zone.env_dns_zone.dns_name}"
-  depends_on = ["google_compute_global_address.cf-address"]
+  depends_on = [google_compute_global_address.cf-address]
   type       = "A"
   ttl        = 300
 
-  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+  managed_zone = google_dns_managed_zone.env_dns_zone.name
 
-  rrdatas = ["${google_compute_address.iso-cf-ws.address}"]
+  rrdatas = [google_compute_address.iso-cf-ws.address]
 }
 
 resource "google_compute_firewall" "iso-firewall-cf" {
   name       = "${var.env_id}-iso-cf-open"
-  depends_on = ["google_compute_network.bbl-network"]
-  network    = "${google_compute_network.bbl-network.name}"
+  depends_on = [google_compute_network.bbl-network]
+  network    = google_compute_network.bbl-network.name
 
   allow {
     protocol = "tcp"
@@ -149,13 +149,13 @@ resource "google_compute_firewall" "iso-firewall-cf" {
 
   source_ranges = ["0.0.0.0/0"]
 
-  target_tags = ["${google_compute_backend_service.iso-router-lb-backend-service.name}"]
+  target_tags = [google_compute_backend_service.iso-router-lb-backend-service.name]
 }
 
 resource "google_compute_firewall" "iso-cf-health-check" {
   name       = "${var.env_id}-iso-cf-health-check"
-  depends_on = ["google_compute_network.bbl-network"]
-  network    = "${google_compute_network.bbl-network.name}"
+  depends_on = [google_compute_network.bbl-network]
+  network    = google_compute_network.bbl-network.name
 
   allow {
     protocol = "tcp"
@@ -163,5 +163,5 @@ resource "google_compute_firewall" "iso-cf-health-check" {
   }
 
   source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
-  target_tags   = ["${google_compute_backend_service.iso-router-lb-backend-service.name}"]
+  target_tags   = [google_compute_backend_service.iso-router-lb-backend-service.name]
 }

--- a/plan-patches/n-cf-gcp/terraform/cf-dns_override.tf
+++ b/plan-patches/n-cf-gcp/terraform/cf-dns_override.tf
@@ -1,94 +1,94 @@
 resource "random_pet" "environment" {
-  count = "${var.cf_env_count}"
+  count = var.cf_env_count
 }
 
 resource "google_dns_record_set" "wildcard-dns" {
   name       = "*.cf${count.index}.${google_dns_managed_zone.env_dns_zone.dns_name}"
-  depends_on = ["google_compute_global_address.cf-address"]
+  depends_on = [google_compute_global_address.cf-address]
   type       = "A"
   ttl        = 300
 
-  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+  managed_zone = google_dns_managed_zone.env_dns_zone.name
 
-  rrdatas = ["${element(google_compute_global_address.cf-address.*.address, count.index)}"]
+  rrdatas = [element(google_compute_global_address.cf-address.*.address, count.index)]
 
-  count = "${var.cf_env_count}"
+  count = var.cf_env_count
 }
 
 resource "google_dns_record_set" "bosh-dns" {
   name       = "bosh.cf${count.index}.${google_dns_managed_zone.env_dns_zone.dns_name}"
-  depends_on = ["google_compute_address.jumpbox-ip"]
+  depends_on = [google_compute_address.jumpbox-ip]
   type       = "A"
   ttl        = 300
 
-  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+  managed_zone = google_dns_managed_zone.env_dns_zone.name
 
-  rrdatas = ["${element(google_compute_address.jumpbox-ip.*.address, count.index)}"]
+  rrdatas = [element(google_compute_address.jumpbox-ip.*.address, count.index)]
 
-  count = "${var.cf_env_count}"
+  count = var.cf_env_count
 }
 
 resource "google_dns_record_set" "cf-ssh-proxy" {
   name       = "ssh.cf${count.index}.${google_dns_managed_zone.env_dns_zone.dns_name}"
-  depends_on = ["google_compute_address.cf-ssh-proxy"]
+  depends_on = [google_compute_address.cf-ssh-proxy]
   type       = "A"
   ttl        = 300
 
-  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+  managed_zone = google_dns_managed_zone.env_dns_zone.name
 
-  rrdatas = ["${element(google_compute_address.cf-ssh-proxy.*.address, count.index)}"]
+  rrdatas = [element(google_compute_address.cf-ssh-proxy.*.address, count.index)]
 
-  count = "${var.cf_env_count}"
+  count = var.cf_env_count
 }
 
 resource "google_dns_record_set" "tcp-dns" {
   name       = "tcp.cf${count.index}.${google_dns_managed_zone.env_dns_zone.dns_name}"
-  depends_on = ["google_compute_address.cf-tcp-router"]
+  depends_on = [google_compute_address.cf-tcp-router]
   type       = "A"
   ttl        = 300
 
-  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+  managed_zone = google_dns_managed_zone.env_dns_zone.name
 
-  rrdatas = ["${element(google_compute_address.cf-tcp-router.*.address, count.index)}"]
+  rrdatas = [element(google_compute_address.cf-tcp-router.*.address, count.index)]
 
-  count = "${var.cf_env_count}"
+  count = var.cf_env_count
 }
 
 resource "google_dns_record_set" "doppler-dns" {
   name       = "doppler.cf${count.index}.${google_dns_managed_zone.env_dns_zone.dns_name}"
-  depends_on = ["google_compute_address.cf-ws"]
+  depends_on = [google_compute_address.cf-ws]
   type       = "A"
   ttl        = 300
 
-  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+  managed_zone = google_dns_managed_zone.env_dns_zone.name
 
-  rrdatas = ["${element(google_compute_address.cf-ws.*.address, count.index)}"]
+  rrdatas = [element(google_compute_address.cf-ws.*.address, count.index)]
 
-  count = "${var.cf_env_count}"
+  count = var.cf_env_count
 }
 
 resource "google_dns_record_set" "loggregator-dns" {
   name       = "loggregator.cf${count.index}.${google_dns_managed_zone.env_dns_zone.dns_name}"
-  depends_on = ["google_compute_address.cf-ws"]
+  depends_on = [google_compute_address.cf-ws]
   type       = "A"
   ttl        = 300
 
-  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+  managed_zone = google_dns_managed_zone.env_dns_zone.name
 
-  rrdatas = ["${element(google_compute_address.cf-ws.*.address, count.index)}"]
+  rrdatas = [element(google_compute_address.cf-ws.*.address, count.index)]
 
-  count = "${var.cf_env_count}"
+  count = var.cf_env_count
 }
 
 resource "google_dns_record_set" "wildcard-ws-dns" {
   name       = "*.ws.cf${count.index}.${google_dns_managed_zone.env_dns_zone.dns_name}"
-  depends_on = ["google_compute_address.cf-ws"]
+  depends_on = [google_compute_address.cf-ws]
   type       = "A"
   ttl        = 300
 
-  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+  managed_zone = google_dns_managed_zone.env_dns_zone.name
 
-  rrdatas = ["${element(google_compute_address.cf-ws.*.address, count.index)}"]
+  rrdatas = [element(google_compute_address.cf-ws.*.address, count.index)]
 
-  count = "${var.cf_env_count}"
+  count = var.cf_env_count
 }

--- a/plan-patches/nat-aws/terraform/nat_override.tf
+++ b/plan-patches/nat-aws/terraform/nat_override.tf
@@ -7,17 +7,17 @@ resource "aws_eip" "nat_eip" {
 }
 
 resource "aws_nat_gateway" "nat" {
-  allocation_id = "${aws_eip.nat_eip.id}"
-  subnet_id     = "${aws_subnet.bosh_subnet.id}"
-  depends_on    = ["aws_internet_gateway.ig"]
+  allocation_id = aws_eip.nat_eip.id
+  subnet_id     = aws_subnet.bosh_subnet.id
+  depends_on    = [aws_internet_gateway.ig]
 
-  tags {
+  tags = {
     Name  = "${var.env_id}-nat"
-    EnvID = "${var.env_id}"
+    EnvID = var.env_id
   }
 }
 
 resource "aws_route" "internal_route_table" {
   instance_id    = ""
-  nat_gateway_id = "${aws_nat_gateway.nat.id}"
+  nat_gateway_id = aws_nat_gateway.nat.id
 }

--- a/plan-patches/nat-per-az/terraform/nat-per-az_override.tf
+++ b/plan-patches/nat-per-az/terraform/nat-per-az_override.tf
@@ -1,90 +1,90 @@
 resource "aws_subnet" "nat_subnet" {
-  count             = "${length(var.availability_zones)}"
+  count = length(var.availability_zones)
 
-  vpc_id            = "${local.vpc_id}"
-  cidr_block        = "${cidrsubnet(var.vpc_cidr, 12, count.index + 16)}"
-  availability_zone = "${element(var.availability_zones, count.index)}"
+  vpc_id            = local.vpc_id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 12, count.index + 16)
+  availability_zone = element(var.availability_zones, count.index)
 
-  tags {
+  tags = {
     Name = "${var.env_id}-nat-subnet"
   }
 }
 
 resource "aws_route_table" "nat_route_table" {
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 
-  tags {
+  tags = {
     Name = "${var.env_id}-nat-rtb"
   }
 }
 
 resource "aws_route" "nat_route" {
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.ig.id}"
-  route_table_id         = "${aws_route_table.nat_route_table.id}"
+  gateway_id             = aws_internet_gateway.ig.id
+  route_table_id         = aws_route_table.nat_route_table.id
 }
 
 resource "aws_route_table_association" "route_nat_subnets" {
-  count          = "${length(var.availability_zones)}"
+  count = length(var.availability_zones)
 
-  subnet_id      = "${element(aws_subnet.nat_subnet.*.id, count.index)}"
-  route_table_id = "${element(aws_route_table.nat_route_table.*.id, count.index)}"
+  subnet_id      = element(aws_subnet.nat_subnet.*.id, count.index)
+  route_table_id = element(aws_route_table.nat_route_table.*.id, count.index)
 }
 
 resource "aws_instance" "nat" {
-  count                  = "${length(var.availability_zones)}"
+  count = length(var.availability_zones)
 
-  private_ip             = "${cidrhost(element(aws_subnet.nat_subnet.*.cidr_block, count.index), 7)}"
+  private_ip             = cidrhost(element(aws_subnet.nat_subnet.*.cidr_block, count.index), 7)
   instance_type          = "t2.medium"
-  subnet_id              = "${element(aws_subnet.nat_subnet.*.id, count.index)}"
+  subnet_id              = element(aws_subnet.nat_subnet.*.id, count.index)
   source_dest_check      = false
-  ami                    = "${lookup(var.nat_ami_map, var.region)}"
-  vpc_security_group_ids = ["${aws_security_group.nat_security_group.id}"]
+  ami                    = lookup(var.nat_ami_map, var.region)
+  vpc_security_group_ids = [aws_security_group.nat_security_group.id]
 
-  tags {
+  tags = {
     Name  = "${var.env_id}-nat"
-    EnvID = "${var.env_id}"
+    EnvID = var.env_id
   }
 }
 
 resource "aws_eip" "nat_eip" {
-  count      = "${length(var.availability_zones)}"
+  count = length(var.availability_zones)
 
-  depends_on = ["aws_internet_gateway.ig"]
-  instance   = "${element(aws_instance.nat.*.id, count.index)}"
+  depends_on = [aws_internet_gateway.ig]
+  instance   = element(aws_instance.nat.*.id, count.index)
   vpc        = true
 
-  tags {
+  tags = {
     Name  = "${var.env_id}-nat_eip-${count.index}"
     EnvID = "${var.env_id}"
   }
 }
 
 resource "aws_route_table" "internal_route_table" {
-  count = "${length(var.availability_zones)}"
+  count = length(var.availability_zones)
 
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 
-  tags {
+  tags = {
     Name = "${var.env_id}-private-rtb-${count.index}"
   }
 }
 
 resource "aws_route" "internal_route_table" {
-  count = "${length(var.availability_zones)}"
+  count = length(var.availability_zones)
 
   destination_cidr_block = "0.0.0.0/0"
-  instance_id            = "${element(aws_instance.nat.*.id, count.index)}"
-  route_table_id         = "${element(aws_route_table.internal_route_table.*.id, count.index)}"
+  instance_id            = element(aws_instance.nat.*.id, count.index)
+  route_table_id         = element(aws_route_table.internal_route_table.*.id, count.index)
 }
 
 resource "aws_route_table_association" "route_internal_subnets" {
-  count          = "${length(var.availability_zones)}"
+  count = length(var.availability_zones)
 
-  subnet_id      = "${element(aws_subnet.internal_subnets.*.id, count.index)}"
-  route_table_id = "${element(aws_route_table.internal_route_table.*.id, count.index)}"
+  subnet_id      = element(aws_subnet.internal_subnets.*.id, count.index)
+  route_table_id = element(aws_route_table.internal_route_table.*.id, count.index)
 }
 
 output "nat_eip" {
-  value = "${aws_eip.nat_eip.*.public_ip}"
+  value = aws_eip.nat_eip.*.public_ip
 }

--- a/plan-patches/network-lb-gcp/terraform/network_lb_override.tf
+++ b/plan-patches/network-lb-gcp/terraform/network_lb_override.tf
@@ -12,8 +12,8 @@ resource "google_compute_global_forwarding_rule" "cf-http-forwarding-rule" {
 
 resource "google_compute_forwarding_rule" "cf-http-forwarding-rule" {
   name        = "${var.env_id}-cf-http"
-  ip_address  = "${google_compute_address.cf-address.address}"
-  target      = "${google_compute_target_pool.router-lb-target-pool.self_link}"
+  ip_address  = google_compute_address.cf-address.address
+  target      = google_compute_target_pool.router-lb-target-pool.self_link
   port_range  = "80"
   ip_protocol = "TCP"
 }
@@ -24,8 +24,8 @@ resource "google_compute_global_forwarding_rule" "cf-https-forwarding-rule" {
 
 resource "google_compute_forwarding_rule" "cf-https-forwarding-rule" {
   name        = "${var.env_id}-cf-https"
-  ip_address  = "${google_compute_address.cf-address.address}"
-  target      = "${google_compute_target_pool.router-lb-target-pool.self_link}"
+  ip_address  = google_compute_address.cf-address.address
+  target      = google_compute_target_pool.router-lb-target-pool.self_link
   port_range  = "443"
   ip_protocol = "TCP"
 }
@@ -58,14 +58,14 @@ resource "google_compute_target_pool" "router-lb-target-pool" {
   name = "${var.env_id}-router-lb"
 
   health_checks = [
-    "${google_compute_http_health_check.cf-public-health-check.name}",
+    google_compute_http_health_check.cf-public-health-check.name,
   ]
 }
 
 resource "google_compute_firewall" "cf-health-check" {
   name       = "${var.env_id}-cf-health-check"
-  depends_on = ["google_compute_network.bbl-network"]
-  network    = "${google_compute_network.bbl-network.name}"
+  depends_on = [google_compute_network.bbl-network]
+  network    = google_compute_network.bbl-network.name
 
   allow {
     protocol = "tcp"
@@ -73,13 +73,13 @@ resource "google_compute_firewall" "cf-health-check" {
   }
 
   source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
-  target_tags   = ["${google_compute_target_pool.router-lb-target-pool.name}"]
+  target_tags   = [google_compute_target_pool.router-lb-target-pool.name]
 }
 
 resource "google_compute_firewall" "firewall-cf" {
   name       = "${var.env_id}-cf-open"
-  depends_on = ["google_compute_network.bbl-network"]
-  network    = "${google_compute_network.bbl-network.name}"
+  depends_on = [google_compute_network.bbl-network]
+  network    = google_compute_network.bbl-network.name
 
   allow {
     protocol = "tcp"
@@ -88,18 +88,18 @@ resource "google_compute_firewall" "firewall-cf" {
 
   source_ranges = ["0.0.0.0/0"]
 
-  target_tags = ["${google_compute_target_pool.router-lb-target-pool.name}"]
+  target_tags = [google_compute_target_pool.router-lb-target-pool.name]
 }
 
 resource "google_dns_record_set" "wildcard-dns" {
   name       = "*.${google_dns_managed_zone.env_dns_zone.dns_name}"
-  depends_on = ["google_compute_address.cf-address"]
+  depends_on = [google_compute_address.cf-address]
   type       = "A"
   ttl        = 300
 
-  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+  managed_zone = google_dns_managed_zone.env_dns_zone.name
 
-  rrdatas = ["${google_compute_address.cf-address.address}"]
+  rrdatas = [google_compute_address.cf-address.address]
 }
 
 # Should always be empty, added to avoid a terraform warning
@@ -108,11 +108,11 @@ output "router_backend_service" {
 }
 
 output "router_target_pool" {
-  value = "${google_compute_target_pool.router-lb-target-pool.name}"
+  value = google_compute_target_pool.router-lb-target-pool.name
 }
 
 output "router_lb_ip" {
-  value = "${google_compute_address.cf-address.address}"
+  value = google_compute_address.cf-address.address
 }
 
 output "ws_lb_ip" {

--- a/plan-patches/openvpn-aws/terraform/openvpn_override.tf
+++ b/plan-patches/openvpn-aws/terraform/openvpn_override.tf
@@ -1,9 +1,9 @@
 resource "aws_subnet" "openvpn_subnet" {
-  vpc_id            = "${local.vpc_id}"
-  cidr_block        = "${cidrsubnet(var.vpc_cidr, 8, 144)}"
-  availability_zone = "${element(var.availability_zones, 0)}"
+  vpc_id            = local.vpc_id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, 144)
+  availability_zone = element(var.availability_zones, 0)
 
-  tags {
+  tags = {
     Name = "${var.env_id}-openvpn-subnet"
   }
 
@@ -13,26 +13,26 @@ resource "aws_subnet" "openvpn_subnet" {
 }
 
 resource "aws_route_table" "openvpn_route_table" {
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 }
 
 resource "aws_route" "openvpn_route" {
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.ig.id}"
-  route_table_id         = "${aws_route_table.openvpn_route_table.id}"
+  gateway_id             = aws_internet_gateway.ig.id
+  route_table_id         = aws_route_table.openvpn_route_table.id
 }
 
 resource "aws_route_table_association" "openvpn_route_table_association" {
-  subnet_id      = "${aws_subnet.openvpn_subnet.id}"
-  route_table_id = "${aws_route_table.openvpn_route_table.id}"
+  subnet_id      = aws_subnet.openvpn_subnet.id
+  route_table_id = aws_route_table.openvpn_route_table.id
 }
 
 resource "aws_security_group" "openvpn_security_group" {
   name        = "${var.env_id}-openvpn-security-group"
   description = "OpenVPN"
-  vpc_id      = "${local.vpc_id}"
+  vpc_id      = local.vpc_id
 
-  tags {
+  tags = {
     Name = "${var.env_id}-openvpn-security-group"
   }
 
@@ -42,7 +42,7 @@ resource "aws_security_group" "openvpn_security_group" {
 }
 
 resource "aws_security_group_rule" "openvpn_security_group_rule_tcp" {
-  security_group_id = "${aws_security_group.openvpn_security_group.id}"
+  security_group_id = aws_security_group.openvpn_security_group.id
   type              = "ingress"
   protocol          = "tcp"
   from_port         = 0
@@ -51,7 +51,7 @@ resource "aws_security_group_rule" "openvpn_security_group_rule_tcp" {
 }
 
 resource "aws_security_group_rule" "openvpn_security_group_rule_udp" {
-  security_group_id = "${aws_security_group.openvpn_security_group.id}"
+  security_group_id = aws_security_group.openvpn_security_group.id
   type              = "ingress"
   protocol          = "udp"
   from_port         = 0
@@ -60,7 +60,7 @@ resource "aws_security_group_rule" "openvpn_security_group_rule_udp" {
 }
 
 resource "aws_security_group_rule" "openvpn_security_group_rule_icmp" {
-  security_group_id = "${aws_security_group.openvpn_security_group.id}"
+  security_group_id = aws_security_group.openvpn_security_group.id
   type              = "ingress"
   protocol          = "icmp"
   from_port         = -1
@@ -69,7 +69,7 @@ resource "aws_security_group_rule" "openvpn_security_group_rule_icmp" {
 }
 
 resource "aws_security_group_rule" "openvpn_security_group_rule_openvpn" {
-  security_group_id = "${aws_security_group.openvpn_security_group.id}"
+  security_group_id = aws_security_group.openvpn_security_group.id
   type              = "ingress"
   protocol          = "TCP"
   from_port         = 1194
@@ -78,7 +78,7 @@ resource "aws_security_group_rule" "openvpn_security_group_rule_openvpn" {
 }
 
 resource "aws_security_group_rule" "openvpn_security_group_rule_allow_internet" {
-  security_group_id = "${aws_security_group.openvpn_security_group.id}"
+  security_group_id = aws_security_group.openvpn_security_group.id
   type              = "egress"
   protocol          = "-1"
   from_port         = 0
@@ -87,48 +87,48 @@ resource "aws_security_group_rule" "openvpn_security_group_rule_allow_internet" 
 }
 
 resource "aws_security_group_rule" "openvpn_security_group_rule_ssh" {
-  security_group_id        = "${aws_security_group.openvpn_security_group.id}"
+  security_group_id        = aws_security_group.openvpn_security_group.id
   type                     = "ingress"
   protocol                 = "TCP"
   from_port                = 22
   to_port                  = 22
-  source_security_group_id = "${aws_security_group.jumpbox.id}"
+  source_security_group_id = aws_security_group.jumpbox.id
 }
 
 resource "aws_security_group_rule" "bosh_openvpn_security_group_rule_tcp" {
-  security_group_id        = "${aws_security_group.openvpn_security_group.id}"
+  security_group_id        = aws_security_group.openvpn_security_group.id
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 0
   to_port                  = 65535
-  source_security_group_id = "${aws_security_group.bosh_security_group.id}"
+  source_security_group_id = aws_security_group.bosh_security_group.id
 }
 
 resource "aws_security_group_rule" "bosh_openvpn_security_group_rule_udp" {
-  security_group_id        = "${aws_security_group.openvpn_security_group.id}"
+  security_group_id        = aws_security_group.openvpn_security_group.id
   type                     = "ingress"
   protocol                 = "udp"
   from_port                = 0
   to_port                  = 65535
-  source_security_group_id = "${aws_security_group.bosh_security_group.id}"
+  source_security_group_id = aws_security_group.bosh_security_group.id
 }
 
 resource "aws_security_group_rule" "openvpn_bosh_security_group_rule_tcp" {
-  security_group_id        = "${aws_security_group.bosh_security_group.id}"
+  security_group_id        = aws_security_group.bosh_security_group.id
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 0
   to_port                  = 65535
-  source_security_group_id = "${aws_security_group.openvpn_security_group.id}"
+  source_security_group_id = aws_security_group.openvpn_security_group.id
 }
 
 resource "aws_security_group_rule" "openvpn_bosh_security_group_rule_udp" {
-  security_group_id        = "${aws_security_group.bosh_security_group.id}"
+  security_group_id        = aws_security_group.bosh_security_group.id
   type                     = "ingress"
   protocol                 = "udp"
   from_port                = 0
   to_port                  = 65535
-  source_security_group_id = "${aws_security_group.openvpn_security_group.id}"
+  source_security_group_id = aws_security_group.openvpn_security_group.id
 }
 
 resource "aws_eip" "openvpn_eip" {
@@ -136,17 +136,17 @@ resource "aws_eip" "openvpn_eip" {
 }
 
 output "openvpn_ip" {
-  value = "${aws_eip.openvpn_eip.public_ip}"
+  value = aws_eip.openvpn_eip.public_ip
 }
 
 output "openvpn_security_group" {
-  value = "${aws_security_group.openvpn_security_group.id}"
+  value = aws_security_group.openvpn_security_group.id
 }
 
 output "openvpn_subnet_cidr" {
-  value = "${aws_subnet.openvpn_subnet.cidr_block}"
+  value = aws_subnet.openvpn_subnet.cidr_block
 }
 
 output "openvpn_subnet_id" {
-  value = "${aws_subnet.openvpn_subnet.id}"
+  value = aws_subnet.openvpn_subnet.id
 }

--- a/plan-patches/prometheus-lb-aws/terraform/prometheus_lb.tf
+++ b/plan-patches/prometheus-lb-aws/terraform/prometheus_lb.tf
@@ -1,10 +1,10 @@
 resource "aws_subnet" "prom_lb_subnets" {
-  count             = "${length(var.availability_zones)}"
-  vpc_id            = "${local.vpc_id}"
-  cidr_block        = "${cidrsubnet(var.vpc_cidr, 8, count.index+5)}"
-  availability_zone = "${element(var.availability_zones, count.index)}"
+  count             = length(var.availability_zones)
+  vpc_id            = local.vpc_id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index + 5)
+  availability_zone = element(var.availability_zones, count.index)
 
-  tags {
+  tags = {
     Name = "${var.env_id}-lb-subnet${count.index}"
   }
 
@@ -14,39 +14,39 @@ resource "aws_subnet" "prom_lb_subnets" {
 }
 
 resource "aws_route_table" "prom_lb_route_table" {
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 }
 
 resource "aws_route" "prom_lb_route_table" {
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.ig.id}"
-  route_table_id         = "${aws_route_table.prom_lb_route_table.id}"
+  gateway_id             = aws_internet_gateway.ig.id
+  route_table_id         = aws_route_table.prom_lb_route_table.id
 }
 
 resource "aws_route_table_association" "route_prom_lb_subnets" {
-  count          = "${length(var.availability_zones)}"
-  subnet_id      = "${element(aws_subnet.prom_lb_subnets.*.id, count.index)}"
-  route_table_id = "${aws_route_table.prom_lb_route_table.id}"
+  count          = length(var.availability_zones)
+  subnet_id      = element(aws_subnet.prom_lb_subnets.*.id, count.index)
+  route_table_id = aws_route_table.prom_lb_route_table.id
 }
 
 output "prom_lb_subnet_ids" {
-  value = ["${aws_subnet.prom_lb_subnets.*.id}"]
+  value = aws_subnet.prom_lb_subnets.*.id
 }
 
 output "prom_lb_subnet_availability_zones" {
-  value = ["${aws_subnet.prom_lb_subnets.*.availability_zone}"]
+  value = aws_subnet.prom_lb_subnets.*.availability_zone
 }
 
 output "prom_lb_subnet_cidrs" {
-  value = ["${aws_subnet.prom_lb_subnets.*.cidr_block}"]
+  value = aws_subnet.prom_lb_subnets.*.cidr_block
 }
 
 resource "aws_security_group" "prometheus_lb_internal_security_group" {
   name        = "${var.env_id}-prometheus-lb-internal-security-group"
   description = "Prometheus Internal"
-  vpc_id      = "${local.vpc_id}"
+  vpc_id      = local.vpc_id
 
-  tags {
+  tags = {
     Name = "${var.env_id}-prometheus-lb-internal-security-group"
   }
 
@@ -62,7 +62,7 @@ resource "aws_security_group_rule" "prometheus_lb_internal_3000" {
   to_port     = 3000
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.prometheus_lb_internal_security_group.id}"
+  security_group_id = aws_security_group.prometheus_lb_internal_security_group.id
 }
 
 resource "aws_security_group_rule" "prometheus_lb_internal_9090" {
@@ -72,7 +72,7 @@ resource "aws_security_group_rule" "prometheus_lb_internal_9090" {
   to_port     = 9090
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.prometheus_lb_internal_security_group.id}"
+  security_group_id = aws_security_group.prometheus_lb_internal_security_group.id
 }
 
 resource "aws_security_group_rule" "prometheus_lb_internal_9093" {
@@ -82,7 +82,7 @@ resource "aws_security_group_rule" "prometheus_lb_internal_9093" {
   to_port     = 9093
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.prometheus_lb_internal_security_group.id}"
+  security_group_id = aws_security_group.prometheus_lb_internal_security_group.id
 }
 
 resource "aws_security_group_rule" "prometheus_lb_internal_egress" {
@@ -92,23 +92,23 @@ resource "aws_security_group_rule" "prometheus_lb_internal_egress" {
   to_port     = 0
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.prometheus_lb_internal_security_group.id}"
+  security_group_id = aws_security_group.prometheus_lb_internal_security_group.id
 }
 
 resource "aws_lb" "prometheus_lb" {
   name               = "${var.short_env_id}-prometheus-lb"
   load_balancer_type = "network"
-  subnets            = ["${aws_subnet.prom_lb_subnets.*.id}"]
+  subnets            = aws_subnet.prom_lb_subnets.*.id
 }
 
 resource "aws_lb_listener" "prometheus_lb_3000" {
-  load_balancer_arn = "${aws_lb.prometheus_lb.arn}"
+  load_balancer_arn = aws_lb.prometheus_lb.arn
   protocol          = "TCP"
   port              = 3000
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.prometheus_lb_3000.arn}"
+    target_group_arn = aws_lb_target_group.prometheus_lb_3000.arn
   }
 }
 
@@ -116,7 +116,7 @@ resource "aws_lb_target_group" "prometheus_lb_3000" {
   name     = "${var.short_env_id}-prometheus3000"
   port     = 3000
   protocol = "TCP"
-  vpc_id   = "${local.vpc_id}"
+  vpc_id   = local.vpc_id
 
   health_check {
     healthy_threshold   = 10
@@ -127,24 +127,24 @@ resource "aws_lb_target_group" "prometheus_lb_3000" {
 }
 
 resource "aws_lb_listener" "prometheus_lb_9090" {
-  load_balancer_arn = "${aws_lb.prometheus_lb.arn}"
+  load_balancer_arn = aws_lb.prometheus_lb.arn
   protocol          = "TCP"
   port              = 9090
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.prometheus_lb_9090.arn}"
+    target_group_arn = aws_lb_target_group.prometheus_lb_9090.arn
   }
 }
 
 resource "aws_lb_listener" "prometheus_lb_9093" {
-  load_balancer_arn = "${aws_lb.prometheus_lb.arn}"
+  load_balancer_arn = aws_lb.prometheus_lb.arn
   protocol          = "TCP"
   port              = 9093
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.prometheus_lb_9093.arn}"
+    target_group_arn = aws_lb_target_group.prometheus_lb_9093.arn
   }
 }
 
@@ -152,28 +152,28 @@ resource "aws_lb_target_group" "prometheus_lb_9090" {
   name     = "${var.short_env_id}-prometheus9090"
   port     = 9090
   protocol = "TCP"
-  vpc_id   = "${local.vpc_id}"
+  vpc_id   = local.vpc_id
 }
 
 resource "aws_lb_target_group" "prometheus_lb_9093" {
   name     = "${var.short_env_id}-prometheus9093"
   port     = 9093
   protocol = "TCP"
-  vpc_id   = "${local.vpc_id}"
+  vpc_id   = local.vpc_id
 }
 
 output "prometheus_lb_internal_security_group" {
-  value = "${aws_security_group.prometheus_lb_internal_security_group.name}"
+  value = aws_security_group.prometheus_lb_internal_security_group.name
 }
 
 output "prometheus_lb_target_groups" {
-  value = ["${aws_lb_target_group.prometheus_lb_3000.name}", "${aws_lb_target_group.prometheus_lb_9090.name}", "${aws_lb_target_group.prometheus_lb_9093.name}"]
+  value = [aws_lb_target_group.prometheus_lb_3000.name, aws_lb_target_group.prometheus_lb_9090.name, aws_lb_target_group.prometheus_lb_9093.name]
 }
 
 output "prometheus_lb_name" {
-  value = "${aws_lb.prometheus_lb.name}"
+  value = aws_lb.prometheus_lb.name
 }
 
 output "prometheus_lb_url" {
-  value = "${aws_lb.prometheus_lb.dns_name}"
+  value = aws_lb.prometheus_lb.dns_name
 }

--- a/plan-patches/prometheus-lb-gcp/terraform/prometheus-lb.tf
+++ b/plan-patches/prometheus-lb-gcp/terraform/prometheus-lb.tf
@@ -1,14 +1,14 @@
 output "prometheus_target_pool" {
-  value = "${google_compute_target_pool.prometheus-target-pool.name}"
+  value = google_compute_target_pool.prometheus-target-pool.name
 }
 
 output "prometheus_lb_ip" {
-  value = "${google_compute_address.prometheus-address.address}"
+  value = google_compute_address.prometheus-address.address
 }
 
 resource "google_compute_firewall" "firewall-prometheus" {
   name    = "${var.env_id}-prometheus-open"
-  network = "${google_compute_network.bbl-network.name}"
+  network = google_compute_network.bbl-network.name
 
   allow {
     protocol = "tcp"
@@ -30,24 +30,24 @@ resource "google_compute_target_pool" "prometheus-target-pool" {
 
 resource "google_compute_forwarding_rule" "grafana-forwarding-rule" {
   name        = "${var.env_id}-prometheus-grafana"
-  target      = "${google_compute_target_pool.prometheus-target-pool.self_link}"
+  target      = google_compute_target_pool.prometheus-target-pool.self_link
   port_range  = "3000"
   ip_protocol = "TCP"
-  ip_address  = "${google_compute_address.prometheus-address.address}"
+  ip_address  = google_compute_address.prometheus-address.address
 }
 
 resource "google_compute_forwarding_rule" "prometheus-forwarding-rule" {
   name        = "${var.env_id}-prometheus-prometheus"
-  target      = "${google_compute_target_pool.prometheus-target-pool.self_link}"
+  target      = google_compute_target_pool.prometheus-target-pool.self_link
   port_range  = "9090"
   ip_protocol = "TCP"
-  ip_address  = "${google_compute_address.prometheus-address.address}"
+  ip_address  = google_compute_address.prometheus-address.address
 }
 
 resource "google_compute_forwarding_rule" "alertmanager-forwarding-rule" {
   name        = "${var.env_id}-prometheus-alertmanager"
-  target      = "${google_compute_target_pool.prometheus-target-pool.self_link}"
+  target      = google_compute_target_pool.prometheus-target-pool.self_link
   port_range  = "9093"
   ip_protocol = "TCP"
-  ip_address  = "${google_compute_address.prometheus-address.address}"
+  ip_address  = google_compute_address.prometheus-address.address
 }

--- a/plan-patches/restricted-instance-groups-gcp/terraform/restricted_instance_groups_override.tf
+++ b/plan-patches/restricted-instance-groups-gcp/terraform/restricted_instance_groups_override.tf
@@ -6,14 +6,14 @@ resource "google_compute_backend_service" "router-lb-backend-service" {
   enable_cdn  = false
 
   backend {
-    group = "${google_compute_instance_group.router-lb-0.self_link}"
+    group = google_compute_instance_group.router-lb-0.self_link
   }
 
   backend {
-    group = "${google_compute_instance_group.router-lb-1.self_link}"
+    group = google_compute_instance_group.router-lb-1.self_link
   }
 
-  health_checks = ["${google_compute_health_check.cf-public-health-check.self_link}"]
+  health_checks = [google_compute_health_check.cf-public-health-check.self_link]
 }
 
 resource "google_compute_instance_group" "router-lb-2" {

--- a/plan-patches/s3-blobstore-aws/terraform/s3_blobstore_iam_override.tf
+++ b/plan-patches/s3-blobstore-aws/terraform/s3_blobstore_iam_override.tf
@@ -1,5 +1,16 @@
-data "template_file" "blobstore_access" {
-  template = <<EOF
+resource "aws_iam_user" "blobstore_access" {
+  name = "${var.env_id}-s3-blobstore-access"
+}
+
+resource "aws_iam_access_key" "blobstore_access" {
+  user = aws_iam_user.blobstore_access.name
+}
+
+resource "aws_iam_user_policy" "blobstore_access" {
+  name = "${var.env_id}-s3-blobstore-access"
+  user = aws_iam_user.blobstore_access.name
+
+  policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -9,39 +20,17 @@ data "template_file" "blobstore_access" {
         "s3:*"
       ],
       "Resource": [
-        "$${buildpacks_bucket_arn}",
-        "$${buildpacks_bucket_arn}/*",
-        "$${droplets_bucket_arn}",
-        "$${droplets_bucket_arn}/*",
-        "$${packages_bucket_arn}",
-        "$${packages_bucket_arn}/*",
-        "$${resources_bucket_arn}",
-        "$${resources_bucket_arn}/*"
+        "${aws_s3_bucket.buildpacks_bucket.arn}",
+        "${aws_s3_bucket.buildpacks_bucket.arn}/*",
+        "${aws_s3_bucket.droplets_bucket.arn}",
+        "${aws_s3_bucket.droplets_bucket.arn}/*",
+        "${aws_s3_bucket.packages_bucket.arn}",
+        "${aws_s3_bucket.packages_bucket.arn}/*",
+        "${aws_s3_bucket.resources_bucket.arn}",
+        "${aws_s3_bucket.resources_bucket.arn}/*"
       ]
     }
   ]
 }
 EOF
-
-  vars {
-    buildpacks_bucket_arn = "${aws_s3_bucket.buildpacks_bucket.arn}"
-    droplets_bucket_arn   = "${aws_s3_bucket.droplets_bucket.arn}"
-    packages_bucket_arn   = "${aws_s3_bucket.packages_bucket.arn}"
-    resources_bucket_arn  = "${aws_s3_bucket.resources_bucket.arn}"
-  }
-}
-
-resource "aws_iam_user" "blobstore_access" {
-  name = "${var.env_id}-s3-blobstore-access"
-}
-
-resource "aws_iam_access_key" "blobstore_access" {
-  user = "${aws_iam_user.blobstore_access.name}"
-}
-
-resource "aws_iam_user_policy" "blobstore_access" {
-  name = "${var.env_id}-s3-blobstore-access"
-  user = "${aws_iam_user.blobstore_access.name}"
-
-  policy = "${data.template_file.blobstore_access.rendered}"
 }

--- a/plan-patches/s3-blobstore-aws/terraform/s3_blobstore_outputs_override.tf
+++ b/plan-patches/s3-blobstore-aws/terraform/s3_blobstore_outputs_override.tf
@@ -1,23 +1,23 @@
 output "s3_blobstore_buildpacks_bucket" {
-  value = "${aws_s3_bucket.buildpacks_bucket.bucket}"
+  value = aws_s3_bucket.buildpacks_bucket.bucket
 }
 
 output "s3_blobstore_droplets_bucket" {
-  value = "${aws_s3_bucket.droplets_bucket.bucket}"
+  value = aws_s3_bucket.droplets_bucket.bucket
 }
 
 output "s3_blobstore_packages_bucket" {
-  value = "${aws_s3_bucket.packages_bucket.bucket}"
+  value = aws_s3_bucket.packages_bucket.bucket
 }
 
 output "s3_blobstore_resources_bucket" {
-  value = "${aws_s3_bucket.resources_bucket.bucket}"
+  value = aws_s3_bucket.resources_bucket.bucket
 }
 
 output "s3_blobstore_access_key_id" {
-  value = "${aws_iam_access_key.blobstore_access.id}"
+  value = aws_iam_access_key.blobstore_access.id
 }
 
 output "s3_blobstore_secret_access_key" {
-  value = "${aws_iam_access_key.blobstore_access.secret}"
+  value = aws_iam_access_key.blobstore_access.secret
 }

--- a/terraform/aws/templates/base.tf
+++ b/terraform/aws/templates/base.tf
@@ -1,25 +1,25 @@
 provider "aws" {
-  access_key = "${var.access_key}"
-  secret_key = "${var.secret_key}"
-  region     = "${var.region}"
+  access_key = var.access_key
+  secret_key = var.secret_key
+  region     = var.region
 
-  version = "~> 1.60"
+  version = "~> 2.0"
 }
 
 provider "tls" {
-  version = "~> 1.2"
+  version = "~> 2.0"
 }
 
 variable "access_key" {
-  type = "string"
+  type = string
 }
 
 variable "secret_key" {
-  type = "string"
+  type = string
 }
 
 variable "region" {
-  type = "string"
+  type = string
 }
 
 variable "bosh_inbound_cidr" {
@@ -27,24 +27,24 @@ variable "bosh_inbound_cidr" {
 }
 
 variable "availability_zones" {
-  type = "list"
+  type = list(string)
 }
 
 variable "env_id" {
-  type = "string"
+  type = string
 }
 
 variable "short_env_id" {
-  type = "string"
+  type = string
 }
 
 variable "vpc_cidr" {
-  type    = "string"
+  type    = string
   default = "10.0.0.0/16"
 }
 
 resource "aws_eip" "jumpbox_eip" {
-  depends_on = ["aws_internet_gateway.ig"]
+  depends_on = [aws_internet_gateway.ig]
   vpc        = true
 }
 
@@ -55,25 +55,25 @@ resource "tls_private_key" "bosh_vms" {
 
 resource "aws_key_pair" "bosh_vms" {
   key_name   = "${var.env_id}_bosh_vms"
-  public_key = "${tls_private_key.bosh_vms.public_key_openssh}"
+  public_key = tls_private_key.bosh_vms.public_key_openssh
 }
 
 resource "aws_security_group" "nat_security_group" {
   name        = "${var.env_id}-nat-security-group"
   description = "NAT"
-  vpc_id      = "${local.vpc_id}"
+  vpc_id      = local.vpc_id
 
-  tags {
+  tags = {
     Name = "${var.env_id}-nat-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
 }
 
 resource "aws_security_group_rule" "nat_to_internet_rule" {
-  security_group_id = "${aws_security_group.nat_security_group.id}"
+  security_group_id = aws_security_group.nat_security_group.id
 
   type        = "egress"
   from_port   = 0
@@ -83,7 +83,7 @@ resource "aws_security_group_rule" "nat_to_internet_rule" {
 }
 
 resource "aws_security_group_rule" "nat_icmp_rule" {
-  security_group_id = "${aws_security_group.nat_security_group.id}"
+  security_group_id = aws_security_group.nat_security_group.id
 
   type        = "ingress"
   protocol    = "icmp"
@@ -93,64 +93,64 @@ resource "aws_security_group_rule" "nat_icmp_rule" {
 }
 
 resource "aws_security_group_rule" "nat_tcp_rule" {
-  security_group_id = "${aws_security_group.nat_security_group.id}"
+  security_group_id = aws_security_group.nat_security_group.id
 
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 0
   to_port                  = 65535
-  source_security_group_id = "${aws_security_group.internal_security_group.id}"
+  source_security_group_id = aws_security_group.internal_security_group.id
 }
 
 resource "aws_security_group_rule" "nat_udp_rule" {
-  security_group_id = "${aws_security_group.nat_security_group.id}"
+  security_group_id = aws_security_group.nat_security_group.id
 
   type                     = "ingress"
   protocol                 = "udp"
   from_port                = 0
   to_port                  = 65535
-  source_security_group_id = "${aws_security_group.internal_security_group.id}"
+  source_security_group_id = aws_security_group.internal_security_group.id
 }
 
 resource "aws_nat_gateway" "nat" {
-  subnet_id     = "${aws_subnet.bosh_subnet.id}"
-  allocation_id = "${aws_eip.nat_eip.id}"
+  subnet_id     = aws_subnet.bosh_subnet.id
+  allocation_id = aws_eip.nat_eip.id
 
-  tags {
+  tags = {
     Name  = "${var.env_id}-nat"
-    EnvID = "${var.env_id}"
+    EnvID = var.env_id
   }
 }
 
 resource "aws_eip" "nat_eip" {
   vpc = true
 
-  tags {
+  tags = {
     Name  = "${var.env_id}-nat"
-    EnvID = "${var.env_id}"
+    EnvID = var.env_id
   }
 }
 
 resource "aws_default_security_group" "default_security_group" {
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 }
 
 resource "aws_security_group" "internal_security_group" {
   name        = "${var.env_id}-internal-security-group"
   description = "Internal"
-  vpc_id      = "${local.vpc_id}"
+  vpc_id      = local.vpc_id
 
-  tags {
+  tags = {
     Name = "${var.env_id}-internal-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
 }
 
 resource "aws_security_group_rule" "internal_security_group_rule_tcp" {
-  security_group_id = "${aws_security_group.internal_security_group.id}"
+  security_group_id = aws_security_group.internal_security_group.id
   type              = "ingress"
   protocol          = "tcp"
   from_port         = 0
@@ -159,7 +159,7 @@ resource "aws_security_group_rule" "internal_security_group_rule_tcp" {
 }
 
 resource "aws_security_group_rule" "internal_security_group_rule_udp" {
-  security_group_id = "${aws_security_group.internal_security_group.id}"
+  security_group_id = aws_security_group.internal_security_group.id
   type              = "ingress"
   protocol          = "udp"
   from_port         = 0
@@ -168,7 +168,7 @@ resource "aws_security_group_rule" "internal_security_group_rule_udp" {
 }
 
 resource "aws_security_group_rule" "internal_security_group_rule_icmp" {
-  security_group_id = "${aws_security_group.internal_security_group.id}"
+  security_group_id = aws_security_group.internal_security_group.id
   type              = "ingress"
   protocol          = "icmp"
   from_port         = -1
@@ -177,7 +177,7 @@ resource "aws_security_group_rule" "internal_security_group_rule_icmp" {
 }
 
 resource "aws_security_group_rule" "internal_security_group_rule_allow_internet" {
-  security_group_id = "${aws_security_group.internal_security_group.id}"
+  security_group_id = aws_security_group.internal_security_group.id
   type              = "egress"
   protocol          = "-1"
   from_port         = 0
@@ -186,93 +186,93 @@ resource "aws_security_group_rule" "internal_security_group_rule_allow_internet"
 }
 
 resource "aws_security_group_rule" "internal_security_group_rule_ssh" {
-  security_group_id        = "${aws_security_group.internal_security_group.id}"
+  security_group_id        = aws_security_group.internal_security_group.id
   type                     = "ingress"
   protocol                 = "TCP"
   from_port                = 22
   to_port                  = 22
-  source_security_group_id = "${aws_security_group.jumpbox.id}"
+  source_security_group_id = aws_security_group.jumpbox.id
 }
 
 resource "aws_security_group" "bosh_security_group" {
   name        = "${var.env_id}-bosh-security-group"
   description = "BOSH Director"
-  vpc_id      = "${local.vpc_id}"
+  vpc_id      = local.vpc_id
 
-  tags {
+  tags = {
     Name = "${var.env_id}-bosh-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name", "description"]
+    ignore_changes = [name, description]
   }
 }
 
 resource "aws_security_group_rule" "bosh_security_group_rule_tcp_ssh" {
-  security_group_id        = "${aws_security_group.bosh_security_group.id}"
+  security_group_id        = aws_security_group.bosh_security_group.id
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 22
   to_port                  = 22
-  source_security_group_id = "${aws_security_group.jumpbox.id}"
+  source_security_group_id = aws_security_group.jumpbox.id
 }
 
 resource "aws_security_group_rule" "bosh_security_group_rule_tcp_bosh_agent" {
-  security_group_id        = "${aws_security_group.bosh_security_group.id}"
+  security_group_id        = aws_security_group.bosh_security_group.id
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 6868
   to_port                  = 6868
-  source_security_group_id = "${aws_security_group.jumpbox.id}"
+  source_security_group_id = aws_security_group.jumpbox.id
 }
 
 resource "aws_security_group_rule" "bosh_security_group_rule_uaa" {
-  security_group_id        = "${aws_security_group.bosh_security_group.id}"
+  security_group_id        = aws_security_group.bosh_security_group.id
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 8443
   to_port                  = 8443
-  source_security_group_id = "${aws_security_group.jumpbox.id}"
+  source_security_group_id = aws_security_group.jumpbox.id
 }
 
 resource "aws_security_group_rule" "bosh_security_group_rule_credhub" {
-  security_group_id        = "${aws_security_group.bosh_security_group.id}"
+  security_group_id        = aws_security_group.bosh_security_group.id
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 8844
   to_port                  = 8844
-  source_security_group_id = "${aws_security_group.jumpbox.id}"
+  source_security_group_id = aws_security_group.jumpbox.id
 }
 
 resource "aws_security_group_rule" "bosh_security_group_rule_tcp_director_api" {
-  security_group_id        = "${aws_security_group.bosh_security_group.id}"
+  security_group_id        = aws_security_group.bosh_security_group.id
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 25555
   to_port                  = 25555
-  source_security_group_id = "${aws_security_group.jumpbox.id}"
+  source_security_group_id = aws_security_group.jumpbox.id
 }
 
 resource "aws_security_group_rule" "bosh_security_group_rule_tcp" {
-  security_group_id        = "${aws_security_group.bosh_security_group.id}"
+  security_group_id        = aws_security_group.bosh_security_group.id
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 0
   to_port                  = 65535
-  source_security_group_id = "${aws_security_group.internal_security_group.id}"
+  source_security_group_id = aws_security_group.internal_security_group.id
 }
 
 resource "aws_security_group_rule" "bosh_security_group_rule_udp" {
-  security_group_id        = "${aws_security_group.bosh_security_group.id}"
+  security_group_id        = aws_security_group.bosh_security_group.id
   type                     = "ingress"
   protocol                 = "udp"
   from_port                = 0
   to_port                  = 65535
-  source_security_group_id = "${aws_security_group.internal_security_group.id}"
+  source_security_group_id = aws_security_group.internal_security_group.id
 }
 
 resource "aws_security_group_rule" "bosh_security_group_rule_allow_internet" {
-  security_group_id = "${aws_security_group.bosh_security_group.id}"
+  security_group_id = aws_security_group.bosh_security_group.id
   type              = "egress"
   protocol          = "-1"
   from_port         = 0
@@ -283,55 +283,55 @@ resource "aws_security_group_rule" "bosh_security_group_rule_allow_internet" {
 resource "aws_security_group" "jumpbox" {
   name        = "${var.env_id}-jumpbox-security-group"
   description = "Jumpbox"
-  vpc_id      = "${local.vpc_id}"
+  vpc_id      = local.vpc_id
 
-  tags {
+  tags = {
     Name = "${var.env_id}-jumpbox-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name", "description"]
+    ignore_changes = [name, description]
   }
 }
 
 resource "aws_security_group_rule" "jumpbox_ssh" {
-  security_group_id = "${aws_security_group.jumpbox.id}"
+  security_group_id = aws_security_group.jumpbox.id
   type              = "ingress"
   protocol          = "tcp"
   from_port         = 22
   to_port           = 22
-  cidr_blocks       = ["${var.bosh_inbound_cidr}"]
+  cidr_blocks       = [var.bosh_inbound_cidr]
 }
 
 resource "aws_security_group_rule" "jumpbox_rdp" {
-  security_group_id = "${aws_security_group.jumpbox.id}"
+  security_group_id = aws_security_group.jumpbox.id
   type              = "ingress"
   protocol          = "tcp"
   from_port         = 3389
   to_port           = 3389
-  cidr_blocks       = ["${var.bosh_inbound_cidr}"]
+  cidr_blocks       = [var.bosh_inbound_cidr]
 }
 
 resource "aws_security_group_rule" "jumpbox_agent" {
-  security_group_id = "${aws_security_group.jumpbox.id}"
+  security_group_id = aws_security_group.jumpbox.id
   type              = "ingress"
   protocol          = "tcp"
   from_port         = 6868
   to_port           = 6868
-  cidr_blocks       = ["${var.bosh_inbound_cidr}"]
+  cidr_blocks       = [var.bosh_inbound_cidr]
 }
 
 resource "aws_security_group_rule" "jumpbox_director" {
-  security_group_id = "${aws_security_group.jumpbox.id}"
+  security_group_id = aws_security_group.jumpbox.id
   type              = "ingress"
   protocol          = "tcp"
   from_port         = 25555
   to_port           = 25555
-  cidr_blocks       = ["${var.bosh_inbound_cidr}"]
+  cidr_blocks       = [var.bosh_inbound_cidr]
 }
 
 resource "aws_security_group_rule" "jumpbox_egress" {
-  security_group_id = "${aws_security_group.jumpbox.id}"
+  security_group_id = aws_security_group.jumpbox.id
   type              = "egress"
   protocol          = "-1"
   from_port         = 0
@@ -340,87 +340,87 @@ resource "aws_security_group_rule" "jumpbox_egress" {
 }
 
 resource "aws_security_group_rule" "bosh_internal_security_rule_tcp" {
-  security_group_id        = "${aws_security_group.internal_security_group.id}"
+  security_group_id        = aws_security_group.internal_security_group.id
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 0
   to_port                  = 65535
-  source_security_group_id = "${aws_security_group.bosh_security_group.id}"
+  source_security_group_id = aws_security_group.bosh_security_group.id
 }
 
 resource "aws_security_group_rule" "bosh_internal_security_rule_udp" {
-  security_group_id        = "${aws_security_group.internal_security_group.id}"
+  security_group_id        = aws_security_group.internal_security_group.id
   type                     = "ingress"
   protocol                 = "udp"
   from_port                = 0
   to_port                  = 65535
-  source_security_group_id = "${aws_security_group.bosh_security_group.id}"
+  source_security_group_id = aws_security_group.bosh_security_group.id
 }
 
 resource "aws_subnet" "bosh_subnet" {
-  vpc_id     = "${local.vpc_id}"
-  cidr_block = "${cidrsubnet(var.vpc_cidr, 8, 0)}"
+  vpc_id     = local.vpc_id
+  cidr_block = cidrsubnet(var.vpc_cidr, 8, 0)
 
-  tags {
+  tags = {
     Name = "${var.env_id}-bosh-subnet"
   }
 }
 
 resource "aws_route_table" "bosh_route_table" {
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 }
 
 resource "aws_route" "bosh_route_table" {
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.ig.id}"
-  route_table_id         = "${aws_route_table.bosh_route_table.id}"
+  gateway_id             = aws_internet_gateway.ig.id
+  route_table_id         = aws_route_table.bosh_route_table.id
 }
 
 resource "aws_route_table_association" "route_bosh_subnets" {
-  subnet_id      = "${aws_subnet.bosh_subnet.id}"
-  route_table_id = "${aws_route_table.bosh_route_table.id}"
+  subnet_id      = aws_subnet.bosh_subnet.id
+  route_table_id = aws_route_table.bosh_route_table.id
 }
 
 resource "aws_subnet" "internal_subnets" {
-  count             = "${length(var.availability_zones)}"
-  vpc_id            = "${local.vpc_id}"
-  cidr_block        = "${cidrsubnet(var.vpc_cidr, 4, count.index+1)}"
-  availability_zone = "${element(var.availability_zones, count.index)}"
+  count             = length(var.availability_zones)
+  vpc_id            = local.vpc_id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 4, count.index + 1)
+  availability_zone = element(var.availability_zones, count.index)
 
-  tags {
+  tags = {
     Name = "${var.env_id}-internal-subnet${count.index}"
   }
 
   lifecycle {
-    ignore_changes = ["cidr_block", "availability_zone"]
+    ignore_changes = [cidr_block, availability_zone]
   }
 }
 
 resource "aws_route_table" "nated_route_table" {
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 
   route {
     cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = "${aws_nat_gateway.nat.id}"
+    nat_gateway_id = aws_nat_gateway.nat.id
   }
 }
 
 resource "aws_route_table_association" "route_internal_subnets" {
-  count          = "${length(var.availability_zones)}"
-  subnet_id      = "${element(aws_subnet.internal_subnets.*.id, count.index)}"
-  route_table_id = "${aws_route_table.nated_route_table.id}"
+  count          = length(var.availability_zones)
+  subnet_id      = element(aws_subnet.internal_subnets.*.id, count.index)
+  route_table_id = aws_route_table.nated_route_table.id
 }
 
 resource "aws_internet_gateway" "ig" {
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 }
 
 locals {
   director_name        = "bosh-${var.env_id}"
-  internal_cidr        = "${aws_subnet.bosh_subnet.cidr_block}"
-  internal_gw          = "${cidrhost(local.internal_cidr, 1)}"
-  jumpbox_internal_ip  = "${cidrhost(local.internal_cidr, 5)}"
-  director_internal_ip = "${cidrhost(local.internal_cidr, 6)}"
+  internal_cidr        = aws_subnet.bosh_subnet.cidr_block
+  internal_gw          = cidrhost(local.internal_cidr, 1)
+  jumpbox_internal_ip  = cidrhost(local.internal_cidr, 5)
+  director_internal_ip = cidrhost(local.internal_cidr, 6)
 }
 
 resource "aws_kms_key" "kms_key" {
@@ -428,16 +428,16 @@ resource "aws_kms_key" "kms_key" {
 }
 
 output "default_key_name" {
-  value = "${aws_key_pair.bosh_vms.key_name}"
+  value = aws_key_pair.bosh_vms.key_name
 }
 
 output "private_key" {
-  value     = "${tls_private_key.bosh_vms.private_key_pem}"
+  value     = tls_private_key.bosh_vms.private_key_pem
   sensitive = true
 }
 
 output "external_ip" {
-  value = "${aws_eip.jumpbox_eip.public_ip}"
+  value = aws_eip.jumpbox_eip.public_ip
 }
 
 output "jumpbox_url" {
@@ -449,77 +449,73 @@ output "director_address" {
 }
 
 output "nat_eip" {
-  value = "${aws_eip.nat_eip.public_ip}"
+  value = aws_eip.nat_eip.public_ip
 }
 
 output "internal_security_group" {
-  value = "${aws_security_group.internal_security_group.id}"
+  value = aws_security_group.internal_security_group.id
 }
 
 output "bosh_security_group" {
-  value = "${aws_security_group.bosh_security_group.id}"
+  value = aws_security_group.bosh_security_group.id
 }
 
 output "jumpbox_security_group" {
-  value = "${aws_security_group.jumpbox.id}"
+  value = aws_security_group.jumpbox.id
 }
 
 output "jumpbox__default_security_groups" {
-  value = ["${aws_security_group.jumpbox.id}"]
+  value = [aws_security_group.jumpbox.id]
 }
 
 output "director__default_security_groups" {
-  value = ["${aws_security_group.bosh_security_group.id}"]
+  value = [aws_security_group.bosh_security_group.id]
 }
 
 output "subnet_id" {
-  value = "${aws_subnet.bosh_subnet.id}"
+  value = aws_subnet.bosh_subnet.id
 }
 
 output "az" {
-  value = "${aws_subnet.bosh_subnet.availability_zone}"
+  value = aws_subnet.bosh_subnet.availability_zone
 }
 
 output "vpc_id" {
-  value = "${local.vpc_id}"
+  value = local.vpc_id
 }
 
 output "region" {
-  value = "${var.region}"
+  value = var.region
 }
 
 output "kms_key_arn" {
-  value = "${aws_kms_key.kms_key.arn}"
+  value = aws_kms_key.kms_key.arn
 }
 
 output "internal_az_subnet_id_mapping" {
-  value = "${
-	  zipmap("${aws_subnet.internal_subnets.*.availability_zone}", "${aws_subnet.internal_subnets.*.id}")
-	}"
+  value = zipmap(aws_subnet.internal_subnets.*.availability_zone, aws_subnet.internal_subnets.*.id)
 }
 
 output "internal_az_subnet_cidr_mapping" {
-  value = "${
-	  zipmap("${aws_subnet.internal_subnets.*.availability_zone}", "${aws_subnet.internal_subnets.*.cidr_block}")
-	}"
+  value = zipmap(aws_subnet.internal_subnets.*.availability_zone, aws_subnet.internal_subnets.*.cidr_block)
 }
 
 output "director_name" {
-  value = "${local.director_name}"
+  value = local.director_name
 }
 
 output "internal_cidr" {
-  value = "${local.internal_cidr}"
+  value = local.internal_cidr
 }
 
 output "internal_gw" {
-  value = "${local.internal_gw}"
+  value = local.internal_gw
 }
 
 output "jumpbox__internal_ip" {
-  value = "${local.jumpbox_internal_ip}"
+  value = local.jumpbox_internal_ip
 }
 
 output "director__internal_ip" {
-  value = "${local.director_internal_ip}"
+  value = local.director_internal_ip
 }

--- a/terraform/aws/templates/cf_dns.tf
+++ b/terraform/aws/templates/cf_dns.tf
@@ -1,92 +1,92 @@
 variable "system_domain" {
-  type = "string"
+  type = string
 }
 
 variable "parent_zone" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "The name of the parent zone for the provided system domain if it exists."
 }
 
 data "aws_route53_zone" "parent" {
-  count = "${var.parent_zone == "" ? 0 : 1}"
+  count = var.parent_zone == "" ? 0 : 1
 
-  name = "${var.parent_zone}"
+  name = var.parent_zone
 }
 
 output "env_dns_zone_name_servers" {
-  value = ["${split(",", local.name_servers)}"]
+  value = compact(split(",", local.name_servers))
 }
 
 locals {
-  zone_id      = "${var.parent_zone == "" ? element(concat(aws_route53_zone.env_dns_zone.*.zone_id, list("")), 0) : element(concat(data.aws_route53_zone.parent.*.zone_id, list("")), 0)}"
-  name_servers = "${var.parent_zone == "" ? join(",", flatten(concat(aws_route53_zone.env_dns_zone.*.name_servers, list(list(""))))) :  join(",", flatten(concat(data.aws_route53_zone.env_dns_zone.*.name_servers, list(list("")))))}"
+  zone_id      = var.parent_zone == "" ? element(concat(aws_route53_zone.env_dns_zone.*.zone_id, list("")), 0) : element(concat(data.aws_route53_zone.parent.*.zone_id, list("")), 0)
+  name_servers = var.parent_zone == "" ? join(",", flatten(concat(aws_route53_zone.env_dns_zone.*.name_servers, list(list(""))))) : join(",", flatten(concat(data.aws_route53_zone.parent.*.name_servers, list(list("")))))
 }
 
 resource "aws_route53_zone" "env_dns_zone" {
-  count = "${var.parent_zone == "" ? 1 : 0}"
+  count = var.parent_zone == "" ? 1 : 0
 
-  name = "${var.system_domain}"
+  name = var.system_domain
 
-  tags {
+  tags = {
     Name = "${var.env_id}-hosted-zone"
   }
 }
 
 resource "aws_route53_record" "dns" {
-  count = "${var.parent_zone == "" ? 1 : 0}"
+  count = var.parent_zone == "" ? 1 : 0
 
-  zone_id = "${local.zone_id}"
-  name    = "${var.system_domain}"
+  zone_id = local.zone_id
+  name    = var.system_domain
   type    = "NS"
   ttl     = 300
 
-  records = ["${local.name_servers}"]
+  records = [local.name_servers]
 }
 
 resource "aws_route53_record" "wildcard_dns" {
-  zone_id = "${local.zone_id}"
+  zone_id = local.zone_id
   name    = "*.${var.system_domain}"
   type    = "CNAME"
   ttl     = 300
 
-  records = ["${aws_elb.cf_router_lb.dns_name}"]
+  records = [aws_elb.cf_router_lb.dns_name]
 }
 
 resource "aws_route53_record" "ssh" {
-  zone_id = "${local.zone_id}"
+  zone_id = local.zone_id
   name    = "ssh.${var.system_domain}"
   type    = "CNAME"
   ttl     = 300
 
-  records = ["${aws_elb.cf_ssh_lb.dns_name}"]
+  records = [aws_elb.cf_ssh_lb.dns_name]
 }
 
 resource "aws_route53_record" "bosh" {
-  zone_id = "${local.zone_id}"
+  zone_id = local.zone_id
   name    = "bosh.${var.system_domain}"
   type    = "A"
   ttl     = 300
 
-  records = ["${aws_eip.jumpbox_eip.public_ip}"]
+  records = [aws_eip.jumpbox_eip.public_ip]
 }
 
 resource "aws_route53_record" "tcp" {
-  zone_id = "${local.zone_id}"
+  zone_id = local.zone_id
   name    = "tcp.${var.system_domain}"
   type    = "CNAME"
   ttl     = 300
 
-  records = ["${aws_elb.cf_tcp_lb.dns_name}"]
+  records = [aws_elb.cf_tcp_lb.dns_name]
 }
 
 resource "aws_route53_record" "iso" {
-  count = "${var.isolation_segments}"
+  count = var.isolation_segments
 
-  zone_id = "${local.zone_id}"
+  zone_id = local.zone_id
   name    = "*.iso-seg.${var.system_domain}"
   type    = "CNAME"
   ttl     = 300
 
-  records = ["${aws_elb.iso_router_lb.dns_name}"]
+  records = [aws_elb.iso_router_lb[count.index].dns_name]
 }

--- a/terraform/aws/templates/cf_lb.tf
+++ b/terraform/aws/templates/cf_lb.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "cf_ssh_lb_security_group" {
   name        = "${var.env_id}-cf-ssh-lb-security-group"
   description = "CF SSH"
-  vpc_id      = "${local.vpc_id}"
+  vpc_id      = local.vpc_id
 
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
@@ -17,26 +17,26 @@ resource "aws_security_group" "cf_ssh_lb_security_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.env_id}-cf-ssh-lb-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
 }
 
 output "cf_ssh_lb_security_group" {
-  value = "${aws_security_group.cf_ssh_lb_security_group.id}"
+  value = aws_security_group.cf_ssh_lb_security_group.id
 }
 
 resource "aws_security_group" "cf_ssh_lb_internal_security_group" {
   name        = "${var.env_id}-cf-ssh-lb-internal-security-group"
   description = "CF SSH Internal"
-  vpc_id      = "${local.vpc_id}"
+  vpc_id      = local.vpc_id
 
   ingress {
-    security_groups = ["${aws_security_group.cf_ssh_lb_security_group.id}"]
+    security_groups = [aws_security_group.cf_ssh_lb_security_group.id]
     protocol        = "tcp"
     from_port       = 2222
     to_port         = 2222
@@ -49,17 +49,17 @@ resource "aws_security_group" "cf_ssh_lb_internal_security_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.env_id}-cf-ssh-lb-internal-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
 }
 
 output "cf_ssh_lb_internal_security_group" {
-  value = "${aws_security_group.cf_ssh_lb_internal_security_group.id}"
+  value = aws_security_group.cf_ssh_lb_internal_security_group.id
 }
 
 resource "aws_elb" "cf_ssh_lb" {
@@ -81,26 +81,26 @@ resource "aws_elb" "cf_ssh_lb" {
     lb_protocol       = "tcp"
   }
 
-  security_groups = ["${aws_security_group.cf_ssh_lb_security_group.id}"]
-  subnets         = ["${aws_subnet.lb_subnets.*.id}"]
+  security_groups = [aws_security_group.cf_ssh_lb_security_group.id]
+  subnets         = aws_subnet.lb_subnets.*.id
 
-  tags {
-    Name = "${var.env_id}"
+  tags = {
+    Name = var.env_id
   }
 }
 
 output "cf_ssh_lb_name" {
-  value = "${aws_elb.cf_ssh_lb.name}"
+  value = aws_elb.cf_ssh_lb.name
 }
 
 output "cf_ssh_lb_url" {
-  value = "${aws_elb.cf_ssh_lb.dns_name}"
+  value = aws_elb.cf_ssh_lb.dns_name
 }
 
 resource "aws_security_group" "cf_router_lb_security_group" {
   name        = "${var.env_id}-cf-router-lb-security-group"
   description = "CF Router"
-  vpc_id      = "${local.vpc_id}"
+  vpc_id      = local.vpc_id
 
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
@@ -130,26 +130,26 @@ resource "aws_security_group" "cf_router_lb_security_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.env_id}-cf-router-lb-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
 }
 
 output "cf_router_lb_security_group" {
-  value = "${aws_security_group.cf_router_lb_security_group.id}"
+  value = aws_security_group.cf_router_lb_security_group.id
 }
 
 resource "aws_security_group" "cf_router_lb_internal_security_group" {
   name        = "${var.env_id}-cf-router-lb-internal-security-group"
   description = "CF Router Internal"
-  vpc_id      = "${local.vpc_id}"
+  vpc_id      = local.vpc_id
 
   ingress {
-    security_groups = ["${aws_security_group.cf_router_lb_security_group.id}"]
+    security_groups = [aws_security_group.cf_router_lb_security_group.id]
     protocol        = "tcp"
     from_port       = 80
     to_port         = 80
@@ -162,17 +162,17 @@ resource "aws_security_group" "cf_router_lb_internal_security_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.env_id}-cf-router-lb-internal-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
 }
 
 output "cf_router_lb_internal_security_group" {
-  value = "${aws_security_group.cf_router_lb_internal_security_group.id}"
+  value = aws_security_group.cf_router_lb_internal_security_group.id
 }
 
 resource "aws_elb" "cf_router_lb" {
@@ -199,7 +199,7 @@ resource "aws_elb" "cf_router_lb" {
     instance_protocol  = "http"
     lb_port            = 443
     lb_protocol        = "https"
-    ssl_certificate_id = "${aws_iam_server_certificate.lb_cert.arn}"
+    ssl_certificate_id = aws_iam_server_certificate.lb_cert.arn
   }
 
   listener {
@@ -207,14 +207,14 @@ resource "aws_elb" "cf_router_lb" {
     instance_protocol  = "tcp"
     lb_port            = 4443
     lb_protocol        = "ssl"
-    ssl_certificate_id = "${aws_iam_server_certificate.lb_cert.arn}"
+    ssl_certificate_id = aws_iam_server_certificate.lb_cert.arn
   }
 
-  security_groups = ["${aws_security_group.cf_router_lb_security_group.id}"]
-  subnets         = ["${aws_subnet.lb_subnets.*.id}"]
+  security_groups = [aws_security_group.cf_router_lb_security_group.id]
+  subnets         = aws_subnet.lb_subnets.*.id
 
-  tags {
-    Name = "${var.env_id}"
+  tags = {
+    Name = var.env_id
   }
 }
 
@@ -222,29 +222,29 @@ resource "aws_lb_target_group" "cf_router_4443" {
   name     = "${var.short_env_id}-routertg-4443"
   port     = 4443
   protocol = "TCP"
-  vpc_id   = "${local.vpc_id}"
+  vpc_id   = local.vpc_id
 
   health_check {
     protocol = "TCP"
   }
 
-  tags {
-    Name = "${var.env_id}"
+  tags = {
+    Name = var.env_id
   }
 }
 
 output "cf_router_lb_name" {
-  value = "${aws_elb.cf_router_lb.name}"
+  value = aws_elb.cf_router_lb.name
 }
 
 output "cf_router_lb_url" {
-  value = "${aws_elb.cf_router_lb.dns_name}"
+  value = aws_elb.cf_router_lb.dns_name
 }
 
 resource "aws_security_group" "cf_tcp_lb_security_group" {
   name        = "${var.env_id}-cf-tcp-lb-security-group"
   description = "CF TCP"
-  vpc_id      = "${local.vpc_id}"
+  vpc_id      = local.vpc_id
 
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
@@ -260,33 +260,33 @@ resource "aws_security_group" "cf_tcp_lb_security_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.env_id}-cf-tcp-lb-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
 }
 
 output "cf_tcp_lb_security_group" {
-  value = "${aws_security_group.cf_tcp_lb_security_group.id}"
+  value = aws_security_group.cf_tcp_lb_security_group.id
 }
 
 resource "aws_security_group" "cf_tcp_lb_internal_security_group" {
   name        = "${var.env_id}-cf-tcp-lb-internal-security-group"
   description = "CF TCP Internal"
-  vpc_id      = "${local.vpc_id}"
+  vpc_id      = local.vpc_id
 
   ingress {
-    security_groups = ["${aws_security_group.cf_tcp_lb_security_group.id}"]
+    security_groups = [aws_security_group.cf_tcp_lb_security_group.id]
     protocol        = "tcp"
     from_port       = 1024
     to_port         = 1123
   }
 
   ingress {
-    security_groups = ["${aws_security_group.cf_tcp_lb_security_group.id}"]
+    security_groups = [aws_security_group.cf_tcp_lb_security_group.id]
     protocol        = "tcp"
     from_port       = 80
     to_port         = 80
@@ -299,17 +299,17 @@ resource "aws_security_group" "cf_tcp_lb_internal_security_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.env_id}-cf-tcp-lb-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
 }
 
 output "cf_tcp_lb_internal_security_group" {
-  value = "${aws_security_group.cf_tcp_lb_internal_security_group.id}"
+  value = aws_security_group.cf_tcp_lb_internal_security_group.id
 }
 
 resource "aws_elb" "cf_tcp_lb" {
@@ -324,718 +324,28 @@ resource "aws_elb" "cf_tcp_lb" {
     timeout             = 3
   }
 
-  listener {
-    instance_port     = 1024
-    instance_protocol = "tcp"
-    lb_port           = 1024
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1025
-    instance_protocol = "tcp"
-    lb_port           = 1025
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1026
-    instance_protocol = "tcp"
-    lb_port           = 1026
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1027
-    instance_protocol = "tcp"
-    lb_port           = 1027
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1028
-    instance_protocol = "tcp"
-    lb_port           = 1028
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1029
-    instance_protocol = "tcp"
-    lb_port           = 1029
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1030
-    instance_protocol = "tcp"
-    lb_port           = 1030
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1031
-    instance_protocol = "tcp"
-    lb_port           = 1031
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1032
-    instance_protocol = "tcp"
-    lb_port           = 1032
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1033
-    instance_protocol = "tcp"
-    lb_port           = 1033
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1034
-    instance_protocol = "tcp"
-    lb_port           = 1034
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1035
-    instance_protocol = "tcp"
-    lb_port           = 1035
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1036
-    instance_protocol = "tcp"
-    lb_port           = 1036
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1037
-    instance_protocol = "tcp"
-    lb_port           = 1037
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1038
-    instance_protocol = "tcp"
-    lb_port           = 1038
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1039
-    instance_protocol = "tcp"
-    lb_port           = 1039
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1040
-    instance_protocol = "tcp"
-    lb_port           = 1040
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1041
-    instance_protocol = "tcp"
-    lb_port           = 1041
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1042
-    instance_protocol = "tcp"
-    lb_port           = 1042
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1043
-    instance_protocol = "tcp"
-    lb_port           = 1043
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1044
-    instance_protocol = "tcp"
-    lb_port           = 1044
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1045
-    instance_protocol = "tcp"
-    lb_port           = 1045
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1046
-    instance_protocol = "tcp"
-    lb_port           = 1046
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1047
-    instance_protocol = "tcp"
-    lb_port           = 1047
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1048
-    instance_protocol = "tcp"
-    lb_port           = 1048
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1049
-    instance_protocol = "tcp"
-    lb_port           = 1049
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1050
-    instance_protocol = "tcp"
-    lb_port           = 1050
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1051
-    instance_protocol = "tcp"
-    lb_port           = 1051
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1052
-    instance_protocol = "tcp"
-    lb_port           = 1052
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1053
-    instance_protocol = "tcp"
-    lb_port           = 1053
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1054
-    instance_protocol = "tcp"
-    lb_port           = 1054
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1055
-    instance_protocol = "tcp"
-    lb_port           = 1055
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1056
-    instance_protocol = "tcp"
-    lb_port           = 1056
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1057
-    instance_protocol = "tcp"
-    lb_port           = 1057
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1058
-    instance_protocol = "tcp"
-    lb_port           = 1058
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1059
-    instance_protocol = "tcp"
-    lb_port           = 1059
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1060
-    instance_protocol = "tcp"
-    lb_port           = 1060
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1061
-    instance_protocol = "tcp"
-    lb_port           = 1061
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1062
-    instance_protocol = "tcp"
-    lb_port           = 1062
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1063
-    instance_protocol = "tcp"
-    lb_port           = 1063
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1064
-    instance_protocol = "tcp"
-    lb_port           = 1064
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1065
-    instance_protocol = "tcp"
-    lb_port           = 1065
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1066
-    instance_protocol = "tcp"
-    lb_port           = 1066
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1067
-    instance_protocol = "tcp"
-    lb_port           = 1067
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1068
-    instance_protocol = "tcp"
-    lb_port           = 1068
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1069
-    instance_protocol = "tcp"
-    lb_port           = 1069
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1070
-    instance_protocol = "tcp"
-    lb_port           = 1070
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1071
-    instance_protocol = "tcp"
-    lb_port           = 1071
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1072
-    instance_protocol = "tcp"
-    lb_port           = 1072
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1073
-    instance_protocol = "tcp"
-    lb_port           = 1073
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1074
-    instance_protocol = "tcp"
-    lb_port           = 1074
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1075
-    instance_protocol = "tcp"
-    lb_port           = 1075
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1076
-    instance_protocol = "tcp"
-    lb_port           = 1076
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1077
-    instance_protocol = "tcp"
-    lb_port           = 1077
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1078
-    instance_protocol = "tcp"
-    lb_port           = 1078
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1079
-    instance_protocol = "tcp"
-    lb_port           = 1079
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1080
-    instance_protocol = "tcp"
-    lb_port           = 1080
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1081
-    instance_protocol = "tcp"
-    lb_port           = 1081
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1082
-    instance_protocol = "tcp"
-    lb_port           = 1082
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1083
-    instance_protocol = "tcp"
-    lb_port           = 1083
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1084
-    instance_protocol = "tcp"
-    lb_port           = 1084
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1085
-    instance_protocol = "tcp"
-    lb_port           = 1085
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1086
-    instance_protocol = "tcp"
-    lb_port           = 1086
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1087
-    instance_protocol = "tcp"
-    lb_port           = 1087
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1088
-    instance_protocol = "tcp"
-    lb_port           = 1088
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1089
-    instance_protocol = "tcp"
-    lb_port           = 1089
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1090
-    instance_protocol = "tcp"
-    lb_port           = 1090
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1091
-    instance_protocol = "tcp"
-    lb_port           = 1091
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1092
-    instance_protocol = "tcp"
-    lb_port           = 1092
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1093
-    instance_protocol = "tcp"
-    lb_port           = 1093
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1094
-    instance_protocol = "tcp"
-    lb_port           = 1094
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1095
-    instance_protocol = "tcp"
-    lb_port           = 1095
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1096
-    instance_protocol = "tcp"
-    lb_port           = 1096
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1097
-    instance_protocol = "tcp"
-    lb_port           = 1097
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1098
-    instance_protocol = "tcp"
-    lb_port           = 1098
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1099
-    instance_protocol = "tcp"
-    lb_port           = 1099
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1100
-    instance_protocol = "tcp"
-    lb_port           = 1100
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1101
-    instance_protocol = "tcp"
-    lb_port           = 1101
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1102
-    instance_protocol = "tcp"
-    lb_port           = 1102
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1103
-    instance_protocol = "tcp"
-    lb_port           = 1103
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1104
-    instance_protocol = "tcp"
-    lb_port           = 1104
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1105
-    instance_protocol = "tcp"
-    lb_port           = 1105
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1106
-    instance_protocol = "tcp"
-    lb_port           = 1106
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1107
-    instance_protocol = "tcp"
-    lb_port           = 1107
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1108
-    instance_protocol = "tcp"
-    lb_port           = 1108
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1109
-    instance_protocol = "tcp"
-    lb_port           = 1109
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1110
-    instance_protocol = "tcp"
-    lb_port           = 1110
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1111
-    instance_protocol = "tcp"
-    lb_port           = 1111
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1112
-    instance_protocol = "tcp"
-    lb_port           = 1112
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1113
-    instance_protocol = "tcp"
-    lb_port           = 1113
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1114
-    instance_protocol = "tcp"
-    lb_port           = 1114
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1115
-    instance_protocol = "tcp"
-    lb_port           = 1115
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1116
-    instance_protocol = "tcp"
-    lb_port           = 1116
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1117
-    instance_protocol = "tcp"
-    lb_port           = 1117
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1118
-    instance_protocol = "tcp"
-    lb_port           = 1118
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1119
-    instance_protocol = "tcp"
-    lb_port           = 1119
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1120
-    instance_protocol = "tcp"
-    lb_port           = 1120
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1121
-    instance_protocol = "tcp"
-    lb_port           = 1121
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1122
-    instance_protocol = "tcp"
-    lb_port           = 1122
-    lb_protocol       = "tcp"
-  }
-
-  listener {
-    instance_port     = 1123
-    instance_protocol = "tcp"
-    lb_port           = 1123
-    lb_protocol       = "tcp"
-  }
-
-  security_groups = ["${aws_security_group.cf_tcp_lb_security_group.id}"]
-  subnets         = ["${aws_subnet.lb_subnets.*.id}"]
-
-  tags {
-    Name = "${var.env_id}"
+  dynamic "listener" {
+    for_each = range(1024, 1123)
+    content {
+      instance_port     = listener.value
+      instance_protocol = "tcp"
+      lb_port           = listener.value
+      lb_protocol       = "tcp"
+    }
+  }
+
+  security_groups = [aws_security_group.cf_tcp_lb_security_group.id]
+  subnets         = aws_subnet.lb_subnets.*.id
+
+  tags = {
+    Name = var.env_id
   }
 }
 
 output "cf_tcp_lb_name" {
-  value = "${aws_elb.cf_tcp_lb.name}"
+  value = aws_elb.cf_tcp_lb.name
 }
 
 output "cf_tcp_lb_url" {
-  value = "${aws_elb.cf_tcp_lb.dns_name}"
+  value = aws_elb.cf_tcp_lb.dns_name
 }

--- a/terraform/aws/templates/concourse_lb.tf
+++ b/terraform/aws/templates/concourse_lb.tf
@@ -1,14 +1,14 @@
 resource "aws_security_group" "concourse_lb_internal_security_group" {
   name        = "${var.env_id}-concourse-lb-internal-security-group"
   description = "Concourse Internal"
-  vpc_id      = "${local.vpc_id}"
+  vpc_id      = local.vpc_id
 
-  tags {
+  tags = {
     Name = "${var.env_id}-concourse-lb-internal-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
 }
 
@@ -19,7 +19,7 @@ resource "aws_security_group_rule" "concourse_lb_internal_80" {
   to_port     = 80
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.concourse_lb_internal_security_group.id}"
+  security_group_id = aws_security_group.concourse_lb_internal_security_group.id
 }
 
 resource "aws_security_group_rule" "concourse_lb_internal_2222" {
@@ -29,7 +29,7 @@ resource "aws_security_group_rule" "concourse_lb_internal_2222" {
   to_port     = 2222
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.concourse_lb_internal_security_group.id}"
+  security_group_id = aws_security_group.concourse_lb_internal_security_group.id
 }
 
 resource "aws_security_group_rule" "concourse_lb_internal_443" {
@@ -39,7 +39,7 @@ resource "aws_security_group_rule" "concourse_lb_internal_443" {
   to_port     = 443
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.concourse_lb_internal_security_group.id}"
+  security_group_id = aws_security_group.concourse_lb_internal_security_group.id
 }
 
 resource "aws_security_group_rule" "concourse_lb_internal_egress" {
@@ -49,27 +49,27 @@ resource "aws_security_group_rule" "concourse_lb_internal_egress" {
   to_port     = 0
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.concourse_lb_internal_security_group.id}"
+  security_group_id = aws_security_group.concourse_lb_internal_security_group.id
 }
 
 resource "aws_lb" "concourse_lb" {
   name               = "${var.short_env_id}-concourse-lb"
   load_balancer_type = "network"
-  subnets            = ["${aws_subnet.lb_subnets.*.id}"]
+  subnets            = [aws_subnet.lb_subnets.*.id]
 
-  tags {
-    Name = "${var.env_id}"
+  tags = {
+    Name = var.env_id
   }
 }
 
 resource "aws_lb_listener" "concourse_lb_80" {
-  load_balancer_arn = "${aws_lb.concourse_lb.arn}"
+  load_balancer_arn = aws_lb.concourse_lb.arn
   protocol          = "TCP"
   port              = 80
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.concourse_lb_80.arn}"
+    target_group_arn = aws_lb_target_group.concourse_lb_80.arn
   }
 }
 
@@ -77,7 +77,7 @@ resource "aws_lb_target_group" "concourse_lb_80" {
   name     = "${var.short_env_id}-concourse80"
   port     = 80
   protocol = "TCP"
-  vpc_id   = "${local.vpc_id}"
+  vpc_id   = local.vpc_id
 
   health_check {
     healthy_threshold   = 10
@@ -86,19 +86,19 @@ resource "aws_lb_target_group" "concourse_lb_80" {
     protocol            = "TCP"
   }
 
-  tags {
-    Name = "${var.env_id}"
+  tags = {
+    Name = var.env_id
   }
 }
 
 resource "aws_lb_listener" "concourse_lb_2222" {
-  load_balancer_arn = "${aws_lb.concourse_lb.arn}"
+  load_balancer_arn = aws_lb.concourse_lb.arn
   protocol          = "TCP"
   port              = 2222
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.concourse_lb_2222.arn}"
+    target_group_arn = aws_lb_target_group.concourse_lb_2222.arn
   }
 }
 
@@ -106,21 +106,21 @@ resource "aws_lb_target_group" "concourse_lb_2222" {
   name     = "${var.short_env_id}-concourse2222"
   port     = 2222
   protocol = "TCP"
-  vpc_id   = "${local.vpc_id}"
+  vpc_id   = local.vpc_id
 
-  tags {
-    Name = "${var.env_id}"
+  tags = {
+    Name = var.env_id
   }
 }
 
 resource "aws_lb_listener" "concourse_lb_443" {
-  load_balancer_arn = "${aws_lb.concourse_lb.arn}"
+  load_balancer_arn = aws_lb.concourse_lb.arn
   protocol          = "TCP"
   port              = 443
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.concourse_lb_443.arn}"
+    target_group_arn = aws_lb_target_group.concourse_lb_443.arn
   }
 }
 
@@ -128,10 +128,10 @@ resource "aws_lb_target_group" "concourse_lb_443" {
   name     = "${var.short_env_id}-concourse443"
   port     = 443
   protocol = "TCP"
-  vpc_id   = "${local.vpc_id}"
+  vpc_id   = local.vpc_id
 
-  tags {
-    Name = "${var.env_id}"
+  tags = {
+    Name = var.env_id
   }
 }
 
@@ -142,7 +142,7 @@ resource "aws_security_group_rule" "concourse_lb_internal_8844" {
   to_port     = 8844
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.concourse_lb_internal_security_group.id}"
+  security_group_id = aws_security_group.concourse_lb_internal_security_group.id
 }
 
 resource "aws_security_group_rule" "concourse_lb_internal_8443" {
@@ -152,17 +152,17 @@ resource "aws_security_group_rule" "concourse_lb_internal_8443" {
   to_port     = 8443
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.concourse_lb_internal_security_group.id}"
+  security_group_id = aws_security_group.concourse_lb_internal_security_group.id
 }
 
 resource "aws_lb_listener" "concourse_lb_8844" {
-  load_balancer_arn = "${aws_lb.concourse_lb.arn}"
+  load_balancer_arn = aws_lb.concourse_lb.arn
   protocol          = "TCP"
   port              = 8844
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.concourse_lb_8844.arn}"
+    target_group_arn = aws_lb_target_group.concourse_lb_8844.arn
   }
 }
 
@@ -170,21 +170,21 @@ resource "aws_lb_target_group" "concourse_lb_8844" {
   name     = "${var.short_env_id}-concourse8844"
   port     = 8844
   protocol = "TCP"
-  vpc_id   = "${local.vpc_id}"
+  vpc_id   = local.vpc_id
 
-  tags {
-    Name = "${var.env_id}"
+  tags = {
+    Name = var.env_id
   }
 }
 
 resource "aws_lb_listener" "concourse_lb_8443" {
-  load_balancer_arn = "${aws_lb.concourse_lb.arn}"
+  load_balancer_arn = aws_lb.concourse_lb.arn
   protocol          = "TCP"
   port              = 8443
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.concourse_lb_8443.arn}"
+    target_group_arn = aws_lb_target_group.concourse_lb_8443.arn
   }
 }
 
@@ -192,31 +192,31 @@ resource "aws_lb_target_group" "concourse_lb_8443" {
   name     = "${var.short_env_id}-concourse8443"
   port     = 8443
   protocol = "TCP"
-  vpc_id   = "${local.vpc_id}"
+  vpc_id   = local.vpc_id
 
-  tags {
-    Name = "${var.env_id}"
+  tags = {
+    Name = var.env_id
   }
 }
 
 output "concourse_lb_internal_security_group" {
-  value = "${aws_security_group.concourse_lb_internal_security_group.name}"
+  value = aws_security_group.concourse_lb_internal_security_group.name
 }
 
 output "concourse_lb_target_groups" {
   value = [
-    "${aws_lb_target_group.concourse_lb_80.name}",
-    "${aws_lb_target_group.concourse_lb_443.name}",
-    "${aws_lb_target_group.concourse_lb_2222.name}",
-    "${aws_lb_target_group.concourse_lb_8443.name}",
-    "${aws_lb_target_group.concourse_lb_8844.name}"
+    aws_lb_target_group.concourse_lb_80.name,
+    aws_lb_target_group.concourse_lb_443.name,
+    aws_lb_target_group.concourse_lb_2222.name,
+    aws_lb_target_group.concourse_lb_8443.name,
+    aws_lb_target_group.concourse_lb_8844.name
   ]
 }
 
 output "concourse_lb_name" {
-  value = "${aws_lb.concourse_lb.name}"
+  value = aws_lb.concourse_lb.name
 }
 
 output "concourse_lb_url" {
-  value = "${aws_lb.concourse_lb.dns_name}"
+  value = aws_lb.concourse_lb.dns_name
 }

--- a/terraform/aws/templates/iso_segments.tf
+++ b/terraform/aws/templates/iso_segments.tf
@@ -1,47 +1,47 @@
 variable "isolation_segments" {
-  type        = "string"
-  default     = "0"
+  type        = number
+  default     = 0
   description = "Optionally create a load balancer and DNS entries for a single isolation segment. Valid values are 0 or 1."
 }
 
 variable "iso_to_bosh_ports" {
-  type    = "list"
+  type    = list(number)
   default = [22, 6868, 2555, 4222, 25250]
 }
 
 variable "iso_to_shared_tcp_ports" {
-  type    = "list"
+  type    = list(number)
   default = [9090, 9091, 8082, 8300, 8301, 8889, 8443, 3000, 4443, 8080, 3457, 9023, 9022, 4222]
 }
 
 variable "iso_to_shared_udp_ports" {
-  type    = "list"
+  type    = list(number)
   default = [8301, 8302, 8600]
 }
 
 locals {
-  iso_az_count = "${var.isolation_segments > 0 ? length(var.availability_zones) : 0}"
+  iso_az_count = var.isolation_segments > 0 ? length(var.availability_zones) : 0
 }
 
 resource "aws_subnet" "iso_subnets" {
-  count             = "${local.iso_az_count}"
-  vpc_id            = "${local.vpc_id}"
-  cidr_block        = "${cidrsubnet(var.vpc_cidr, 4, count.index + length(var.availability_zones) + 1)}"
-  availability_zone = "${element(var.availability_zones, count.index)}"
+  count             = local.iso_az_count
+  vpc_id            = local.vpc_id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 4, count.index + length(var.availability_zones) + 1)
+  availability_zone = element(var.availability_zones, count.index)
 
-  tags {
+  tags = {
     Name = "${var.env_id}-iso-subnet${count.index}"
   }
 }
 
 resource "aws_route_table_association" "route_iso_subnets" {
-  count          = "${local.iso_az_count}"
-  subnet_id      = "${element(aws_subnet.iso_subnets.*.id, count.index)}"
-  route_table_id = "${aws_route_table.nated_route_table.id}"
+  count          = local.iso_az_count
+  subnet_id      = element(aws_subnet.iso_subnets.*.id, count.index)
+  route_table_id = aws_route_table.nated_route_table.id
 }
 
 resource "aws_elb" "iso_router_lb" {
-  count = "${var.isolation_segments}"
+  count = var.isolation_segments
 
   name                      = "${var.short_env_id}-iso-router-lb"
   cross_zone_load_balancing = true
@@ -66,7 +66,7 @@ resource "aws_elb" "iso_router_lb" {
     instance_protocol  = "http"
     lb_port            = 443
     lb_protocol        = "https"
-    ssl_certificate_id = "${aws_iam_server_certificate.lb_cert.arn}"
+    ssl_certificate_id = aws_iam_server_certificate.lb_cert.arn
   }
 
   listener {
@@ -74,159 +74,155 @@ resource "aws_elb" "iso_router_lb" {
     instance_protocol  = "tcp"
     lb_port            = 4443
     lb_protocol        = "ssl"
-    ssl_certificate_id = "${aws_iam_server_certificate.lb_cert.arn}"
+    ssl_certificate_id = aws_iam_server_certificate.lb_cert.arn
   }
 
-  security_groups = ["${aws_security_group.cf_router_lb_security_group.id}"]
-  subnets         = ["${aws_subnet.lb_subnets.*.id}"]
+  security_groups = [aws_security_group.cf_router_lb_security_group.id]
+  subnets         = aws_subnet.lb_subnets.*.id
 
-  tags {
-    Name = "${var.env_id}"
+  tags = {
+    Name = var.env_id
   }
 }
 
 resource "aws_lb_target_group" "iso_router_lb_4443" {
-  count    = "${var.isolation_segments}"
+  count    = var.isolation_segments
   name     = "${var.short_env_id}-isotg-4443"
   port     = 4443
   protocol = "TCP"
-  vpc_id   = "${local.vpc_id}"
+  vpc_id   = local.vpc_id
 
   health_check {
     protocol = "TCP"
   }
 
-  tags {
-    Name = "${var.env_id}"
+  tags = {
+    Name = var.env_id
   }
 }
 
 resource "aws_security_group" "iso_security_group" {
-  count = "${var.isolation_segments}"
+  count = var.isolation_segments
 
   name   = "${var.env_id}-iso-sg"
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 
   description = "Private isolation segment"
 
-  tags {
+  tags = {
     Name = "${var.env_id}-iso-security-group"
   }
 }
 
 resource "aws_security_group" "iso_shared_security_group" {
-  count = "${var.isolation_segments}"
+  count = var.isolation_segments
 
   name   = "${var.env_id}-iso-shared-sg"
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 
   description = "Shared isolation segments"
 
-  tags {
+  tags = {
     Name = "${var.env_id}-iso-shared-security-group"
   }
 }
 
 resource "aws_security_group_rule" "isolation_segments_to_bosh_rule" {
-  count = "${var.isolation_segments * length(var.iso_to_bosh_ports)}"
+  count = var.isolation_segments * length(var.iso_to_bosh_ports)
 
   description = "TCP traffic from iso-sg to bosh"
 
-  security_group_id        = "${aws_security_group.bosh_security_group.id}"
+  security_group_id        = aws_security_group.bosh_security_group.id
   type                     = "ingress"
   protocol                 = "tcp"
-  to_port                  = "${element(var.iso_to_bosh_ports, count.index)}"
-  from_port                = "${element(var.iso_to_bosh_ports, count.index)}"
-  source_security_group_id = "${aws_security_group.iso_security_group.id}"
+  to_port                  = element(var.iso_to_bosh_ports, count.index)
+  from_port                = element(var.iso_to_bosh_ports, count.index)
+  source_security_group_id = aws_security_group.iso_security_group[0].id
 }
 
 resource "aws_security_group_rule" "isolation_segments_to_shared_tcp_rule" {
-  count = "${var.isolation_segments * length(var.iso_to_shared_tcp_ports)}"
+  count = var.isolation_segments * length(var.iso_to_shared_tcp_ports)
 
   description = "TCP traffic from iso-sg to iso-shared-sg"
 
-  security_group_id        = "${aws_security_group.iso_shared_security_group.id}"
+  security_group_id        = aws_security_group.iso_shared_security_group[0].id
   type                     = "ingress"
   protocol                 = "tcp"
-  to_port                  = "${element(var.iso_to_shared_tcp_ports, count.index)}"
-  from_port                = "${element(var.iso_to_shared_tcp_ports, count.index)}"
-  source_security_group_id = "${aws_security_group.iso_security_group.id}"
+  to_port                  = element(var.iso_to_shared_tcp_ports, count.index)
+  from_port                = element(var.iso_to_shared_tcp_ports, count.index)
+  source_security_group_id = aws_security_group.iso_security_group[0].id
 }
 
 resource "aws_security_group_rule" "isolation_segments_to_shared_udp_rule" {
-  count = "${var.isolation_segments * length(var.iso_to_shared_udp_ports)}"
+  count = var.isolation_segments * length(var.iso_to_shared_udp_ports)
 
   description = "UDP traffic from iso-sg to iso-shared-sg"
 
-  security_group_id        = "${aws_security_group.iso_shared_security_group.id}"
+  security_group_id        = aws_security_group.iso_shared_security_group[0].id
   type                     = "ingress"
   protocol                 = "udp"
-  to_port                  = "${element(var.iso_to_shared_udp_ports, count.index)}"
-  from_port                = "${element(var.iso_to_shared_udp_ports, count.index)}"
-  source_security_group_id = "${aws_security_group.iso_security_group.id}"
+  to_port                  = element(var.iso_to_shared_udp_ports, count.index)
+  from_port                = element(var.iso_to_shared_udp_ports, count.index)
+  source_security_group_id = aws_security_group.iso_security_group[0].id
 }
 
 resource "aws_security_group_rule" "isolation_segments_to_bosh_all_traffic_rule" {
-  count = "${var.isolation_segments}"
+  count = var.isolation_segments
 
   description = "ALL traffic from iso-sg to bosh"
 
-  depends_on               = ["aws_security_group.bosh_security_group"]
-  security_group_id        = "${aws_security_group.bosh_security_group.id}"
+  depends_on               = [aws_security_group.bosh_security_group]
+  security_group_id        = aws_security_group.bosh_security_group.id
   type                     = "ingress"
   protocol                 = "-1"
   from_port                = 0
   to_port                  = 0
-  source_security_group_id = "${aws_security_group.iso_security_group.id}"
+  source_security_group_id = aws_security_group.iso_security_group[count.index].id
 }
 
 resource "aws_security_group_rule" "shared_diego_bbs_to_isolated_cells_rule" {
-  count = "${var.isolation_segments}"
+  count = var.isolation_segments
 
   description = "TCP traffic from shared diego bbs to iso-sg"
 
-  depends_on               = ["aws_security_group.iso_security_group"]
-  security_group_id        = "${aws_security_group.iso_security_group.id}"
+  depends_on               = [aws_security_group.iso_security_group]
+  security_group_id        = aws_security_group.iso_security_group[count.index].id
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 1801
   to_port                  = 1801
-  source_security_group_id = "${aws_security_group.iso_shared_security_group.id}"
+  source_security_group_id = aws_security_group.iso_shared_security_group[count.index].id
 }
 
 resource "aws_security_group_rule" "nat_to_isolated_cells_rule" {
-  count = "${var.isolation_segments}"
+  count = var.isolation_segments
 
   description = "ALL traffic from nat-sg to iso-sg"
 
-  security_group_id        = "${aws_security_group.nat_security_group.id}"
+  security_group_id        = aws_security_group.nat_security_group.id
   type                     = "ingress"
   protocol                 = "-1"
   from_port                = 0
   to_port                  = 0
-  source_security_group_id = "${aws_security_group.iso_security_group.id}"
+  source_security_group_id = aws_security_group.iso_security_group[count.index].id
 }
 
 output "cf_iso_router_lb_name" {
-  value = "${element(concat(aws_elb.iso_router_lb.*.name, list("")), 0)}"
+  value = element(concat(aws_elb.iso_router_lb.*.name, list("")), 0)
 }
 
 output "iso_security_group_id" {
-  value = "${element(concat(aws_security_group.iso_security_group.*.id, list("")), 0)}"
+  value = element(concat(aws_security_group.iso_security_group.*.id, list("")), 0)
 }
 
 output "iso_az_subnet_id_mapping" {
-  value = "${
-    zipmap("${aws_subnet.iso_subnets.*.availability_zone}", "${aws_subnet.iso_subnets.*.id}")
-  }"
+  value = zipmap(aws_subnet.iso_subnets.*.availability_zone, aws_subnet.iso_subnets.*.id)
 }
 
 output "iso_az_subnet_cidr_mapping" {
-  value = "${
-    zipmap("${aws_subnet.iso_subnets.*.availability_zone}", "${aws_subnet.iso_subnets.*.cidr_block}")
-  }"
+  value = zipmap(aws_subnet.iso_subnets.*.availability_zone, aws_subnet.iso_subnets.*.cidr_block)
 }
 
 output "iso_shared_security_group_id" {
-  value = "${element(concat(aws_security_group.iso_shared_security_group.*.id, list("")), 0)}"
+  value = element(concat(aws_security_group.iso_shared_security_group.*.id, list("")), 0)
 }

--- a/terraform/aws/templates/lb_subnet.tf
+++ b/terraform/aws/templates/lb_subnet.tf
@@ -1,42 +1,42 @@
 resource "aws_subnet" "lb_subnets" {
-  count             = "${length(var.availability_zones)}"
-  vpc_id            = "${local.vpc_id}"
-  cidr_block        = "${cidrsubnet(var.vpc_cidr, 8, count.index+2)}"
-  availability_zone = "${element(var.availability_zones, count.index)}"
+  count             = length(var.availability_zones)
+  vpc_id            = local.vpc_id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index + 2)
+  availability_zone = element(var.availability_zones, count.index)
 
-  tags {
+  tags = {
     Name = "${var.env_id}-lb-subnet${count.index}"
   }
 
   lifecycle {
-    ignore_changes = ["cidr_block", "availability_zone"]
+    ignore_changes = [cidr_block, availability_zone]
   }
 }
 
 resource "aws_route_table" "lb_route_table" {
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 }
 
 resource "aws_route" "lb_route_table" {
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.ig.id}"
-  route_table_id         = "${aws_route_table.lb_route_table.id}"
+  gateway_id             = aws_internet_gateway.ig.id
+  route_table_id         = aws_route_table.lb_route_table.id
 }
 
 resource "aws_route_table_association" "route_lb_subnets" {
-  count          = "${length(var.availability_zones)}"
-  subnet_id      = "${element(aws_subnet.lb_subnets.*.id, count.index)}"
-  route_table_id = "${aws_route_table.lb_route_table.id}"
+  count          = length(var.availability_zones)
+  subnet_id      = element(aws_subnet.lb_subnets.*.id, count.index)
+  route_table_id = aws_route_table.lb_route_table.id
 }
 
 output "lb_subnet_ids" {
-  value = ["${aws_subnet.lb_subnets.*.id}"]
+  value = aws_subnet.lb_subnets.*.id
 }
 
 output "lb_subnet_availability_zones" {
-  value = ["${aws_subnet.lb_subnets.*.availability_zone}"]
+  value = aws_subnet.lb_subnets.*.availability_zone
 }
 
 output "lb_subnet_cidrs" {
-  value = ["${aws_subnet.lb_subnets.*.cidr_block}"]
+  value = aws_subnet.lb_subnets.*.cidr_block
 }

--- a/terraform/aws/templates/ssl_certificate.tf
+++ b/terraform/aws/templates/ssl_certificate.tf
@@ -1,16 +1,16 @@
 variable "ssl_certificate" {
-  type = "string"
+  type = string
 }
 
 variable "ssl_certificate_private_key" {
-  type = "string"
+  type = string
 }
 
 resource "aws_iam_server_certificate" "lb_cert" {
-  name_prefix = "${var.short_env_id}"
+  name_prefix = var.short_env_id
 
-  certificate_body = "${var.ssl_certificate}"
-  private_key      = "${var.ssl_certificate_private_key}"
+  certificate_body = var.ssl_certificate
+  private_key      = var.ssl_certificate_private_key
 
   lifecycle {
     create_before_destroy = true

--- a/terraform/aws/templates/vpc.tf
+++ b/terraform/aws/templates/vpc.tf
@@ -1,21 +1,21 @@
 variable "existing_vpc_id" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Optionally use an existing vpc"
 }
 
 locals {
-  vpc_count = "${length(var.existing_vpc_id) > 0 ? 0 : 1}"
-  vpc_id    = "${length(var.existing_vpc_id) > 0 ? var.existing_vpc_id : join(" ", aws_vpc.vpc.*.id)}"
+  vpc_count = length(var.existing_vpc_id) > 0 ? 0 : 1
+  vpc_id    = length(var.existing_vpc_id) > 0 ? var.existing_vpc_id : join(" ", aws_vpc.vpc.*.id)
 }
 
 resource "aws_vpc" "vpc" {
-  count                = "${local.vpc_count}"
-  cidr_block           = "${var.vpc_cidr}"
+  count                = local.vpc_count
+  cidr_block           = var.vpc_cidr
   instance_tenancy     = "default"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "${var.env_id}-vpc"
   }
 }

--- a/terraform/azure/templates/cf_dns.tf
+++ b/terraform/azure/templates/cf_dns.tf
@@ -1,30 +1,30 @@
 data "azurerm_public_ip" "cf-lb" {
   name                = "${var.env_id}-cf-lb-ip"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
-  depends_on          = ["azurerm_application_gateway.cf"]
+  resource_group_name = azurerm_resource_group.bosh.name
+  depends_on          = [azurerm_application_gateway.cf]
 }
 
 resource "azurerm_dns_zone" "cf" {
-  name                = "${var.system_domain}"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
+  name                = var.system_domain
+  resource_group_name = azurerm_resource_group.bosh.name
 
-  tags {
-    environment = "${var.env_id}"
+  tags = {
+    environment = var.env_id
   }
 }
 
 resource "azurerm_dns_a_record" "cf" {
   name                = "*"
-  zone_name           = "${azurerm_dns_zone.cf.name}"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
+  zone_name           = azurerm_dns_zone.cf.name
+  resource_group_name = azurerm_resource_group.bosh.name
   ttl                 = "300"
-  records             = ["${data.azurerm_public_ip.cf-lb.ip_address}"]
+  records             = [data.azurerm_public_ip.cf-lb.ip_address]
 }
 
 resource "azurerm_dns_a_record" "bosh" {
   name                = "bosh"
-  zone_name           = "${azurerm_dns_zone.cf.name}"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
+  zone_name           = azurerm_dns_zone.cf.name
+  resource_group_name = azurerm_resource_group.bosh.name
   ttl                 = "300"
-  records             = ["${azurerm_public_ip.bosh.ip_address}"]
+  records             = [azurerm_public_ip.bosh.ip_address]
 }

--- a/terraform/azure/templates/cf_lb.tf
+++ b/terraform/azure/templates/cf_lb.tf
@@ -6,18 +6,18 @@ variable "pfx_password" {}
 
 resource "azurerm_subnet" "cf-sn" {
   name                 = "${var.env_id}-cf-sn"
-  address_prefix       = "${cidrsubnet(var.network_cidr, 8, 1)}"
-  resource_group_name  = "${azurerm_resource_group.bosh.name}"
-  virtual_network_name = "${azurerm_virtual_network.bosh.name}"
+  address_prefix       = cidrsubnet(var.network_cidr, 8, 1)
+  resource_group_name  = azurerm_resource_group.bosh.name
+  virtual_network_name = azurerm_virtual_network.bosh.name
 }
 
 resource "azurerm_network_security_group" "cf" {
   name                = "${var.env_id}-cf"
-  location            = "${var.region}"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
+  location            = var.region
+  resource_group_name = azurerm_resource_group.bosh.name
 
-  tags {
-    environment = "${var.env_id}"
+  tags = {
+    environment = var.env_id
   }
 }
 
@@ -31,8 +31,8 @@ resource "azurerm_network_security_rule" "cf-http" {
   destination_port_range      = "80"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${azurerm_resource_group.bosh.name}"
-  network_security_group_name = "${azurerm_network_security_group.cf.name}"
+  resource_group_name         = azurerm_resource_group.bosh.name
+  network_security_group_name = azurerm_network_security_group.cf.name
 }
 
 resource "azurerm_network_security_rule" "cf-https" {
@@ -45,8 +45,8 @@ resource "azurerm_network_security_rule" "cf-https" {
   destination_port_range      = "443"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${azurerm_resource_group.bosh.name}"
-  network_security_group_name = "${azurerm_network_security_group.cf.name}"
+  resource_group_name         = azurerm_resource_group.bosh.name
+  network_security_group_name = azurerm_network_security_group.cf.name
 }
 
 resource "azurerm_network_security_rule" "cf-log" {
@@ -59,21 +59,21 @@ resource "azurerm_network_security_rule" "cf-log" {
   destination_port_range      = "4443"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${azurerm_resource_group.bosh.name}"
-  network_security_group_name = "${azurerm_network_security_group.cf.name}"
+  resource_group_name         = azurerm_resource_group.bosh.name
+  network_security_group_name = azurerm_network_security_group.cf.name
 }
 
 resource "azurerm_public_ip" "cf" {
   name                         = "${var.env_id}-cf-lb-ip"
-  location                     = "${var.region}"
-  resource_group_name          = "${azurerm_resource_group.bosh.name}"
+  location                     = var.region
+  resource_group_name          = azurerm_resource_group.bosh.name
   public_ip_address_allocation = "dynamic"
 }
 
 resource "azurerm_application_gateway" "cf" {
   name                = "${var.env_id}-app-gateway"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
-  location            = "${var.region}"
+  resource_group_name = azurerm_resource_group.bosh.name
+  location            = var.region
 
   sku {
     name     = "Standard_Small"
@@ -113,7 +113,7 @@ resource "azurerm_application_gateway" "cf" {
 
   frontend_ip_configuration {
     name                 = "${var.env_id}-cf-frontend-ip-configuration"
-    public_ip_address_id = "${azurerm_public_ip.cf.id}"
+    public_ip_address_id = azurerm_public_ip.cf.id
   }
 
   backend_address_pool {
@@ -131,8 +131,8 @@ resource "azurerm_application_gateway" "cf" {
 
   ssl_certificate {
     name     = "ssl-cert"
-    data     = "${var.pfx_cert_base64}"
-    password = "${var.pfx_password}"
+    data     = var.pfx_cert_base64
+    password = var.pfx_password
   }
 
   http_listener {
@@ -184,9 +184,9 @@ resource "azurerm_application_gateway" "cf" {
 }
 
 output "cf_app_gateway_name" {
-  value = "${azurerm_application_gateway.cf.name}"
+  value = azurerm_application_gateway.cf.name
 }
 
 output "cf_security_group" {
-  value = "${azurerm_network_security_group.cf.name}"
+  value = azurerm_network_security_group.cf.name
 }

--- a/terraform/azure/templates/concourse_lb.tf
+++ b/terraform/azure/templates/concourse_lb.tf
@@ -1,111 +1,111 @@
 resource "azurerm_public_ip" "concourse" {
   name                         = "${var.env_id}-concourse-lb"
-  location                     = "${var.region}"
-  resource_group_name          = "${azurerm_resource_group.bosh.name}"
+  location                     = var.region
+  resource_group_name          = azurerm_resource_group.bosh.name
   public_ip_address_allocation = "static"
   sku                          = "Standard"
 
-  tags {
+  tags = {
     environment = "${var.env_id}"
   }
 }
 
 resource "azurerm_lb" "concourse" {
   name                = "${var.env_id}-concourse-lb"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
-  location            = "${var.region}"
+  resource_group_name = azurerm_resource_group.bosh.name
+  location            = var.region
   sku                 = "Standard"
 
   frontend_ip_configuration {
     name                 = "${var.env_id}-concourse-frontend-ip-configuration"
-    public_ip_address_id = "${azurerm_public_ip.concourse.id}"
+    public_ip_address_id = azurerm_public_ip.concourse.id
   }
 }
 
 resource "azurerm_lb_rule" "concourse-https" {
   name                = "${var.env_id}-concourse-https"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
-  loadbalancer_id     = "${azurerm_lb.concourse.id}"
+  resource_group_name = azurerm_resource_group.bosh.name
+  loadbalancer_id     = azurerm_lb.concourse.id
 
   frontend_ip_configuration_name = "${var.env_id}-concourse-frontend-ip-configuration"
   protocol                       = "TCP"
   frontend_port                  = 443
   backend_port                   = 443
 
-  backend_address_pool_id = "${azurerm_lb_backend_address_pool.concourse.id}"
-  probe_id                = "${azurerm_lb_probe.concourse-https.id}"
+  backend_address_pool_id = azurerm_lb_backend_address_pool.concourse.id
+  probe_id                = azurerm_lb_probe.concourse-https.id
 }
 
 resource "azurerm_lb_probe" "concourse-https" {
   name                = "${var.env_id}-concourse-https"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
-  loadbalancer_id     = "${azurerm_lb.concourse.id}"
+  resource_group_name = azurerm_resource_group.bosh.name
+  loadbalancer_id     = azurerm_lb.concourse.id
   protocol            = "TCP"
   port                = 443
 }
 
 resource "azurerm_lb_rule" "concourse-http" {
   name                = "${var.env_id}-concourse-http"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
-  loadbalancer_id     = "${azurerm_lb.concourse.id}"
+  resource_group_name = azurerm_resource_group.bosh.name
+  loadbalancer_id     = azurerm_lb.concourse.id
 
   frontend_ip_configuration_name = "${var.env_id}-concourse-frontend-ip-configuration"
   protocol                       = "TCP"
   frontend_port                  = 80
   backend_port                   = 80
 
-  backend_address_pool_id = "${azurerm_lb_backend_address_pool.concourse.id}"
-  probe_id                = "${azurerm_lb_probe.concourse-http.id}"
+  backend_address_pool_id = azurerm_lb_backend_address_pool.concourse.id
+  probe_id                = azurerm_lb_probe.concourse-http.id
 }
 
 resource "azurerm_lb_probe" "concourse-http" {
   name                = "${var.env_id}-concourse-http"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
-  loadbalancer_id     = "${azurerm_lb.concourse.id}"
+  resource_group_name = azurerm_resource_group.bosh.name
+  loadbalancer_id     = azurerm_lb.concourse.id
   protocol            = "TCP"
   port                = 80
 }
 
 resource "azurerm_lb_rule" "concourse-uaa" {
   name                = "${var.env_id}-concourse-uaa"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
-  loadbalancer_id     = "${azurerm_lb.concourse.id}"
+  resource_group_name = azurerm_resource_group.bosh.name
+  loadbalancer_id     = azurerm_lb.concourse.id
 
   frontend_ip_configuration_name = "${var.env_id}-concourse-frontend-ip-configuration"
   protocol                       = "TCP"
   frontend_port                  = 8443
   backend_port                   = 8443
 
-  backend_address_pool_id = "${azurerm_lb_backend_address_pool.concourse.id}"
-  probe_id                = "${azurerm_lb_probe.concourse-uaa.id}"
+  backend_address_pool_id = azurerm_lb_backend_address_pool.concourse.id
+  probe_id                = azurerm_lb_probe.concourse-uaa.id
 }
 
 resource "azurerm_lb_probe" "concourse-uaa" {
   name                = "${var.env_id}-concourse-uaa"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
-  loadbalancer_id     = "${azurerm_lb.concourse.id}"
+  resource_group_name = azurerm_resource_group.bosh.name
+  loadbalancer_id     = azurerm_lb.concourse.id
   protocol            = "TCP"
   port                = 8443
 }
 
 resource "azurerm_lb_rule" "concourse-credhub" {
   name                = "${var.env_id}-concourse-credhub"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
-  loadbalancer_id     = "${azurerm_lb.concourse.id}"
+  resource_group_name = azurerm_resource_group.bosh.name
+  loadbalancer_id     = azurerm_lb.concourse.id
 
   frontend_ip_configuration_name = "${var.env_id}-concourse-frontend-ip-configuration"
   protocol                       = "TCP"
   frontend_port                  = 8844
   backend_port                   = 8844
 
-  backend_address_pool_id = "${azurerm_lb_backend_address_pool.concourse.id}"
-  probe_id                = "${azurerm_lb_probe.concourse-credhub.id}"
+  backend_address_pool_id = azurerm_lb_backend_address_pool.concourse.id
+  probe_id                = azurerm_lb_probe.concourse-credhub.id
 }
 
 resource "azurerm_lb_probe" "concourse-credhub" {
   name                = "${var.env_id}-concourse-credhub"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
-  loadbalancer_id     = "${azurerm_lb.concourse.id}"
+  resource_group_name = azurerm_resource_group.bosh.name
+  loadbalancer_id     = azurerm_lb.concourse.id
   protocol            = "TCP"
   port                = 8844
 }
@@ -120,8 +120,8 @@ resource "azurerm_network_security_rule" "concourse-http" {
   destination_port_range      = "80"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${azurerm_resource_group.bosh.name}"
-  network_security_group_name = "${azurerm_network_security_group.bosh.name}"
+  resource_group_name         = azurerm_resource_group.bosh.name
+  network_security_group_name = azurerm_network_security_group.bosh.name
 }
 
 resource "azurerm_network_security_rule" "concourse-https" {
@@ -134,8 +134,8 @@ resource "azurerm_network_security_rule" "concourse-https" {
   destination_port_range      = "443"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${azurerm_resource_group.bosh.name}"
-  network_security_group_name = "${azurerm_network_security_group.bosh.name}"
+  resource_group_name         = azurerm_resource_group.bosh.name
+  network_security_group_name = azurerm_network_security_group.bosh.name
 }
 
 resource "azurerm_network_security_rule" "concourse-credhub" {
@@ -148,8 +148,8 @@ resource "azurerm_network_security_rule" "concourse-credhub" {
   destination_port_range      = "8844"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${azurerm_resource_group.bosh.name}"
-  network_security_group_name = "${azurerm_network_security_group.bosh.name}"
+  resource_group_name         = azurerm_resource_group.bosh.name
+  network_security_group_name = azurerm_network_security_group.bosh.name
 }
 
 resource "azurerm_network_security_rule" "uaa" {
@@ -162,20 +162,20 @@ resource "azurerm_network_security_rule" "uaa" {
   destination_port_range      = "8443"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${azurerm_resource_group.bosh.name}"
-  network_security_group_name = "${azurerm_network_security_group.bosh.name}"
+  resource_group_name         = azurerm_resource_group.bosh.name
+  network_security_group_name = azurerm_network_security_group.bosh.name
 }
 
 resource "azurerm_lb_backend_address_pool" "concourse" {
   name                = "${var.env_id}-concourse-backend-pool"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
-  loadbalancer_id     = "${azurerm_lb.concourse.id}"
+  resource_group_name = azurerm_resource_group.bosh.name
+  loadbalancer_id     = azurerm_lb.concourse.id
 }
 
 output "concourse_lb_name" {
-  value = "${azurerm_lb.concourse.name}"
+  value = azurerm_lb.concourse.name
 }
 
 output "concourse_lb_ip" {
-  value = "${azurerm_public_ip.concourse.ip_address}"
+  value = azurerm_public_ip.concourse.ip_address
 }

--- a/terraform/azure/templates/network.tf
+++ b/terraform/azure/templates/network.tf
@@ -1,13 +1,13 @@
 resource "azurerm_virtual_network" "bosh" {
   name                = "${var.env_id}-bosh-vn"
-  address_space       = ["${var.network_cidr}"]
-  location            = "${var.region}"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
+  address_space       = [var.network_cidr]
+  location            = var.region
+  resource_group_name = azurerm_resource_group.bosh.name
 }
 
 resource "azurerm_subnet" "bosh" {
   name                 = "${var.env_id}-bosh-sn"
-  address_prefix       = "${cidrsubnet(var.network_cidr, 8, 0)}"
-  resource_group_name  = "${azurerm_resource_group.bosh.name}"
-  virtual_network_name = "${azurerm_virtual_network.bosh.name}"
+  address_prefix       = cidrsubnet(var.network_cidr, 8, 0)
+  resource_group_name  = azurerm_resource_group.bosh.name
+  virtual_network_name = azurerm_virtual_network.bosh.name
 }

--- a/terraform/azure/templates/network_security_group.tf
+++ b/terraform/azure/templates/network_security_group.tf
@@ -1,10 +1,10 @@
 resource "azurerm_network_security_group" "bosh" {
   name                = "${var.env_id}-bosh"
-  location            = "${var.region}"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
+  location            = var.region
+  resource_group_name = azurerm_resource_group.bosh.name
 
-  tags {
-    environment = "${var.env_id}"
+  tags = {
+    environment = var.env_id
   }
 }
 
@@ -18,8 +18,8 @@ resource "azurerm_network_security_rule" "ssh" {
   destination_port_range      = "22"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${azurerm_resource_group.bosh.name}"
-  network_security_group_name = "${azurerm_network_security_group.bosh.name}"
+  resource_group_name         = azurerm_resource_group.bosh.name
+  network_security_group_name = azurerm_network_security_group.bosh.name
 }
 
 resource "azurerm_network_security_rule" "bosh-agent" {
@@ -32,8 +32,8 @@ resource "azurerm_network_security_rule" "bosh-agent" {
   destination_port_range      = "6868"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${azurerm_resource_group.bosh.name}"
-  network_security_group_name = "${azurerm_network_security_group.bosh.name}"
+  resource_group_name         = azurerm_resource_group.bosh.name
+  network_security_group_name = azurerm_network_security_group.bosh.name
 }
 
 resource "azurerm_network_security_rule" "bosh-director" {
@@ -46,8 +46,8 @@ resource "azurerm_network_security_rule" "bosh-director" {
   destination_port_range      = "25555"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${azurerm_resource_group.bosh.name}"
-  network_security_group_name = "${azurerm_network_security_group.bosh.name}"
+  resource_group_name         = azurerm_resource_group.bosh.name
+  network_security_group_name = azurerm_network_security_group.bosh.name
 }
 
 resource "azurerm_network_security_rule" "dns" {
@@ -60,8 +60,8 @@ resource "azurerm_network_security_rule" "dns" {
   destination_port_range      = "53"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${azurerm_resource_group.bosh.name}"
-  network_security_group_name = "${azurerm_network_security_group.bosh.name}"
+  resource_group_name         = azurerm_resource_group.bosh.name
+  network_security_group_name = azurerm_network_security_group.bosh.name
 }
 
 resource "azurerm_network_security_rule" "credhub" {
@@ -74,6 +74,6 @@ resource "azurerm_network_security_rule" "credhub" {
   destination_port_range      = "8844"
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
-  resource_group_name         = "${azurerm_resource_group.bosh.name}"
-  network_security_group_name = "${azurerm_network_security_group.bosh.name}"
+  resource_group_name         = azurerm_resource_group.bosh.name
+  network_security_group_name = azurerm_network_security_group.bosh.name
 }

--- a/terraform/azure/templates/output.tf
+++ b/terraform/azure/templates/output.tf
@@ -1,25 +1,25 @@
 output "vnet_name" {
-  value = "${azurerm_virtual_network.bosh.name}"
+  value = azurerm_virtual_network.bosh.name
 }
 
 output "subnet_name" {
-  value = "${azurerm_subnet.bosh.name}"
+  value = azurerm_subnet.bosh.name
 }
 
 output "resource_group_name" {
-  value = "${azurerm_resource_group.bosh.name}"
+  value = azurerm_resource_group.bosh.name
 }
 
 output "storage_account_name" {
-  value = "${azurerm_storage_account.bosh.name}"
+  value = azurerm_storage_account.bosh.name
 }
 
 output "default_security_group" {
-  value = "${azurerm_network_security_group.bosh.name}"
+  value = azurerm_network_security_group.bosh.name
 }
 
 output "external_ip" {
-  value = "${azurerm_public_ip.bosh.ip_address}"
+  value = azurerm_public_ip.bosh.ip_address
 }
 
 output "director_address" {
@@ -27,12 +27,12 @@ output "director_address" {
 }
 
 output "private_key" {
-  value     = "${tls_private_key.bosh_vms.private_key_pem}"
+  value     = tls_private_key.bosh_vms.private_key_pem
   sensitive = true
 }
 
 output "public_key" {
-  value     = "${tls_private_key.bosh_vms.public_key_openssh}"
+  value     = tls_private_key.bosh_vms.public_key_openssh
   sensitive = false
 }
 
@@ -41,7 +41,7 @@ output "jumpbox_url" {
 }
 
 output "network_cidr" {
-  value = "${var.network_cidr}"
+  value = var.network_cidr
 }
 
 output "director_name" {
@@ -49,21 +49,21 @@ output "director_name" {
 }
 
 output "internal_cidr" {
-  value = "${var.internal_cidr}"
+  value = var.internal_cidr
 }
 
 output "subnet_cidr" {
-  value = "${cidrsubnet(var.network_cidr, 8, 0)}"
+  value = cidrsubnet(var.network_cidr, 8, 0)
 }
 
 output "internal_gw" {
-  value = "${cidrhost(var.internal_cidr, 1)}"
+  value = cidrhost(var.internal_cidr, 1)
 }
 
 output "jumpbox__internal_ip" {
-  value = "${cidrhost(var.internal_cidr, 5)}"
+  value = cidrhost(var.internal_cidr, 5)
 }
 
 output "director__internal_ip" {
-  value = "${cidrhost(var.internal_cidr, 6)}"
+  value = cidrhost(var.internal_cidr, 6)
 }

--- a/terraform/azure/templates/resource_group.tf
+++ b/terraform/azure/templates/resource_group.tf
@@ -1,19 +1,19 @@
 resource "azurerm_resource_group" "bosh" {
   name     = "${var.env_id}-bosh"
-  location = "${var.region}"
+  location = var.region
 
-  tags {
-    environment = "${var.env_id}"
+  tags = {
+    environment = var.env_id
   }
 }
 
 resource "azurerm_public_ip" "bosh" {
   name                         = "${var.env_id}-bosh"
-  location                     = "${var.region}"
-  resource_group_name          = "${azurerm_resource_group.bosh.name}"
+  location                     = var.region
+  resource_group_name          = azurerm_resource_group.bosh.name
   public_ip_address_allocation = "static"
 
-  tags {
-    environment = "${var.env_id}"
+  tags = {
+    environment = var.env_id
   }
 }

--- a/terraform/azure/templates/storage.tf
+++ b/terraform/azure/templates/storage.tf
@@ -6,14 +6,14 @@ resource "random_string" "account" {
 
 resource "azurerm_storage_account" "bosh" {
   name                = "${var.simple_env_id}${random_string.account.result}"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
+  resource_group_name = azurerm_resource_group.bosh.name
 
-  location                 = "${var.region}"
+  location                 = var.region
   account_tier             = "Standard"
   account_replication_type = "GRS"
 
-  tags {
-    environment = "${var.env_id}"
+  tags = {
+    environment = var.env_id
   }
 
   lifecycle {
@@ -23,14 +23,14 @@ resource "azurerm_storage_account" "bosh" {
 
 resource "azurerm_storage_container" "bosh" {
   name                  = "bosh"
-  resource_group_name   = "${azurerm_resource_group.bosh.name}"
-  storage_account_name  = "${azurerm_storage_account.bosh.name}"
+  resource_group_name   = azurerm_resource_group.bosh.name
+  storage_account_name  = azurerm_storage_account.bosh.name
   container_access_type = "private"
 }
 
 resource "azurerm_storage_container" "stemcell" {
   name                  = "stemcell"
-  resource_group_name   = "${azurerm_resource_group.bosh.name}"
-  storage_account_name  = "${azurerm_storage_account.bosh.name}"
+  resource_group_name   = azurerm_resource_group.bosh.name
+  storage_account_name  = azurerm_storage_account.bosh.name
   container_access_type = "blob"
 }

--- a/terraform/azure/templates/vars.tf
+++ b/terraform/azure/templates/vars.tf
@@ -26,11 +26,11 @@ provider "azurerm" {
   client_id       = "${var.client_id}"
   client_secret   = "${var.client_secret}"
 
-  version = "~> 1.22"
+  version = "~> 2.0"
 }
 
 provider "tls" {
-  version = "~> 1.2"
+  version = "~> 2.1"
 }
 
 provider "random" {

--- a/terraform/executor.go
+++ b/terraform/executor.go
@@ -29,7 +29,7 @@ type Executor struct {
 
 type tfOutput struct {
 	Sensitive bool
-	Type      string
+	Type      interface{}
 	Value     interface{}
 }
 

--- a/terraform/executor_test.go
+++ b/terraform/executor_test.go
@@ -606,6 +606,19 @@ var _ = Describe("Executor", func() {
 						"type": "string",
 						"value": "some-director-address"
 					},
+					"env_dns_zone_name_servers": {
+						"sensitive": false,
+						"type": [
+						  "list",
+						  "string"
+						],
+						"value": [
+						  "ns-server-1",
+						  "ns-server-2",
+						  "ns-server-3",
+						  "ns-server-4"
+						]
+					},
 					"external_ip": {
 						"sensitive": false,
 						"type": "string",
@@ -620,8 +633,9 @@ var _ = Describe("Executor", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(outputs).To(Equal(map[string]interface{}{
-				"director_address": "some-director-address",
-				"external_ip":      "some-external-ip",
+				"director_address":          "some-director-address",
+				"env_dns_zone_name_servers": []interface{}{"ns-server-1", "ns-server-2", "ns-server-3", "ns-server-4"},
+				"external_ip":               "some-external-ip",
 			}))
 
 			Expect(bufferingCLI.RunCall.Receives.WorkingDirectory).To(Equal(terraformDir))

--- a/terraform/gcp/template_generator.go
+++ b/terraform/gcp/template_generator.go
@@ -63,14 +63,14 @@ func (t TemplateGenerator) GenerateBackendService(zoneList []string) string {
   timeout_sec = 900
   enable_cdn  = false
 %s
-  health_checks = ["${google_compute_health_check.cf-public-health-check.self_link}"]
+  health_checks = [google_compute_health_check.cf-public-health-check.self_link]
 }
 `
 	var backends string
 	for i := 0; i < len(zoneList); i++ {
 		backends = fmt.Sprintf(`%s
   backend {
-    group = "${google_compute_instance_group.router-lb-%d.self_link}"
+    group = google_compute_instance_group.router-lb-%d.self_link
   }
 `, backends, i)
 	}

--- a/terraform/gcp/template_generator_test.go
+++ b/terraform/gcp/template_generator_test.go
@@ -67,14 +67,14 @@ resource "google_compute_instance_group" "router-lb-2" {
   enable_cdn  = false
 
   backend {
-    group = "${google_compute_instance_group.router-lb-0.self_link}"
+    group = google_compute_instance_group.router-lb-0.self_link
   }
 
   backend {
-    group = "${google_compute_instance_group.router-lb-1.self_link}"
+    group = google_compute_instance_group.router-lb-1.self_link
   }
 
-  health_checks = ["${google_compute_health_check.cf-public-health-check.self_link}"]
+  health_checks = [google_compute_health_check.cf-public-health-check.self_link]
 }
 `
 	})

--- a/terraform/gcp/templates/bosh_director.tf
+++ b/terraform/gcp/templates/bosh_director.tf
@@ -1,5 +1,5 @@
 variable "subnet_cidr" {
-  type    = "string"
+  type    = string
   default = "10.0.0.0/16"
 }
 
@@ -10,13 +10,13 @@ resource "google_compute_network" "bbl-network" {
 
 resource "google_compute_subnetwork" "bbl-subnet" {
   name          = "${var.env_id}-subnet"
-  ip_cidr_range = "${var.subnet_cidr}"
-  network       = "${google_compute_network.bbl-network.self_link}"
+  ip_cidr_range = var.subnet_cidr
+  network       = google_compute_network.bbl-network.self_link
 }
 
 resource "google_compute_firewall" "external" {
   name    = "${var.env_id}-external"
-  network = "${google_compute_network.bbl-network.name}"
+  network = google_compute_network.bbl-network.name
 
   source_ranges = ["0.0.0.0/0"]
 
@@ -30,7 +30,7 @@ resource "google_compute_firewall" "external" {
 
 resource "google_compute_firewall" "bosh-open" {
   name    = "${var.env_id}-bosh-open"
-  network = "${google_compute_network.bbl-network.name}"
+  network = google_compute_network.bbl-network.name
 
   source_tags = ["${var.env_id}-bosh-open"]
 
@@ -44,7 +44,7 @@ resource "google_compute_firewall" "bosh-open" {
 
 resource "google_compute_firewall" "bosh-director" {
   name    = "${var.env_id}-bosh-director"
-  network = "${google_compute_network.bbl-network.name}"
+  network = google_compute_network.bbl-network.name
 
   source_tags = ["${var.env_id}-bosh-director"]
 
@@ -57,7 +57,7 @@ resource "google_compute_firewall" "bosh-director" {
 
 resource "google_compute_firewall" "internal-to-director" {
   name    = "${var.env_id}-internal-to-director"
-  network = "${google_compute_network.bbl-network.name}"
+  network = google_compute_network.bbl-network.name
 
   source_tags = ["${var.env_id}-internal"]
 
@@ -71,7 +71,7 @@ resource "google_compute_firewall" "internal-to-director" {
 
 resource "google_compute_firewall" "jumpbox-to-all" {
   name    = "${var.env_id}-jumpbox-to-all"
-  network = "${google_compute_network.bbl-network.name}"
+  network = google_compute_network.bbl-network.name
 
   source_tags = ["${var.env_id}-jumpbox"]
 
@@ -85,7 +85,7 @@ resource "google_compute_firewall" "jumpbox-to-all" {
 
 resource "google_compute_firewall" "internal" {
   name    = "${var.env_id}-internal"
-  network = "${google_compute_network.bbl-network.name}"
+  network = google_compute_network.bbl-network.name
 
   source_tags = ["${var.env_id}-internal"]
 
@@ -105,19 +105,19 @@ resource "google_compute_firewall" "internal" {
 }
 
 output "network" {
-  value = "${google_compute_network.bbl-network.name}"
+  value = google_compute_network.bbl-network.name
 }
 
 output "subnetwork" {
-  value = "${google_compute_subnetwork.bbl-subnet.name}"
+  value = google_compute_subnetwork.bbl-subnet.name
 }
 
 output "internal_cidr" {
-  value = "${var.subnet_cidr}"
+  value = var.subnet_cidr
 }
 
 output "internal_gw" {
-  value = "${google_compute_subnetwork.bbl-subnet.gateway_address}"
+  value = google_compute_subnetwork.bbl-subnet.gateway_address
 }
 
 output "director_name" {
@@ -125,24 +125,24 @@ output "director_name" {
 }
 
 output "jumpbox__internal_ip" {
-  value = "${cidrhost(var.subnet_cidr, 5)}"
+  value = cidrhost(var.subnet_cidr, 5)
 }
 
 output "director__internal_ip" {
-  value = "${cidrhost(var.subnet_cidr, 6)}"
+  value = cidrhost(var.subnet_cidr, 6)
 }
 
 output "jumpbox__tags" {
   value = [
-    "${google_compute_firewall.bosh-open.name}",
+    google_compute_firewall.bosh-open.name,
     "${var.env_id}-jumpbox",
   ]
 }
 
 output "director__tags" {
-  value = ["${google_compute_firewall.bosh-director.name}"]
+  value = [google_compute_firewall.bosh-director.name]
 }
 
 output "internal_tag_name" {
-  value = "${google_compute_firewall.internal.name}"
+  value = google_compute_firewall.internal.name
 }

--- a/terraform/gcp/templates/cf_dns.tf
+++ b/terraform/gcp/templates/cf_dns.tf
@@ -1,5 +1,5 @@
 variable "system_domain" {
-  type = "string"
+  type = string
 }
 
 resource "google_dns_managed_zone" "env_dns_zone" {
@@ -9,82 +9,82 @@ resource "google_dns_managed_zone" "env_dns_zone" {
 }
 
 output "system_domain_dns_servers" {
-  value = "${google_dns_managed_zone.env_dns_zone.name_servers}"
+  value = google_dns_managed_zone.env_dns_zone.name_servers
 }
 
 resource "google_dns_record_set" "wildcard-dns" {
   name       = "*.${google_dns_managed_zone.env_dns_zone.dns_name}"
-  depends_on = ["google_compute_global_address.cf-address"]
+  depends_on = [google_compute_global_address.cf-address]
   type       = "A"
   ttl        = 300
 
-  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+  managed_zone = google_dns_managed_zone.env_dns_zone.name
 
-  rrdatas = ["${google_compute_global_address.cf-address.address}"]
+  rrdatas = [google_compute_global_address.cf-address.address]
 }
 
 resource "google_dns_record_set" "bosh-dns" {
   name       = "bosh.${google_dns_managed_zone.env_dns_zone.dns_name}"
-  depends_on = ["google_compute_address.jumpbox-ip"]
+  depends_on = [google_compute_address.jumpbox-ip]
   type       = "A"
   ttl        = 300
 
-  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+  managed_zone = google_dns_managed_zone.env_dns_zone.name
 
-  rrdatas = ["${google_compute_address.jumpbox-ip.address}"]
+  rrdatas = [google_compute_address.jumpbox-ip.address]
 }
 
 resource "google_dns_record_set" "cf-ssh-proxy" {
   name       = "ssh.${google_dns_managed_zone.env_dns_zone.dns_name}"
-  depends_on = ["google_compute_address.cf-ssh-proxy"]
+  depends_on = [google_compute_address.cf-ssh-proxy]
   type       = "A"
   ttl        = 300
 
-  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+  managed_zone = google_dns_managed_zone.env_dns_zone.name
 
-  rrdatas = ["${google_compute_address.cf-ssh-proxy.address}"]
+  rrdatas = [google_compute_address.cf-ssh-proxy.address]
 }
 
 resource "google_dns_record_set" "tcp-dns" {
   name       = "tcp.${google_dns_managed_zone.env_dns_zone.dns_name}"
-  depends_on = ["google_compute_address.cf-tcp-router"]
+  depends_on = [google_compute_address.cf-tcp-router]
   type       = "A"
   ttl        = 300
 
-  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+  managed_zone = google_dns_managed_zone.env_dns_zone.name
 
-  rrdatas = ["${google_compute_address.cf-tcp-router.address}"]
+  rrdatas = [google_compute_address.cf-tcp-router.address]
 }
 
 resource "google_dns_record_set" "doppler-dns" {
   name       = "doppler.${google_dns_managed_zone.env_dns_zone.dns_name}"
-  depends_on = ["google_compute_address.cf-ws"]
+  depends_on = [google_compute_address.cf-ws]
   type       = "A"
   ttl        = 300
 
-  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+  managed_zone = google_dns_managed_zone.env_dns_zone.name
 
-  rrdatas = ["${google_compute_address.cf-ws.address}"]
+  rrdatas = [google_compute_address.cf-ws.address]
 }
 
 resource "google_dns_record_set" "loggregator-dns" {
   name       = "loggregator.${google_dns_managed_zone.env_dns_zone.dns_name}"
-  depends_on = ["google_compute_address.cf-ws"]
+  depends_on = [google_compute_address.cf-ws]
   type       = "A"
   ttl        = 300
 
-  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+  managed_zone = google_dns_managed_zone.env_dns_zone.name
 
-  rrdatas = ["${google_compute_address.cf-ws.address}"]
+  rrdatas = [google_compute_address.cf-ws.address]
 }
 
 resource "google_dns_record_set" "wildcard-ws-dns" {
   name       = "*.ws.${google_dns_managed_zone.env_dns_zone.dns_name}"
-  depends_on = ["google_compute_address.cf-ws"]
+  depends_on = [google_compute_address.cf-ws]
   type       = "A"
   ttl        = 300
 
-  managed_zone = "${google_dns_managed_zone.env_dns_zone.name}"
+  managed_zone = google_dns_managed_zone.env_dns_zone.name
 
-  rrdatas = ["${google_compute_address.cf-ws.address}"]
+  rrdatas = [google_compute_address.cf-ws.address]
 }

--- a/terraform/gcp/templates/cf_lb.tf
+++ b/terraform/gcp/templates/cf_lb.tf
@@ -1,35 +1,35 @@
 variable "ssl_certificate" {
-  type = "string"
+  type = string
 }
 
 variable "ssl_certificate_private_key" {
-  type = "string"
+  type = string
 }
 
 output "router_backend_service" {
-  value = "${google_compute_backend_service.router-lb-backend-service.name}"
+  value = google_compute_backend_service.router-lb-backend-service.name
 }
 
 output "router_lb_ip" {
-  value = "${google_compute_global_address.cf-address.address}"
+  value = google_compute_global_address.cf-address.address
 }
 
 output "ssh_proxy_lb_ip" {
-  value = "${google_compute_address.cf-ssh-proxy.address}"
+  value = google_compute_address.cf-ssh-proxy.address
 }
 
 output "tcp_router_lb_ip" {
-  value = "${google_compute_address.cf-tcp-router.address}"
+  value = google_compute_address.cf-tcp-router.address
 }
 
 output "ws_lb_ip" {
-  value = "${google_compute_address.cf-ws.address}"
+  value = google_compute_address.cf-ws.address
 }
 
 resource "google_compute_firewall" "firewall-cf" {
   name       = "${var.env_id}-cf-open"
-  depends_on = ["google_compute_network.bbl-network"]
-  network    = "${google_compute_network.bbl-network.name}"
+  depends_on = [google_compute_network.bbl-network]
+  network    = google_compute_network.bbl-network.name
 
   allow {
     protocol = "tcp"
@@ -38,7 +38,7 @@ resource "google_compute_firewall" "firewall-cf" {
 
   source_ranges = ["0.0.0.0/0"]
 
-  target_tags = ["${google_compute_backend_service.router-lb-backend-service.name}"]
+  target_tags = [google_compute_backend_service.router-lb-backend-service.name]
 }
 
 resource "google_compute_global_address" "cf-address" {
@@ -47,36 +47,36 @@ resource "google_compute_global_address" "cf-address" {
 
 resource "google_compute_global_forwarding_rule" "cf-http-forwarding-rule" {
   name       = "${var.env_id}-cf-http"
-  ip_address = "${google_compute_global_address.cf-address.address}"
-  target     = "${google_compute_target_http_proxy.cf-http-lb-proxy.self_link}"
+  ip_address = google_compute_global_address.cf-address.address
+  target     = google_compute_target_http_proxy.cf-http-lb-proxy.self_link
   port_range = "80"
 }
 
 resource "google_compute_global_forwarding_rule" "cf-https-forwarding-rule" {
   name       = "${var.env_id}-cf-https"
-  ip_address = "${google_compute_global_address.cf-address.address}"
-  target     = "${google_compute_target_https_proxy.cf-https-lb-proxy.self_link}"
+  ip_address = google_compute_global_address.cf-address.address
+  target     = google_compute_target_https_proxy.cf-https-lb-proxy.self_link
   port_range = "443"
 }
 
 resource "google_compute_target_http_proxy" "cf-http-lb-proxy" {
   name        = "${var.env_id}-http-proxy"
   description = "really a load balancer but listed as an http proxy"
-  url_map     = "${google_compute_url_map.cf-https-lb-url-map.self_link}"
+  url_map     = google_compute_url_map.cf-https-lb-url-map.self_link
 }
 
 resource "google_compute_target_https_proxy" "cf-https-lb-proxy" {
   name             = "${var.env_id}-https-proxy"
   description      = "really a load balancer but listed as an https proxy"
-  url_map          = "${google_compute_url_map.cf-https-lb-url-map.self_link}"
-  ssl_certificates = ["${google_compute_ssl_certificate.cf-cert.self_link}"]
+  url_map          = google_compute_url_map.cf-https-lb-url-map.self_link
+  ssl_certificates = [google_compute_ssl_certificate.cf-cert.self_link]
 }
 
 resource "google_compute_ssl_certificate" "cf-cert" {
-  name_prefix = "${var.env_id}"
+  name_prefix = var.env_id
   description = "user provided ssl private key / ssl certificate pair"
-  private_key = "${var.ssl_certificate_private_key}"
-  certificate = "${var.ssl_certificate}"
+  private_key = var.ssl_certificate_private_key
+  certificate = var.ssl_certificate
 
   lifecycle {
     create_before_destroy = true
@@ -86,7 +86,7 @@ resource "google_compute_ssl_certificate" "cf-cert" {
 resource "google_compute_url_map" "cf-https-lb-url-map" {
   name = "${var.env_id}-cf-http"
 
-  default_service = "${google_compute_backend_service.router-lb-backend-service.self_link}"
+  default_service = google_compute_backend_service.router-lb-backend-service.self_link
 }
 
 resource "google_compute_health_check" "cf-public-health-check" {
@@ -106,8 +106,8 @@ resource "google_compute_http_health_check" "cf-public-health-check" {
 
 resource "google_compute_firewall" "cf-health-check" {
   name       = "${var.env_id}-cf-health-check"
-  depends_on = ["google_compute_network.bbl-network"]
-  network    = "${google_compute_network.bbl-network.name}"
+  depends_on = [google_compute_network.bbl-network]
+  network    = google_compute_network.bbl-network.name
 
   allow {
     protocol = "tcp"
@@ -115,11 +115,11 @@ resource "google_compute_firewall" "cf-health-check" {
   }
 
   source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
-  target_tags   = ["${google_compute_backend_service.router-lb-backend-service.name}"]
+  target_tags   = [google_compute_backend_service.router-lb-backend-service.name]
 }
 
 output "ssh_proxy_target_pool" {
-  value = "${google_compute_target_pool.cf-ssh-proxy.name}"
+  value = google_compute_target_pool.cf-ssh-proxy.name
 }
 
 resource "google_compute_address" "cf-ssh-proxy" {
@@ -128,15 +128,15 @@ resource "google_compute_address" "cf-ssh-proxy" {
 
 resource "google_compute_firewall" "cf-ssh-proxy" {
   name       = "${var.env_id}-cf-ssh-proxy-open"
-  depends_on = ["google_compute_network.bbl-network"]
-  network    = "${google_compute_network.bbl-network.name}"
+  depends_on = [google_compute_network.bbl-network]
+  network    = google_compute_network.bbl-network.name
 
   allow {
     protocol = "tcp"
     ports    = ["2222"]
   }
 
-  target_tags = ["${google_compute_target_pool.cf-ssh-proxy.name}"]
+  target_tags = [google_compute_target_pool.cf-ssh-proxy.name]
 }
 
 resource "google_compute_target_pool" "cf-ssh-proxy" {
@@ -147,27 +147,27 @@ resource "google_compute_target_pool" "cf-ssh-proxy" {
 
 resource "google_compute_forwarding_rule" "cf-ssh-proxy" {
   name        = "${var.env_id}-cf-ssh-proxy"
-  target      = "${google_compute_target_pool.cf-ssh-proxy.self_link}"
+  target      = google_compute_target_pool.cf-ssh-proxy.self_link
   port_range  = "2222"
   ip_protocol = "TCP"
-  ip_address  = "${google_compute_address.cf-ssh-proxy.address}"
+  ip_address  = google_compute_address.cf-ssh-proxy.address
 }
 
 output "tcp_router_target_pool" {
-  value = "${google_compute_target_pool.cf-tcp-router.name}"
+  value = google_compute_target_pool.cf-tcp-router.name
 }
 
 resource "google_compute_firewall" "cf-tcp-router" {
   name       = "${var.env_id}-cf-tcp-router"
-  depends_on = ["google_compute_network.bbl-network"]
-  network    = "${google_compute_network.bbl-network.name}"
+  depends_on = [google_compute_network.bbl-network]
+  network    = google_compute_network.bbl-network.name
 
   allow {
     protocol = "tcp"
     ports    = ["1024-32768"]
   }
 
-  target_tags = ["${google_compute_target_pool.cf-tcp-router.name}"]
+  target_tags = [google_compute_target_pool.cf-tcp-router.name]
 }
 
 resource "google_compute_address" "cf-tcp-router" {
@@ -186,20 +186,20 @@ resource "google_compute_target_pool" "cf-tcp-router" {
   session_affinity = "NONE"
 
   health_checks = [
-    "${google_compute_http_health_check.cf-tcp-router.name}",
+    google_compute_http_health_check.cf-tcp-router.name,
   ]
 }
 
 resource "google_compute_forwarding_rule" "cf-tcp-router" {
   name        = "${var.env_id}-cf-tcp-router"
-  target      = "${google_compute_target_pool.cf-tcp-router.self_link}"
+  target      = google_compute_target_pool.cf-tcp-router.self_link
   port_range  = "1024-32768"
   ip_protocol = "TCP"
-  ip_address  = "${google_compute_address.cf-tcp-router.address}"
+  ip_address  = google_compute_address.cf-tcp-router.address
 }
 
 output "ws_target_pool" {
-  value = "${google_compute_target_pool.cf-ws.name}"
+  value = google_compute_target_pool.cf-ws.name
 }
 
 resource "google_compute_address" "cf-ws" {
@@ -211,21 +211,21 @@ resource "google_compute_target_pool" "cf-ws" {
 
   session_affinity = "NONE"
 
-  health_checks = ["${google_compute_http_health_check.cf-public-health-check.name}"]
+  health_checks = [google_compute_http_health_check.cf-public-health-check.name]
 }
 
 resource "google_compute_forwarding_rule" "cf-ws-https" {
   name        = "${var.env_id}-cf-ws-https"
-  target      = "${google_compute_target_pool.cf-ws.self_link}"
+  target      = google_compute_target_pool.cf-ws.self_link
   port_range  = "443"
   ip_protocol = "TCP"
-  ip_address  = "${google_compute_address.cf-ws.address}"
+  ip_address  = google_compute_address.cf-ws.address
 }
 
 resource "google_compute_forwarding_rule" "cf-ws-http" {
   name        = "${var.env_id}-cf-ws-http"
-  target      = "${google_compute_target_pool.cf-ws.self_link}"
+  target      = google_compute_target_pool.cf-ws.self_link
   port_range  = "80"
   ip_protocol = "TCP"
-  ip_address  = "${google_compute_address.cf-ws.address}"
+  ip_address  = google_compute_address.cf-ws.address
 }

--- a/terraform/gcp/templates/concourse_lb.tf
+++ b/terraform/gcp/templates/concourse_lb.tf
@@ -1,14 +1,14 @@
 output "concourse_target_pool" {
-  value = "${google_compute_target_pool.target-pool.name}"
+  value = google_compute_target_pool.target-pool.name
 }
 
 output "concourse_lb_ip" {
-  value = "${google_compute_address.concourse-address.address}"
+  value = google_compute_address.concourse-address.address
 }
 
 resource "google_compute_firewall" "firewall-concourse" {
   name    = "${var.env_id}-concourse-open"
-  network = "${google_compute_network.bbl-network.name}"
+  network = google_compute_network.bbl-network.name
 
   allow {
     protocol = "tcp"
@@ -30,40 +30,40 @@ resource "google_compute_target_pool" "target-pool" {
 
 resource "google_compute_forwarding_rule" "ssh-forwarding-rule" {
   name        = "${var.env_id}-concourse-ssh"
-  target      = "${google_compute_target_pool.target-pool.self_link}"
+  target      = google_compute_target_pool.target-pool.self_link
   port_range  = "2222"
   ip_protocol = "TCP"
-  ip_address  = "${google_compute_address.concourse-address.address}"
+  ip_address  = google_compute_address.concourse-address.address
 }
 
 resource "google_compute_forwarding_rule" "https-forwarding-rule" {
   name        = "${var.env_id}-concourse-https"
-  target      = "${google_compute_target_pool.target-pool.self_link}"
+  target      = google_compute_target_pool.target-pool.self_link
   port_range  = "443"
   ip_protocol = "TCP"
-  ip_address  = "${google_compute_address.concourse-address.address}"
+  ip_address  = google_compute_address.concourse-address.address
 }
 
 resource "google_compute_forwarding_rule" "http-forwarding-rule" {
   name        = "${var.env_id}-concourse-http"
-  target      = "${google_compute_target_pool.target-pool.self_link}"
+  target      = google_compute_target_pool.target-pool.self_link
   port_range  = "80"
   ip_protocol = "TCP"
-  ip_address  = "${google_compute_address.concourse-address.address}"
+  ip_address  = google_compute_address.concourse-address.address
 }
 
 resource "google_compute_forwarding_rule" "credhub-forwarding-rule" {
   name        = "${var.env_id}-concourse-credhub"
-  target      = "${google_compute_target_pool.target-pool.self_link}"
+  target      = google_compute_target_pool.target-pool.self_link
   port_range  = "8844"
   ip_protocol = "TCP"
-  ip_address  = "${google_compute_address.concourse-address.address}"
+  ip_address  = google_compute_address.concourse-address.address
 }
 
 resource "google_compute_forwarding_rule" "uaa-forwarding-rule" {
   name        = "${var.env_id}-concourse-uaa"
-  target      = "${google_compute_target_pool.target-pool.self_link}"
+  target      = google_compute_target_pool.target-pool.self_link
   port_range  = "8443"
   ip_protocol = "TCP"
-  ip_address  = "${google_compute_address.concourse-address.address}"
+  ip_address  = google_compute_address.concourse-address.address
 }

--- a/terraform/gcp/templates/jumpbox.tf
+++ b/terraform/gcp/templates/jumpbox.tf
@@ -7,7 +7,7 @@ output "jumpbox_url" {
 }
 
 output "external_ip" {
-  value = "${google_compute_address.jumpbox-ip.address}"
+  value = google_compute_address.jumpbox-ip.address
 }
 
 output "director_address" {

--- a/terraform/gcp/templates/vars.tf
+++ b/terraform/gcp/templates/vars.tf
@@ -1,27 +1,27 @@
 variable "project_id" {
-  type = "string"
+  type = string
 }
 
 variable "region" {
-  type = "string"
+  type = string
 }
 
 variable "zone" {
-  type = "string"
+  type = string
 }
 
 variable "env_id" {
-  type = "string"
+  type = string
 }
 
 variable "credentials" {
-  type = "string"
+  type = string
 }
 
 provider "google" {
-  credentials = "${file("${var.credentials}")}"
-  project     = "${var.project_id}"
-  region      = "${var.region}"
+  credentials = file(var.credentials)
+  project     = var.project_id
+  region      = var.region
 
-  version = "~> 1.20"
+  version = "~> 2.20.0"
 }

--- a/terraform/openstack/templates/provider-vars.tf
+++ b/terraform/openstack/templates/provider-vars.tf
@@ -21,10 +21,10 @@ variable "tenant_name" {
 
 variable "insecure" {
   description = "Skip SSL verification"
-  default = "false"
+  default     = "false"
 }
 
 variable "cacert_file" {
   description = "Custom CA certificate"
-  default = ""
+  default     = ""
 }

--- a/terraform/openstack/templates/provider.tf
+++ b/terraform/openstack/templates/provider.tf
@@ -1,11 +1,11 @@
 provider "openstack" {
-  auth_url    = "${var.auth_url}"
-  user_name   = "${var.user_name}"
-  password    = "${var.password}"
-  tenant_name = "${var.tenant_name}"
-  domain_name = "${var.domain_name}"
-  insecure    = "${var.insecure}"
-  cacert_file = "${var.cacert_file}"
+  auth_url    = var.auth_url
+  user_name   = var.user_name
+  password    = var.password
+  tenant_name = var.tenant_name
+  domain_name = var.domain_name
+  insecure    = var.insecure
+  cacert_file = var.cacert_file
 
   version = "~> 1.16"
 }

--- a/terraform/openstack/templates/resources-outputs.tf
+++ b/terraform/openstack/templates/resources-outputs.tf
@@ -1,54 +1,54 @@
 output "default_key_name" {
-  value = "${openstack_compute_keypair_v2.bosh.name}"
+  value = openstack_compute_keypair_v2.bosh.name
 }
 
 output "private_key" {
-  value = "${openstack_compute_keypair_v2.bosh.private_key}"
+  value     = openstack_compute_keypair_v2.bosh.private_key
   sensitive = true
 }
 
 output "external_ip" {
-  value = "${openstack_networking_floatingip_v2.jb.address}"
+  value = openstack_networking_floatingip_v2.jb.address
 }
 
 output "vms_security_groups" {
-  value = ["${openstack_networking_secgroup_v2.vms.name}"]
+  value = [openstack_networking_secgroup_v2.vms.name]
 }
 
 output "jumpbox__default_security_groups" {
-  value = ["${openstack_networking_secgroup_v2.jb.name}"]
+  value = [openstack_networking_secgroup_v2.jb.name]
 }
 
 output "director__default_security_groups" {
-  value = ["${openstack_networking_secgroup_v2.bosh.name}"]
+  value = [openstack_networking_secgroup_v2.bosh.name]
 }
 
 output "internal_cidr" {
-  value = "${openstack_networking_subnet_v2.bosh_subnet.cidr}"
+  value = openstack_networking_subnet_v2.bosh_subnet.cidr
 }
 
 output "internal_gw" {
-  value = "${openstack_networking_subnet_v2.bosh_subnet.gateway_ip}"
+  value = openstack_networking_subnet_v2.bosh_subnet.gateway_ip
 }
 
 output "net_id" {
-  value = "${openstack_networking_network_v2.bosh.id}"
+  value = openstack_networking_network_v2.bosh.id
 }
 
 output "internal_ip" {
-  value = "${cidrhost(openstack_networking_subnet_v2.bosh_subnet.cidr, 10)}"
+  value = cidrhost(openstack_networking_subnet_v2.bosh_subnet.cidr, 10)
 }
 
 output "router_id" {
-  value = "${openstack_networking_router_v2.bosh_router.id}"
+  value = openstack_networking_router_v2.bosh_router.id
 }
 
 output "director__internal_ip" {
-  value = "${cidrhost(openstack_networking_subnet_v2.bosh_subnet.cidr, 6)}"
+  value = cidrhost(openstack_networking_subnet_v2.bosh_subnet.cidr, 6)
 }
 
 output "jumpbox__internal_ip" {
-  value = "${cidrhost(openstack_networking_subnet_v2.bosh_subnet.cidr, 5)}"
+  value = cidrhost(openstack_networking_subnet_v2.bosh_subnet.cidr, 5)
 }
 
 output "jumpbox_url" {
@@ -56,29 +56,29 @@ output "jumpbox_url" {
 }
 
 output "auth_url" {
-  value = "${var.auth_url}"
+  value = var.auth_url
 }
 
 output "az" {
-  value = "${var.availability_zone}"
+  value = var.availability_zone
 }
 
 output "openstack_project" {
-  value = "${var.tenant_name}"
+  value = var.tenant_name
 }
 
 output "openstack_domain" {
-  value = "${var.domain_name}"
+  value = var.domain_name
 }
 
 output "region" {
-  value = "${var.region_name}"
+  value = var.region_name
 }
 
 output "env_id" {
-  value = "${var.env_id}"
+  value = var.env_id
 }
 
 output "director_name" {
-  value = "${var.env_id}"
+  value = var.env_id
 }

--- a/terraform/openstack/templates/resources-vars.tf
+++ b/terraform/openstack/templates/resources-vars.tf
@@ -10,8 +10,8 @@ variable "availability_zone" {
 
 variable "dns_nameservers" {
   description = "List of DNS server IPs"
-  default = ["8.8.8.8"]
-  type = "list"
+  default     = ["8.8.8.8"]
+  type        = list(string)
 }
 
 variable "ext_net_name" {

--- a/terraform/openstack/templates/resources.tf
+++ b/terraform/openstack/templates/resources.tf
@@ -1,206 +1,206 @@
 # key pairs
 resource "openstack_compute_keypair_v2" "bosh" {
-  region     = "${var.region_name}"
-  name       = "${var.env_id}-keypair"
+  region = var.region_name
+  name   = "${var.env_id}-keypair"
 }
 
 # networks
 resource "openstack_networking_network_v2" "bosh" {
-  region         = "${var.region_name}"
+  region         = var.region_name
   name           = "${var.env_id}-network"
   admin_state_up = "true"
 }
 
 resource "openstack_networking_subnet_v2" "bosh_subnet" {
-  region           = "${var.region_name}"
-  network_id       = "${openstack_networking_network_v2.bosh.id}"
-  cidr             = "10.0.1.0/24"
-  ip_version       = 4
-  name             = "${var.env_id}-subnet"
+  region     = var.region_name
+  network_id = openstack_networking_network_v2.bosh.id
+  cidr       = "10.0.1.0/24"
+  ip_version = 4
+  name       = "${var.env_id}-subnet"
   allocation_pools = {
     start = "10.0.1.200"
     end   = "10.0.1.254"
   }
-  gateway_ip       = "10.0.1.1"
-  enable_dhcp      = "true"
-  dns_nameservers  = "${var.dns_nameservers}"
+  gateway_ip      = "10.0.1.1"
+  enable_dhcp     = "true"
+  dns_nameservers = var.dns_nameservers
 }
 
 # router
 resource "openstack_networking_router_v2" "bosh_router" {
-  region           = "${var.region_name}"
-  name             = "${var.env_id}-router"
-  admin_state_up   = "true"
-  external_network_id = "${var.ext_net_id}"
+  region              = var.region_name
+  name                = "${var.env_id}-router"
+  admin_state_up      = "true"
+  external_network_id = var.ext_net_id
 }
 
 resource "openstack_networking_router_interface_v2" "bosh_port" {
-  region    = "${var.region_name}"
-  router_id = "${openstack_networking_router_v2.bosh_router.id}"
-  subnet_id = "${openstack_networking_subnet_v2.bosh_subnet.id}"
+  region    = var.region_name
+  router_id = openstack_networking_router_v2.bosh_router.id
+  subnet_id = openstack_networking_subnet_v2.bosh_subnet.id
 }
 
 # floating ips
 resource "openstack_networking_floatingip_v2" "jb" {
-  region = "${var.region_name}"
-  pool   = "${var.ext_net_name}"
+  region = var.region_name
+  pool   = var.ext_net_name
 }
 
 # security groups
 resource "openstack_networking_secgroup_v2" "jb" {
-  region = "${var.region_name}"
-  name = "${var.env_id}-jb"
+  region      = var.region_name
+  name        = "${var.env_id}-jb"
   description = "Jumpbox Security Group"
 }
 resource "openstack_networking_secgroup_rule_v2" "jb_rule_1" {
-  description = "Anyone to Jumpbox SSH"
-  region = "${var.region_name}"
-  direction = "ingress"
-  ethertype = "IPv4"
-  protocol = "tcp"
-  port_range_min = 22
-  port_range_max = 22
-  remote_ip_prefix = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.jb.id}"
+  description       = "Anyone to Jumpbox SSH"
+  region            = var.region_name
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.jb.id
 }
 resource "openstack_networking_secgroup_rule_v2" "jb_rule_2" {
-  description = "Anyone to Jumpbox Agent (for bosh create-env -d jumpbox)"
-  region = "${var.region_name}"
-  direction = "ingress"
-  ethertype = "IPv4"
-  protocol = "tcp"
-  port_range_min = 6868
-  port_range_max = 6868
-  remote_ip_prefix = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.jb.id}"
+  description       = "Anyone to Jumpbox Agent (for bosh create-env -d jumpbox)"
+  region            = var.region_name
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 6868
+  port_range_max    = 6868
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.jb.id
 }
 
 resource "openstack_networking_secgroup_v2" "bosh" {
   description = "BOSH Director Security Group"
-  region = "${var.region_name}"
-  name = "${var.env_id}-bosh"
+  region      = var.region_name
+  name        = "${var.env_id}-bosh"
 }
 resource "openstack_networking_secgroup_rule_v2" "bosh_rule_1" {
-  description = "Jumpbox to Director NGINX"
-  region = "${var.region_name}"
-  direction = "ingress"
-  ethertype = "IPv4"
-  protocol = "tcp"
-  port_range_min = 25555
-  port_range_max = 25555
-  remote_group_id = "${openstack_networking_secgroup_v2.jb.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.bosh.id}"
+  description       = "Jumpbox to Director NGINX"
+  region            = var.region_name
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 25555
+  port_range_max    = 25555
+  remote_group_id   = openstack_networking_secgroup_v2.jb.id
+  security_group_id = openstack_networking_secgroup_v2.bosh.id
 }
 resource "openstack_networking_secgroup_rule_v2" "bosh_rule_2" {
-  description = "Jumpbox to Director MBUS"
-  region = "${var.region_name}"
-  direction = "ingress"
-  ethertype = "IPv4"
-  protocol = "tcp"
-  port_range_min = 6868
-  port_range_max = 6868
-  remote_group_id = "${openstack_networking_secgroup_v2.jb.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.bosh.id}"
+  description       = "Jumpbox to Director MBUS"
+  region            = var.region_name
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 6868
+  port_range_max    = 6868
+  remote_group_id   = openstack_networking_secgroup_v2.jb.id
+  security_group_id = openstack_networking_secgroup_v2.bosh.id
 }
 resource "openstack_networking_secgroup_rule_v2" "bosh_rule_3" {
-  description = "Jumpbox to Director SSH"
-  region = "${var.region_name}"
-  direction = "ingress"
-  ethertype = "IPv4"
-  protocol = "tcp"
-  port_range_min = 22
-  port_range_max = 22
-  remote_group_id = "${openstack_networking_secgroup_v2.jb.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.bosh.id}"
+  description       = "Jumpbox to Director SSH"
+  region            = var.region_name
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_group_id   = openstack_networking_secgroup_v2.jb.id
+  security_group_id = openstack_networking_secgroup_v2.bosh.id
 }
 resource "openstack_networking_secgroup_rule_v2" "bosh_rule_4" {
-  description = "Jumpbox to Director UAA"
-  region = "${var.region_name}"
-  direction = "ingress"
-  ethertype = "IPv4"
-  protocol = "tcp"
-  port_range_min = 8443
-  port_range_max = 8443
-  remote_group_id = "${openstack_networking_secgroup_v2.jb.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.bosh.id}"
+  description       = "Jumpbox to Director UAA"
+  region            = var.region_name
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 8443
+  port_range_max    = 8443
+  remote_group_id   = openstack_networking_secgroup_v2.jb.id
+  security_group_id = openstack_networking_secgroup_v2.bosh.id
 }
 resource "openstack_networking_secgroup_rule_v2" "bosh_rule_5" {
-  description = "Jumpbox to Director Credhub"
-  region = "${var.region_name}"
-  direction = "ingress"
-  ethertype = "IPv4"
-  protocol = "tcp"
-  port_range_min = 8844
-  port_range_max = 8844
-  remote_group_id = "${openstack_networking_secgroup_v2.jb.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.bosh.id}"
+  description       = "Jumpbox to Director Credhub"
+  region            = var.region_name
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 8844
+  port_range_max    = 8844
+  remote_group_id   = openstack_networking_secgroup_v2.jb.id
+  security_group_id = openstack_networking_secgroup_v2.bosh.id
 }
 resource "openstack_networking_secgroup_rule_v2" "bosh_rule_6" {
-  description = "BOSH deployed VMs to Director NATS"
-  region = "${var.region_name}"
-  direction = "ingress"
-  ethertype = "IPv4"
-  protocol = "tcp"
-  port_range_min = 4222
-  port_range_max = 4222
-  remote_group_id = "${openstack_networking_secgroup_v2.vms.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.bosh.id}"
+  description       = "BOSH deployed VMs to Director NATS"
+  region            = var.region_name
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 4222
+  port_range_max    = 4222
+  remote_group_id   = openstack_networking_secgroup_v2.vms.id
+  security_group_id = openstack_networking_secgroup_v2.bosh.id
 }
 resource "openstack_networking_secgroup_rule_v2" "bosh_rule_7" {
-  description = "BOSH deployed VMs to Director Registry"
-  region = "${var.region_name}"
-  direction = "ingress"
-  ethertype = "IPv4"
-  protocol = "tcp"
-  port_range_min = 25777
-  port_range_max = 25777
-  remote_group_id = "${openstack_networking_secgroup_v2.vms.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.bosh.id}"
+  description       = "BOSH deployed VMs to Director Registry"
+  region            = var.region_name
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 25777
+  port_range_max    = 25777
+  remote_group_id   = openstack_networking_secgroup_v2.vms.id
+  security_group_id = openstack_networking_secgroup_v2.bosh.id
 }
 resource "openstack_networking_secgroup_rule_v2" "bosh_rule_8" {
-  description = "BOSH deployed VMs to Director Blobstore"
-  region = "${var.region_name}"
-  direction = "ingress"
-  ethertype = "IPv4"
-  protocol = "tcp"
-  port_range_min = 25250
-  port_range_max = 25250
-  remote_group_id = "${openstack_networking_secgroup_v2.vms.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.bosh.id}"
+  description       = "BOSH deployed VMs to Director Blobstore"
+  region            = var.region_name
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 25250
+  port_range_max    = 25250
+  remote_group_id   = openstack_networking_secgroup_v2.vms.id
+  security_group_id = openstack_networking_secgroup_v2.bosh.id
 }
 
 resource "openstack_networking_secgroup_v2" "vms" {
-  region = "${var.region_name}"
-  name = "${var.env_id}-vms"
+  region      = var.region_name
+  name        = "${var.env_id}-vms"
   description = "BOSH deployed VMs Security Group"
 }
 resource "openstack_networking_secgroup_rule_v2" "vms_rule_1" {
-  description = "BOSH deployed VMs to BOSH deployed VMs TCP"
-  region = "${var.region_name}"
-  direction = "ingress"
-  ethertype = "IPv4"
-  protocol = "tcp"
-  remote_group_id = "${openstack_networking_secgroup_v2.vms.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.vms.id}"
+  description       = "BOSH deployed VMs to BOSH deployed VMs TCP"
+  region            = var.region_name
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  remote_group_id   = openstack_networking_secgroup_v2.vms.id
+  security_group_id = openstack_networking_secgroup_v2.vms.id
 }
 resource "openstack_networking_secgroup_rule_v2" "vms_rule_2" {
-  description = "BOSH deployed VMs to BOSH deployed VMs UDP"
-  region = "${var.region_name}"
-  direction = "ingress"
-  ethertype = "IPv4"
-  protocol = "udp"
-  remote_group_id = "${openstack_networking_secgroup_v2.vms.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.vms.id}"
+  description       = "BOSH deployed VMs to BOSH deployed VMs UDP"
+  region            = var.region_name
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  remote_group_id   = openstack_networking_secgroup_v2.vms.id
+  security_group_id = openstack_networking_secgroup_v2.vms.id
 }
 resource "openstack_networking_secgroup_rule_v2" "vms_rule_3" {
-  description = "Jumpbox to BOSH deployed VMs SSH"
-  region = "${var.region_name}"
-  direction = "ingress"
-  ethertype = "IPv4"
-  protocol = "tcp"
-  port_range_min = 22
-  port_range_max = 22
-  remote_group_id = "${openstack_networking_secgroup_v2.jb.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.vms.id}"
+  description       = "Jumpbox to BOSH deployed VMs SSH"
+  region            = var.region_name
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_group_id   = openstack_networking_secgroup_v2.jb.id
+  security_group_id = openstack_networking_secgroup_v2.vms.id
 }
 

--- a/terraform/vsphere/template_generator.go
+++ b/terraform/vsphere/template_generator.go
@@ -31,21 +31,21 @@ variable "vcenter_templates" {}
 variable "vcenter_vms" {}
 variable "vcenter_disks" {}
 
-output "internal_cidr" { value = "${var.vsphere_subnet_cidr}" }
-output "internal_gw" { value = "${var.internal_gw}" }
-output "network_name" { value = "${var.network_name}" }
-output "vcenter_cluster" { value = "${var.vcenter_cluster}" }
+output "internal_cidr" { value = var.vsphere_subnet_cidr }
+output "internal_gw" { value = var.internal_gw }
+output "network_name" { value = var.network_name }
+output "vcenter_cluster" { value = var.vcenter_cluster }
 output "jumpbox_url" { value = "${var.jumpbox_ip}:22" }
-output "external_ip" { value = "${var.jumpbox_ip}" }
-output "jumpbox__internal_ip" { value = "${var.jumpbox_ip}" }
-output "director__internal_ip" { value = "${var.director_internal_ip}" }
+output "external_ip" { value = var.jumpbox_ip }
+output "jumpbox__internal_ip" { value = var.jumpbox_ip }
+output "director__internal_ip" { value = var.director_internal_ip }
 output "director_name" { value = "bosh-${var.env_id}" }
-output "vcenter_disks" { value = "${var.vcenter_disks}" }
-output "vcenter_vms" { value = "${var.vcenter_vms}" }
-output "vcenter_templates" { value = "${var.vcenter_templates}" }
-output "vcenter_ip" { value = "${var.vcenter_ip}" }
-output "vcenter_dc" { value = "${var.vcenter_dc}" }
-output "vcenter_rp" { value = "${var.vcenter_rp}" }
-output "vcenter_ds" { value = "${var.vcenter_ds}" }
+output "vcenter_disks" { value = var.vcenter_disks }
+output "vcenter_vms" { value = var.vcenter_vms }
+output "vcenter_templates" { value = var.vcenter_templates }
+output "vcenter_ip" { value = var.vcenter_ip }
+output "vcenter_dc" { value = var.vcenter_dc }
+output "vcenter_rp" { value = var.vcenter_rp }
+output "vcenter_ds" { value = var.vcenter_ds }
 `)
 }


### PR DESCRIPTION
Update Terraform templates and plan-patches to use Terraform 0.12 syntax.
I've built and tested BBL changes only in AWS environment. For the Azure/GCP/Openstack/Vsphere only minor changes were required (there is no complex logic used in these templates).

Let me know if I need to submit a PR to update Terraform version used in bosh-bootloader pipeline: https://github.com/cloudfoundry/infrastructure-ci/blob/master/pipelines/bosh-bootloader.yml