### PR TITLE
add plan-patch to enable HTTP2 in GCP load balancer

### DIFF
--- a/plan-patches/README.md
+++ b/plan-patches/README.md
@@ -33,6 +33,7 @@ Many of these have additional prep steps or specific downstream bosh deployments
 | [restricted-instance-groups-gcp](restricted-instance-groups-gcp/) | Create two seperate instance groups |
 | [colocate-gorouter-ssh-proxy-gcp](colocate-gorouter-ssh-proxy-gcp/) | Helpful if you're trying to colocate everything |
 | [prometheus-lb-gcp](prometheus-lb-gcp/) | Deploy a dedicated GCP load balancer for your prometheus cluster |
+| [http2-lb-gcp](http2-lb-gcp/) | Configure the load balancer backends to use HTTP2 protocol in GCP |
 | **VSPHERE** |     |
 | [cfcr-vsphere](cfcr-vsphere/) | Deploy a CFCR with a single master static IP and the vsphere cloud-provider |
 | **OPENSTACK** |     |

--- a/plan-patches/http2-lb-gcp/README.md
+++ b/plan-patches/http2-lb-gcp/README.md
@@ -1,0 +1,21 @@
+## http2 load balancer for GCP
+
+This is a patch that will enable http2 protocol for the backend services used in the GCP load
+balancer.
+
+This will override the existing HTTPS protocol that is configured on the load
+balancer. **Be aware** that requests to the loadbalancer will upgrade its connection to http2. If
+your gorouter is not up-to-date or does not allow http2 traffic, then the
+requests to the gorouter will fail.
+
+To use, please follow the standard plan-patch steps.
+
+```
+mkdir your-env && cd your-env
+
+bbl plan --name your-env
+
+cp -r bosh-bootloader/plan-patches/http2-lb-gcp/. .
+
+bbl up
+```

--- a/plan-patches/http2-lb-gcp/terraform/http2-cf-lb-gcp_override.tf
+++ b/plan-patches/http2-lb-gcp/terraform/http2-cf-lb-gcp_override.tf
@@ -1,0 +1,3 @@
+resource "google_compute_backend_service" "router-lb-backend-service" {
+  protocol    = "HTTP2"
+}


### PR DESCRIPTION
## GCP HTTP2 Load Balancer

We are working on a feature to  add the ability for the gorouter to accept http2 requests. 

Corresponding issue: https://github.com/cloudfoundry/routing-release/issues/200

To fully support end-to-end http2 traffic, load balances must be able to accept http2 requests. This is a plan patch to make sure the load balancer in front CF can accept http2 traffic.

## Compatibility 

Right now this patch is not compatible with the current gorouter because it blocks h2 requests. We will update the README.md with the version of cf-deployment/routing-release it will work with once we are done with the feature.
