### PR TITLE
add plan-patch to enable http2 in azure load balancer

### DIFF
--- a/plan-patches/README.md
+++ b/plan-patches/README.md
@@ -41,3 +41,4 @@ Many of these have additional prep steps or specific downstream bosh deployments
 | [cf-lite-azure](cf-lite-azure/) | Deploy a cf-lite on azure, one-box dev environment for CF |
 | [cf-azure](cf-azure/) | Deploy a cf on azure |
 | [cfcr-azure](cfcr-azure/) | Deploy a cfcr on azure |
+| [http2-lb-azure](http2-lb-azure/) | Enable http2 on load balancer (application gateway) in Azure |

--- a/plan-patches/http2-lb-azure/README.md
+++ b/plan-patches/http2-lb-azure/README.md
@@ -1,0 +1,22 @@
+## HTTP2 load balancer for Azure
+
+This is a patch that will enable http2 protocol in Azure's load balancer(Application Gateway) setup.
+
+**Be aware** that requests to this load balancer might be incompatible with
+older versions of gorouter. We recommend using this plan-patch only if you are
+on a routing-release version with http2 enabled.
+
+Compatible with routing-release version: x.x+ (will fill this in later) and
+cf-deployment version: x.x+
+
+To use, please follow the standard plan-patch steps.
+
+```
+mkdir your-env && cd your-env
+
+bbl plan --name your-env
+
+cp -r bosh-bootloader/plan-patches/http2-lb-azure/. .
+
+bbl up
+```

--- a/plan-patches/http2-lb-azure/terraform/http2-cf-lb-azure_override.tf
+++ b/plan-patches/http2-lb-azure/terraform/http2-cf-lb-azure_override.tf
@@ -1,0 +1,3 @@
+resource "azurerm_application_gateway" "cf" {
+  enable_http2 = "true"
+}


### PR DESCRIPTION
## Azure HTTP2 Loadbalancer

We are working on a feature to add the ability for the gorouter to accept http2 requests.

Corresponding issue: cloudfoundry/routing-release#200

To fully support end-to-end http2 traffic, load balances must be able to accept http2 requests. This is a plan patch to make sure the load balancer in front CF can accept http2 traffic on azure.

**Caution** 
Unlike GCP's http2 load balancer, we were still able to use CF with http1.1 calls when enabling http2 on azure. 
However, we would still only recommend applying this patch on a routing-release that has the http2 feature enabled.

Compatible with versions:
routing-release: x.x
cf-deployment: x.x