### PR TITLE
update azure instance type for diego cells

### DIFF
--- a/cloudconfig/azure/base_ops_template.go
+++ b/cloudconfig/azure/base_ops_template.go
@@ -86,7 +86,7 @@ const (
   value:
     ephemeral_disk:
       size: 10240
-    instance_type: Standard_GS2
+    instance_type: Standard_E2s_v3
 
 - type: replace
   path: /vm_types/name=sharedcpu/cloud_properties?

--- a/cloudconfig/azure/fixtures/azure-ops.yml
+++ b/cloudconfig/azure/fixtures/azure-ops.yml
@@ -82,7 +82,7 @@
   value:
     ephemeral_disk:
       size: 10240
-    instance_type: Standard_GS2
+    instance_type: Standard_E2s_v3
 
 - type: replace
   path: /vm_types/name=sharedcpu/cloud_properties?


### PR DESCRIPTION
GS2 vms are no longer available. Swapping to a E2s_v3. E2s_v3 vms are 2 cores, 16gb of memory and lower cost than a 64gb vm. Since most bbl usage is for development we think this is better choice for the default and can always be overriden if someone wants large expensive diego cells.

closes cloudfoundry/bosh-bootloader#516