### PR TITLE
Update aws templates to be terraform v15 compliant

### DIFF
--- a/terraform/aws/templates/base.tf
+++ b/terraform/aws/templates/base.tf
@@ -1,13 +1,20 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = ">= 3.49"
+    }
+    tls = {
+      source = "hashicorp/tls"
+      version = ">= 3.1"
+    }
+  }
+}
+
 provider "aws" {
   access_key = "${var.access_key}"
   secret_key = "${var.secret_key}"
   region     = "${var.region}"
-
-  version = "~> 1.60"
-}
-
-provider "tls" {
-  version = "~> 1.2"
 }
 
 variable "access_key" {
@@ -27,7 +34,7 @@ variable "bosh_inbound_cidr" {
 }
 
 variable "availability_zones" {
-  type = "list"
+  type = list
 }
 
 variable "env_id" {
@@ -44,7 +51,7 @@ variable "vpc_cidr" {
 }
 
 resource "aws_eip" "jumpbox_eip" {
-  depends_on = ["aws_internet_gateway.ig"]
+  depends_on = [aws_internet_gateway.ig]
   vpc        = true
 }
 
@@ -63,7 +70,7 @@ resource "aws_security_group" "nat_security_group" {
   description = "NAT"
   vpc_id      = "${local.vpc_id}"
 
-  tags {
+  tags = {
     Name = "${var.env_id}-nat-security-group"
   }
 
@@ -116,7 +123,7 @@ resource "aws_nat_gateway" "nat" {
   subnet_id     = "${aws_subnet.bosh_subnet.id}"
   allocation_id = "${aws_eip.nat_eip.id}"
 
-  tags {
+  tags = {
     Name  = "${var.env_id}-nat"
     EnvID = "${var.env_id}"
   }
@@ -125,7 +132,7 @@ resource "aws_nat_gateway" "nat" {
 resource "aws_eip" "nat_eip" {
   vpc = true
 
-  tags {
+  tags = {
     Name  = "${var.env_id}-nat"
     EnvID = "${var.env_id}"
   }
@@ -140,12 +147,12 @@ resource "aws_security_group" "internal_security_group" {
   description = "Internal"
   vpc_id      = "${local.vpc_id}"
 
-  tags {
+  tags = {
     Name = "${var.env_id}-internal-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
 }
 
@@ -199,12 +206,12 @@ resource "aws_security_group" "bosh_security_group" {
   description = "BOSH Director"
   vpc_id      = "${local.vpc_id}"
 
-  tags {
+  tags = {
     Name = "${var.env_id}-bosh-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name", "description"]
+    ignore_changes = [name, description]
   }
 }
 
@@ -285,12 +292,12 @@ resource "aws_security_group" "jumpbox" {
   description = "Jumpbox"
   vpc_id      = "${local.vpc_id}"
 
-  tags {
+  tags = {
     Name = "${var.env_id}-jumpbox-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name", "description"]
+    ignore_changes = [name, description]
   }
 }
 
@@ -361,7 +368,7 @@ resource "aws_subnet" "bosh_subnet" {
   vpc_id     = "${local.vpc_id}"
   cidr_block = "${cidrsubnet(var.vpc_cidr, 8, 0)}"
 
-  tags {
+  tags = {
     Name = "${var.env_id}-bosh-subnet"
   }
 }
@@ -387,7 +394,7 @@ resource "aws_subnet" "internal_subnets" {
   cidr_block        = "${cidrsubnet(var.vpc_cidr, 4, count.index+1)}"
   availability_zone = "${element(var.availability_zones, count.index)}"
 
-  tags {
+  tags = {
     Name = "${var.env_id}-internal-subnet${count.index}"
   }
 

--- a/terraform/aws/templates/cf_dns.tf
+++ b/terraform/aws/templates/cf_dns.tf
@@ -28,7 +28,7 @@ resource "aws_route53_zone" "env_dns_zone" {
 
   name = "${var.system_domain}"
 
-  tags {
+  tags = {
     Name = "${var.env_id}-hosted-zone"
   }
 }

--- a/terraform/aws/templates/cf_lb.tf
+++ b/terraform/aws/templates/cf_lb.tf
@@ -17,12 +17,12 @@ resource "aws_security_group" "cf_ssh_lb_security_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.env_id}-cf-ssh-lb-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
 }
 
@@ -49,12 +49,12 @@ resource "aws_security_group" "cf_ssh_lb_internal_security_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.env_id}-cf-ssh-lb-internal-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
 }
 
@@ -84,7 +84,7 @@ resource "aws_elb" "cf_ssh_lb" {
   security_groups = ["${aws_security_group.cf_ssh_lb_security_group.id}"]
   subnets         = ["${aws_subnet.lb_subnets.*.id}"]
 
-  tags {
+  tags = {
     Name = "${var.env_id}"
   }
 }
@@ -130,12 +130,12 @@ resource "aws_security_group" "cf_router_lb_security_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.env_id}-cf-router-lb-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
 }
 
@@ -162,12 +162,12 @@ resource "aws_security_group" "cf_router_lb_internal_security_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.env_id}-cf-router-lb-internal-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
 }
 
@@ -213,7 +213,7 @@ resource "aws_elb" "cf_router_lb" {
   security_groups = ["${aws_security_group.cf_router_lb_security_group.id}"]
   subnets         = ["${aws_subnet.lb_subnets.*.id}"]
 
-  tags {
+  tags = {
     Name = "${var.env_id}"
   }
 }
@@ -228,7 +228,7 @@ resource "aws_lb_target_group" "cf_router_4443" {
     protocol = "TCP"
   }
 
-  tags {
+  tags = {
     Name = "${var.env_id}"
   }
 }
@@ -260,12 +260,12 @@ resource "aws_security_group" "cf_tcp_lb_security_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.env_id}-cf-tcp-lb-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
 }
 
@@ -299,12 +299,12 @@ resource "aws_security_group" "cf_tcp_lb_internal_security_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.env_id}-cf-tcp-lb-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
 }
 
@@ -1027,7 +1027,7 @@ resource "aws_elb" "cf_tcp_lb" {
   security_groups = ["${aws_security_group.cf_tcp_lb_security_group.id}"]
   subnets         = ["${aws_subnet.lb_subnets.*.id}"]
 
-  tags {
+  tags = {
     Name = "${var.env_id}"
   }
 }

--- a/terraform/aws/templates/concourse_lb.tf
+++ b/terraform/aws/templates/concourse_lb.tf
@@ -3,12 +3,12 @@ resource "aws_security_group" "concourse_lb_internal_security_group" {
   description = "Concourse Internal"
   vpc_id      = "${local.vpc_id}"
 
-  tags {
+  tags = {
     Name = "${var.env_id}-concourse-lb-internal-security-group"
   }
 
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
 }
 
@@ -57,7 +57,7 @@ resource "aws_lb" "concourse_lb" {
   load_balancer_type = "network"
   subnets            = ["${aws_subnet.lb_subnets.*.id}"]
 
-  tags {
+  tags = {
     Name = "${var.env_id}"
   }
 }
@@ -86,7 +86,7 @@ resource "aws_lb_target_group" "concourse_lb_80" {
     protocol            = "TCP"
   }
 
-  tags {
+  tags = {
     Name = "${var.env_id}"
   }
 }
@@ -108,7 +108,7 @@ resource "aws_lb_target_group" "concourse_lb_2222" {
   protocol = "TCP"
   vpc_id   = "${local.vpc_id}"
 
-  tags {
+  tags = {
     Name = "${var.env_id}"
   }
 }
@@ -130,7 +130,7 @@ resource "aws_lb_target_group" "concourse_lb_443" {
   protocol = "TCP"
   vpc_id   = "${local.vpc_id}"
 
-  tags {
+  tags = {
     Name = "${var.env_id}"
   }
 }
@@ -172,7 +172,7 @@ resource "aws_lb_target_group" "concourse_lb_8844" {
   protocol = "TCP"
   vpc_id   = "${local.vpc_id}"
 
-  tags {
+  tags = {
     Name = "${var.env_id}"
   }
 }
@@ -194,7 +194,7 @@ resource "aws_lb_target_group" "concourse_lb_8443" {
   protocol = "TCP"
   vpc_id   = "${local.vpc_id}"
 
-  tags {
+  tags = {
     Name = "${var.env_id}"
   }
 }

--- a/terraform/aws/templates/iam.tf
+++ b/terraform/aws/templates/iam.tf
@@ -3,20 +3,21 @@ variable "bosh_iam_instance_profile" {
 }
 
 locals {
-  iamProfileProvided = "${var.bosh_iam_instance_profile == "" ? 0 : 1}"
+  iamProfileProvided = "${var.bosh_iam_instance_profile == "" ? false : true}"
+  iamProfileCount = "${var.bosh_iam_instance_profile == "" ? 0 : 1}"
 }
 
 data "aws_iam_instance_profile" "bosh" {
   name = "${var.bosh_iam_instance_profile}"
 
-  count = "${local.iamProfileProvided}"
+  count = "${local.iamProfileCount}"
 }
 
 resource "aws_iam_role" "bosh" {
   name = "${var.env_id}_bosh_role"
   path = "/"
 
-  count = "${1 - local.iamProfileProvided}"
+  count = "${1 - local.iamProfileCount}"
 
   lifecycle {
     create_before_destroy = true
@@ -43,7 +44,7 @@ resource "aws_iam_policy" "bosh" {
   name = "${var.env_id}_bosh_policy"
   path = "/"
 
-  count = "${1 - local.iamProfileProvided}"
+  count = "${1 - local.iamProfileCount}"
 
   policy = <<EOF
 {
@@ -118,19 +119,19 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "bosh" {
   role       = "${var.env_id}_bosh_role"
-  policy_arn = "${aws_iam_policy.bosh.arn}"
+  policy_arn = "${aws_iam_policy.bosh[0].arn}"
 
-  count = "${1 - local.iamProfileProvided}"
+  count = "${1 - local.iamProfileCount}"
 }
 
 resource "aws_iam_instance_profile" "bosh" {
   name = "${var.env_id}-bosh"
-  role = "${aws_iam_role.bosh.name}"
+  role = "${aws_iam_role.bosh[0].name}"
 
-  count = "${1 - local.iamProfileProvided}"
+  count = "${1 - local.iamProfileCount}"
 
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
 }
 
@@ -144,7 +145,7 @@ resource "aws_flow_log" "bbl" {
 resource "aws_cloudwatch_log_group" "bbl" {
   name_prefix = "${var.short_env_id}-log-group"
 
-  tags {
+  tags = {
     Name = "${var.env_id}"
   }
 }

--- a/terraform/aws/templates/iso_segments.tf
+++ b/terraform/aws/templates/iso_segments.tf
@@ -5,17 +5,17 @@ variable "isolation_segments" {
 }
 
 variable "iso_to_bosh_ports" {
-  type    = "list"
+  type    = list
   default = [22, 6868, 2555, 4222, 25250]
 }
 
 variable "iso_to_shared_tcp_ports" {
-  type    = "list"
+  type    = list
   default = [9090, 9091, 8082, 8300, 8301, 8889, 8443, 3000, 4443, 8080, 3457, 9023, 9022, 4222]
 }
 
 variable "iso_to_shared_udp_ports" {
-  type    = "list"
+  type    = list
   default = [8301, 8302, 8600]
 }
 
@@ -29,7 +29,7 @@ resource "aws_subnet" "iso_subnets" {
   cidr_block        = "${cidrsubnet(var.vpc_cidr, 4, count.index + length(var.availability_zones) + 1)}"
   availability_zone = "${element(var.availability_zones, count.index)}"
 
-  tags {
+  tags = {
     Name = "${var.env_id}-iso-subnet${count.index}"
   }
 }
@@ -80,7 +80,7 @@ resource "aws_elb" "iso_router_lb" {
   security_groups = ["${aws_security_group.cf_router_lb_security_group.id}"]
   subnets         = ["${aws_subnet.lb_subnets.*.id}"]
 
-  tags {
+  tags = {
     Name = "${var.env_id}"
   }
 }
@@ -96,7 +96,7 @@ resource "aws_lb_target_group" "iso_router_lb_4443" {
     protocol = "TCP"
   }
 
-  tags {
+  tags = {
     Name = "${var.env_id}"
   }
 }
@@ -109,7 +109,7 @@ resource "aws_security_group" "iso_security_group" {
 
   description = "Private isolation segment"
 
-  tags {
+  tags = {
     Name = "${var.env_id}-iso-security-group"
   }
 }
@@ -122,7 +122,7 @@ resource "aws_security_group" "iso_shared_security_group" {
 
   description = "Shared isolation segments"
 
-  tags {
+  tags = {
     Name = "${var.env_id}-iso-shared-security-group"
   }
 }

--- a/terraform/aws/templates/lb_subnet.tf
+++ b/terraform/aws/templates/lb_subnet.tf
@@ -4,12 +4,12 @@ resource "aws_subnet" "lb_subnets" {
   cidr_block        = "${cidrsubnet(var.vpc_cidr, 8, count.index+2)}"
   availability_zone = "${element(var.availability_zones, count.index)}"
 
-  tags {
+  tags = {
     Name = "${var.env_id}-lb-subnet${count.index}"
   }
 
   lifecycle {
-    ignore_changes = ["cidr_block", "availability_zone"]
+    ignore_changes = [cidr_block, availability_zone]
   }
 }
 

--- a/terraform/aws/templates/vpc.tf
+++ b/terraform/aws/templates/vpc.tf
@@ -15,7 +15,7 @@ resource "aws_vpc" "vpc" {
   instance_tenancy     = "default"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "${var.env_id}-vpc"
   }
 }


### PR DESCRIPTION
## Introduction

Hi! Looks like the latest BBL templates for AWS are also broken on v15 of terraform (similar to https://github.com/cloudfoundry/bosh-bootloader/issues/523). This PR updates those templates to be compatible. I have tested it out with a standard BBL up on AWS (install, NOT upgrade) and this now works with v8.4.41.

This PR can serve as a template for the fix, or for others who want to be unblocked and use the latest BBL for AWS.

---

## Summary

- This adds a '=' to each "tags" block as required by aws provider
- This adds a "required_providers" block as recommended by terraform
  deprecation warning
- This removes quotes from the types for variables as required by
  terraform v15
- This removes quotes from arrays as recommended by terraform
  deprecation warning

Signed-off-by: Neil Hickey <nhickey@vmware.com>