### PR TITLE
Openstack Incompatible API Fix

### DIFF
--- a/terraform/openstack/templates/provider.tf
+++ b/terraform/openstack/templates/provider.tf
@@ -7,5 +7,5 @@ provider "openstack" {
   insecure    = "${var.insecure}"
   cacert_file = "${var.cacert_file}"
 
-  version = "~> 1.16"
+  version = "~> 1.16, < 1.44"
 }


### PR DESCRIPTION
terraform-provider-openstack release 1.44 updates major version of terraform-plugin-sdk from `v1` to `v2` https://github.com/terraform-provider-openstack/terraform-provider-openstack/blob/main/CHANGELOG.md#1440-2-october-2021
It causes BBL error: `provider.openstack: Incompatible API version with plugin. Plugin version: 5, Core version: 4`