### PR TITLE
Update Azure VM sizes used in CF-D to be cheaper

### DIFF
--- a/cloudconfig/azure/fixtures/azure-ops.yml
+++ b/cloudconfig/azure/fixtures/azure-ops.yml
@@ -54,14 +54,14 @@
   value:
     ephemeral_disk:
       size: 10240
-    instance_type: Standard_F1s
+    instance_type: Standard_B1ms
 
 - type: replace
   path: /vm_types/name=small/cloud_properties?
   value:
     ephemeral_disk:
       size: 10240
-    instance_type: Standard_F2s_v2
+    instance_type: Standard_D2as_v4
 
 - type: replace
   path: /vm_types/name=medium/cloud_properties?
@@ -82,7 +82,7 @@
   value:
     ephemeral_disk:
       size: 10240
-    instance_type: Standard_GS2
+    instance_type: Standard_E4s_v3
 
 - type: replace
   path: /vm_types/name=sharedcpu/cloud_properties?


### PR DESCRIPTION
We use 3 VM sizes, probably poorly named: 
* minimal (can run in 1-2GB of memory and shared core)
* small (needs 4-8GB of memory and at least 1 real core)
* small-highmem (needs 12+ GB of memory and at least 1 real core)
This change updates those 3 VM types to use 4th generation hardware and the cheapest option for each requirement.