### PR TITLE
Fix compilation vms not found with modern VM sizes

### DIFF
--- a/cloudconfig/aws/base_ops_template.go
+++ b/cloudconfig/aws/base_ops_template.go
@@ -179,6 +179,56 @@ const (
 - type: replace
   path: /vm_types/-
   value:
+    name: m5a.large
+    cloud_properties:
+      instance_type: m5a.large
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: m5a.xlarge
+    cloud_properties:
+      instance_type: m5a.xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: m5a.2xlarge
+    cloud_properties:
+      instance_type: m5a.2xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: m5a.4xlarge
+    cloud_properties:
+      instance_type: m5a.4xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: m5a.10xlarge
+    cloud_properties:
+      instance_type: m5a.10xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
     name: c4.large
     cloud_properties:
       instance_type: c4.large
@@ -222,6 +272,56 @@ const (
     name: c4.8xlarge
     cloud_properties:
       instance_type: c4.8xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: c5a.large
+    cloud_properties:
+      instance_type: c5a.large
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: c5a.xlarge
+    cloud_properties:
+      instance_type: c5a.xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: c5a.2xlarge
+    cloud_properties:
+      instance_type: c5a.2xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: c5a.4xlarge
+    cloud_properties:
+      instance_type: c5a.4xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: c5a.8xlarge
+    cloud_properties:
+      instance_type: c5a.8xlarge
       ephemeral_disk:
         size: 10240
         type: gp3
@@ -279,6 +379,56 @@ const (
 - type: replace
   path: /vm_types/-
   value:
+    name: r5a.large
+    cloud_properties:
+      instance_type: r5a.large
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: r5a.xlarge
+    cloud_properties:
+      instance_type: r5a.xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: r5a.2xlarge
+    cloud_properties:
+      instance_type: r5a.2xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: r5a.4xlarge
+    cloud_properties:
+      instance_type: r5a.4xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: r5a.8xlarge
+    cloud_properties:
+      instance_type: r5a.8xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
     name: t2.nano
     cloud_properties:
       instance_type: t2.nano
@@ -322,6 +472,56 @@ const (
     name: t2.large
     cloud_properties:
       instance_type: t2.large
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: t3a.nano
+    cloud_properties:
+      instance_type: t3a.nano
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: t3a.micro
+    cloud_properties:
+      instance_type: t3a.micro
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: t3a.small
+    cloud_properties:
+      instance_type: t3a.small
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: t3a.medium
+    cloud_properties:
+      instance_type: t3a.medium
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: t3a.large
+    cloud_properties:
+      instance_type: t3a.large
       ephemeral_disk:
         size: 10240
         type: gp3

--- a/cloudconfig/aws/fixtures/aws-ops.yml
+++ b/cloudconfig/aws/fixtures/aws-ops.yml
@@ -175,6 +175,57 @@
 - type: replace
   path: /vm_types/-
   value:
+    name: m5a.large
+    cloud_properties:
+      instance_type: m5a.large
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: m5a.xlarge
+    cloud_properties:
+      instance_type: m5a.xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: m5a.2xlarge
+    cloud_properties:
+      instance_type: m5a.2xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: m5a.4xlarge
+    cloud_properties:
+      instance_type: m5a.4xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: m5a.10xlarge
+    cloud_properties:
+      instance_type: m5a.10xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+
+- type: replace
+  path: /vm_types/-
+  value:
     name: c4.large
     cloud_properties:
       instance_type: c4.large
@@ -218,6 +269,56 @@
     name: c4.8xlarge
     cloud_properties:
       instance_type: c4.8xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: c5a.large
+    cloud_properties:
+      instance_type: c5a.large
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: c5a.xlarge
+    cloud_properties:
+      instance_type: c5a.xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: c5a.2xlarge
+    cloud_properties:
+      instance_type: c5a.2xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: c5a.4xlarge
+    cloud_properties:
+      instance_type: c5a.4xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: c5a.8xlarge
+    cloud_properties:
+      instance_type: c5a.8xlarge
       ephemeral_disk:
         size: 10240
         type: gp3
@@ -275,6 +376,56 @@
 - type: replace
   path: /vm_types/-
   value:
+    name: r5a.large
+    cloud_properties:
+      instance_type: r5a.large
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: r5a.xlarge
+    cloud_properties:
+      instance_type: r5a.xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: r5a.2xlarge
+    cloud_properties:
+      instance_type: r5a.2xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: r5a.4xlarge
+    cloud_properties:
+      instance_type: r5a.4xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: r5a.8xlarge
+    cloud_properties:
+      instance_type: r5a.8xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
     name: t2.nano
     cloud_properties:
       instance_type: t2.nano
@@ -318,6 +469,56 @@
     name: t2.large
     cloud_properties:
       instance_type: t2.large
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: t3a.nano
+    cloud_properties:
+      instance_type: t3a.nano
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: t3a.micro
+    cloud_properties:
+      instance_type: t3a.micro
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: t3a.small
+    cloud_properties:
+      instance_type: t3a.small
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: t3a.medium
+    cloud_properties:
+      instance_type: t3a.medium
+      ephemeral_disk:
+        size: 10240
+        type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: t3a.large
+    cloud_properties:
+      instance_type: t3a.large
       ephemeral_disk:
         size: 10240
         type: gp3

--- a/cloudconfig/azure/base_ops_template.go
+++ b/cloudconfig/azure/base_ops_template.go
@@ -98,5 +98,101 @@ const (
     ephemeral_disk:
       size: 10240
     instance_type: Standard_B1ms
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_F2s_v2
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_F2s_v2
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_F4s_v2
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_F4s_v2
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_F8s_v2
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_F8s_v2
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_E2s_v3
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_E2s_v3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_E4s_v3
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_E4s_v3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_E8s_v3
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_E8s_v3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_B1s
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_B1s
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_B1ms
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_B1ms
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_B2s
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_B2s
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_D2_v3
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_D2_v3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_D4_v3
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_D4_v3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_D8_v3
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_D8_v3
 `
 )

--- a/cloudconfig/azure/fixtures/azure-ops.yml
+++ b/cloudconfig/azure/fixtures/azure-ops.yml
@@ -96,6 +96,102 @@
     instance_type: Standard_B1ms
 
 - type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_F2s_v2
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_F2s_v2
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_F4s_v2
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_F4s_v2
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_F8s_v2
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_F8s_v2
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_E2s_v3
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_E2s_v3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_E4s_v3
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_E4s_v3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_E8s_v3
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_E8s_v3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_B1s
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_B1s
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_B1ms
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_B1ms
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_B2s
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_B2s
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_D2_v3
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_D2_v3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_D4_v3
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_D4_v3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: Standard_D8_v3
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_D8_v3
+
+- type: replace
   path: /networks/-
   value:
     name: default

--- a/cloudconfig/gcp/base_ops_template.go
+++ b/cloudconfig/gcp/base_ops_template.go
@@ -265,6 +265,132 @@ const (
 - type: replace
   path: /vm_types/-
   value:
+    name: e2-standard-2
+    cloud_properties:
+      machine_type: e2-standard-2
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-standard-4
+    cloud_properties:
+      machine_type: e2-standard-4
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-standard-8
+    cloud_properties:
+      machine_type: e2-standard-8
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-standard-16
+    cloud_properties:
+      machine_type: e2-standard-16
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-standard-32
+    cloud_properties:
+      machine_type: e2-standard-32
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-highmem-2
+    cloud_properties:
+      machine_type: e2-highmem-2
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-highmem-4
+    cloud_properties:
+      machine_type: e2-highmem-4
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-highmem-8
+    cloud_properties:
+      machine_type: e2-highmem-8
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-highmem-16
+    cloud_properties:
+      machine_type: e2-highmem-16
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-highcpu-2
+    cloud_properties:
+      machine_type: e2-highcpu-2
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-highcpu-4
+    cloud_properties:
+      machine_type: e2-highcpu-4
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-highcpu-8
+    cloud_properties:
+      machine_type: e2-highcpu-8
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-highcpu-16
+    cloud_properties:
+      machine_type: e2-highcpu-16
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-highcpu-32
+    cloud_properties:
+      machine_type: e2-highcpu-32
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
     name: f1-micro
     cloud_properties:
       machine_type: f1-micro

--- a/cloudconfig/gcp/fixtures/gcp-ops.yml
+++ b/cloudconfig/gcp/fixtures/gcp-ops.yml
@@ -261,6 +261,132 @@
 - type: replace
   path: /vm_types/-
   value:
+    name: e2-standard-2
+    cloud_properties:
+      machine_type: e2-standard-2
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-standard-4
+    cloud_properties:
+      machine_type: e2-standard-4
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-standard-8
+    cloud_properties:
+      machine_type: e2-standard-8
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-standard-16
+    cloud_properties:
+      machine_type: e2-standard-16
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-standard-32
+    cloud_properties:
+      machine_type: e2-standard-32
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-highmem-2
+    cloud_properties:
+      machine_type: e2-highmem-2
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-highmem-4
+    cloud_properties:
+      machine_type: e2-highmem-4
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-highmem-8
+    cloud_properties:
+      machine_type: e2-highmem-8
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-highmem-16
+    cloud_properties:
+      machine_type: e2-highmem-16
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-highcpu-2
+    cloud_properties:
+      machine_type: e2-highcpu-2
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-highcpu-4
+    cloud_properties:
+      machine_type: e2-highcpu-4
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-highcpu-8
+    cloud_properties:
+      machine_type: e2-highcpu-8
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-highcpu-16
+    cloud_properties:
+      machine_type: e2-highcpu-16
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: e2-highcpu-32
+    cloud_properties:
+      machine_type: e2-highcpu-32
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
     name: f1-micro
     cloud_properties:
       machine_type: f1-micro


### PR DESCRIPTION
I did incorrectly ported over the community RFC 0009 intensions around compilation VM sizes, forgetting that they have to refer to VM Type in BOSH. So I added a lot of named VM types for modern VM sizes as well, allowing you to change compilation (or other VM) sizes more flexibly later.