### PR TITLE
Standardized medium and large VM sizes, add medium-highmem option

### DIFF
--- a/cloudconfig/aws/base_ops_template.go
+++ b/cloudconfig/aws/base_ops_template.go
@@ -105,7 +105,7 @@ const (
 - type: replace
   path: /vm_types/name=medium/cloud_properties?
   value:
-    instance_type: m4.xlarge
+    instance_type: m5a.xlarge
     ephemeral_disk:
       size: 10240
       type: gp3
@@ -113,7 +113,7 @@ const (
 - type: replace
   path: /vm_types/name=large/cloud_properties?
   value:
-    instance_type: m4.2xlarge
+    instance_type: m5a.2xlarge
     ephemeral_disk:
       size: 10240
       type: gp3
@@ -121,10 +121,20 @@ const (
 - type: replace
   path: /vm_types/name=extra-large/cloud_properties?
   value:
-    instance_type: m4.4xlarge
+    instance_type: m5a.4xlarge
     ephemeral_disk:
       size: 10240
       type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: medium-highmem
+    cloud_properties:
+      instance_type: r5a.xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
 
 - type: replace
   path: /vm_types/-

--- a/cloudconfig/aws/fixtures/aws-ops.yml
+++ b/cloudconfig/aws/fixtures/aws-ops.yml
@@ -101,7 +101,7 @@
 - type: replace
   path: /vm_types/name=medium/cloud_properties?
   value:
-    instance_type: m4.xlarge
+    instance_type: m5a.xlarge
     ephemeral_disk:
       size: 10240
       type: gp3
@@ -109,7 +109,7 @@
 - type: replace
   path: /vm_types/name=large/cloud_properties?
   value:
-    instance_type: m4.2xlarge
+    instance_type: m5a.2xlarge
     ephemeral_disk:
       size: 10240
       type: gp3
@@ -117,10 +117,20 @@
 - type: replace
   path: /vm_types/name=extra-large/cloud_properties?
   value:
-    instance_type: m4.4xlarge
+    instance_type: m5a.4xlarge
     ephemeral_disk:
       size: 10240
       type: gp3
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: medium-highmem
+    cloud_properties:
+      instance_type: r5a.xlarge
+      ephemeral_disk:
+        size: 10240
+        type: gp3
 
 - type: replace
   path: /vm_types/-

--- a/cloudconfig/azure/base_ops_template.go
+++ b/cloudconfig/azure/base_ops_template.go
@@ -76,14 +76,14 @@ const (
   value:
     ephemeral_disk:
       size: 10240
-    instance_type: Standard_F4s_v2
+    instance_type: Standard_D4s_v3
 
 - type: replace
   path: /vm_types/name=large/cloud_properties?
   value:
     ephemeral_disk:
       size: 10240
-    instance_type: Standard_DS12_v2
+    instance_type: Standard_D8s_v3
 
 - type: replace
   path: /vm_types/name=small-highmem/cloud_properties?
@@ -98,6 +98,14 @@ const (
     ephemeral_disk:
       size: 10240
     instance_type: Standard_B1ms
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: medium-highmem
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_E4s_v3
 
 - type: replace
   path: /vm_types/-

--- a/cloudconfig/azure/fixtures/azure-ops.yml
+++ b/cloudconfig/azure/fixtures/azure-ops.yml
@@ -72,14 +72,14 @@
   value:
     ephemeral_disk:
       size: 10240
-    instance_type: Standard_F4s_v2
+    instance_type: Standard_D4s_v3
 
 - type: replace
   path: /vm_types/name=large/cloud_properties?
   value:
     ephemeral_disk:
       size: 10240
-    instance_type: Standard_DS12_v2
+    instance_type: Standard_D8s_v3
 
 - type: replace
   path: /vm_types/name=small-highmem/cloud_properties?
@@ -94,6 +94,14 @@
     ephemeral_disk:
       size: 10240
     instance_type: Standard_B1ms
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: medium-highmem
+    ephemeral_disk:
+      size: 10240
+    instance_type: Standard_E4s_v3
 
 - type: replace
   path: /vm_types/-

--- a/cloudconfig/gcp/base_ops_template.go
+++ b/cloudconfig/gcp/base_ops_template.go
@@ -92,30 +92,39 @@ const (
 - type: replace
   path: /vm_types/name=small-highcpu?/cloud_properties
   value:
-    machine_type: n1-highcpu-2
+    machine_type: e2-highcpu-2
     root_disk_size_gb: 10
     root_disk_type: pd-balanced
 
 - type: replace
   path: /vm_types/name=medium/cloud_properties?
   value:
-    machine_type: n1-standard-4
+    machine_type: e2-standard-4
     root_disk_size_gb: 10
     root_disk_type: pd-balanced
 
 - type: replace
   path: /vm_types/name=large/cloud_properties?
   value:
-    machine_type: n1-standard-8
+    machine_type: e2-standard-8
     root_disk_size_gb: 10
     root_disk_type: pd-balanced
 
 - type: replace
   path: /vm_types/name=extra-large/cloud_properties?
   value:
-    machine_type: n1-standard-16
+    machine_type: e2-standard-16
     root_disk_size_gb: 10
     root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: medium-highmem
+    cloud_properties:
+      machine_type: e2-highmem-4
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
 
 - type: replace
   path: /vm_types/-

--- a/cloudconfig/gcp/fixtures/gcp-ops.yml
+++ b/cloudconfig/gcp/fixtures/gcp-ops.yml
@@ -88,30 +88,39 @@
 - type: replace
   path: /vm_types/name=small-highcpu?/cloud_properties
   value:
-    machine_type: n1-highcpu-2
+    machine_type: e2-highcpu-2
     root_disk_size_gb: 10
     root_disk_type: pd-balanced
 
 - type: replace
   path: /vm_types/name=medium/cloud_properties?
   value:
-    machine_type: n1-standard-4
+    machine_type: e2-standard-4
     root_disk_size_gb: 10
     root_disk_type: pd-balanced
 
 - type: replace
   path: /vm_types/name=large/cloud_properties?
   value:
-    machine_type: n1-standard-8
+    machine_type: e2-standard-8
     root_disk_size_gb: 10
     root_disk_type: pd-balanced
 
 - type: replace
   path: /vm_types/name=extra-large/cloud_properties?
   value:
-    machine_type: n1-standard-16
+    machine_type: e2-standard-16
     root_disk_size_gb: 10
     root_disk_type: pd-balanced
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: medium-highmem
+    cloud_properties:
+      machine_type: e2-highmem-4
+      root_disk_size_gb: 10
+      root_disk_type: pd-balanced
 
 - type: replace
   path: /vm_types/-


### PR DESCRIPTION
* Small highmem may not be enough for diego with CATS in high
  parallelism, so we want to offer some additional cross-iaas
standardized options. Medium & large would be balanced CPU/memory,
whereas medium-highmem would be a larger memory-rich cell

Signed-off-by: David Stevenson <stevensonda@vmware.com>