### PR TITLE
ioutil is deprecated

### DIFF
--- a/acceptance-tests/actors/bbl.go
+++ b/acceptance-tests/actors/bbl.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -184,9 +183,9 @@ func (b BBL) SaveDirectorCA() string {
 	}, stdout, os.Stderr)
 	Eventually(session, 10*time.Minute).Should(gexec.Exit(0))
 
-	file, err := ioutil.TempFile("", "")
-	defer file.Close()
+	file, err := os.CreateTemp("", "")
 	Expect(err).NotTo(HaveOccurred())
+	defer file.Close()
 
 	file.Write(stdout.Bytes())
 

--- a/acceptance-tests/actors/gcp.go
+++ b/acceptance-tests/actors/gcp.go
@@ -3,7 +3,7 @@ package actors
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	"golang.org/x/oauth2/google"
 
@@ -22,7 +22,7 @@ type gcpLBHelper struct {
 }
 
 func NewGCPLBHelper(config acceptance.Config) gcpLBHelper {
-	rawServiceAccountKey, err := ioutil.ReadFile(config.GCPServiceAccountKey)
+	rawServiceAccountKey, err := os.ReadFile(config.GCPServiceAccountKey)
 	if err != nil {
 		rawServiceAccountKey = []byte(config.GCPServiceAccountKey)
 	}

--- a/acceptance-tests/bbl/latest_error_test.go
+++ b/acceptance-tests/bbl/latest_error_test.go
@@ -1,7 +1,7 @@
 package acceptance_test
 
 import (
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 
@@ -21,7 +21,7 @@ var _ = Describe("bbl latest-error", func() {
 		acceptance.SkipUnless("latest-error")
 
 		var err error
-		tempDirectory, err = ioutil.TempDir("", "")
+		tempDirectory, err = os.MkdirTemp("", "")
 		Expect(err).NotTo(HaveOccurred())
 
 		state := []byte(`{
@@ -30,7 +30,7 @@ var _ = Describe("bbl latest-error", func() {
 			"tfState": "some-tf-state",
 			"latestTFOutput": "some terraform output"
 		}`)
-		err = ioutil.WriteFile(filepath.Join(tempDirectory, storage.STATE_FILE), state, storage.StateMode)
+		err = os.WriteFile(filepath.Join(tempDirectory, storage.STATE_FILE), state, storage.StateMode)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/acceptance-tests/bbl/plan_test.go
+++ b/acceptance-tests/bbl/plan_test.go
@@ -1,7 +1,6 @@
 package acceptance_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -69,7 +68,7 @@ var _ = Describe("plan", func() {
 
 		By("modifying artifacts", func() {
 			for _, f := range expectedArtifacts {
-				err := ioutil.WriteFile(f, []byte("modified after plan"), storage.StateMode)
+				err := os.WriteFile(f, []byte("modified after plan"), storage.StateMode)
 				Expect(err).NotTo(HaveOccurred())
 			}
 		})
@@ -90,7 +89,7 @@ var _ = Describe("plan", func() {
 
 		By("verifying that modified artifacts were overwritten", func() {
 			for _, f := range expectedArtifacts {
-				contents, err := ioutil.ReadFile(f)
+				contents, err := os.ReadFile(f)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(contents)).NotTo(ContainSubstring("modified after plan"))
 			}

--- a/acceptance-tests/bbl/upgrade_test.go
+++ b/acceptance-tests/bbl/upgrade_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/user"
@@ -42,15 +41,15 @@ var _ = Describe("Upgrade", func() {
 		Expect(err).NotTo(HaveOccurred())
 		var bblBinaryLocation string
 		if runtime.GOOS == "darwin" {
-			bblBinaryLocation = fmt.Sprintf(BBLReleaseURL, "v8.4.41", "bbl-v8.4.41_osx")
+			bblBinaryLocation = fmt.Sprintf(BBLReleaseURL, "v8.4.111", "bbl-v8.4.111_osx")
 		} else {
-			bblBinaryLocation = fmt.Sprintf(BBLReleaseURL, "v8.4.41", "bbl-v8.4.41_linux_x86-64")
+			bblBinaryLocation = fmt.Sprintf(BBLReleaseURL, "v8.4.111", "bbl-v8.4.111_linux_x86-64")
 		}
 
 		resp, err := http.Get(bblBinaryLocation)
 		Expect(err).NotTo(HaveOccurred())
 
-		f, err = ioutil.TempFile("", "")
+		f, err = os.CreateTemp("", "")
 		Expect(err).NotTo(HaveOccurred())
 
 		_, err = io.Copy(f, resp.Body)
@@ -121,7 +120,7 @@ var _ = Describe("Upgrade", func() {
 
 		By("cleaning out an installation directory holding onto old golang", func() {
 			removeInstallation := func(stateFileName string) {
-				stateJSON, err := ioutil.ReadFile(filepath.Join(configuration.StateFileDir, "vars", stateFileName))
+				stateJSON, err := os.ReadFile(filepath.Join(configuration.StateFileDir, "vars", stateFileName))
 				Expect(err).NotTo(HaveOccurred())
 
 				var state struct {

--- a/acceptance-tests/config.go
+++ b/acceptance-tests/config.go
@@ -3,7 +3,6 @@ package acceptance
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -82,7 +81,7 @@ func LoadConfig() (Config, error) {
 	}
 
 	if config.StateFileDir == "" {
-		dir, err := ioutil.TempDir("", "")
+		dir, err := os.MkdirTemp("", "")
 		if err != nil {
 			return Config{}, err
 		}

--- a/acceptance-tests/no-iaas/state_query_test.go
+++ b/acceptance-tests/no-iaas/state_query_test.go
@@ -1,7 +1,7 @@
 package acceptance_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	acceptance "github.com/cloudfoundry/bosh-bootloader/acceptance-tests"
@@ -16,8 +16,8 @@ var _ = Describe("state query against a bbl 6.10.46 state file", func() {
 	var bbl actors.BBL
 
 	BeforeEach(func() {
-		stateDir, err := ioutil.TempDir("", "")
-		ioutil.WriteFile(filepath.Join(stateDir, "bbl-state.json"), []byte(BBL_STATE_6_10_46), storage.StateMode)
+		stateDir, err := os.MkdirTemp("", "")
+		os.WriteFile(filepath.Join(stateDir, "bbl-state.json"), []byte(BBL_STATE_6_10_46), storage.StateMode)
 		Expect(err).NotTo(HaveOccurred())
 		bbl = actors.NewBBL(stateDir, pathToBBL, acceptance.Config{}, "no-env", false)
 	})

--- a/acceptance-tests/state.go
+++ b/acceptance-tests/state.go
@@ -4,7 +4,6 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -36,7 +35,7 @@ func NewState(stateDirectory string) State {
 }
 
 func (s State) Checksum() string {
-	buf, err := ioutil.ReadFile(s.stateFilePath)
+	buf, err := os.ReadFile(s.stateFilePath)
 	Expect(err).NotTo(HaveOccurred())
 	return fmt.Sprintf("%x", md5.Sum(buf))
 }

--- a/application/state_validator_test.go
+++ b/application/state_validator_test.go
@@ -2,7 +2,6 @@ package application_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -22,7 +21,7 @@ var _ = Describe("StateValidator", func() {
 
 	BeforeEach(func() {
 		var err error
-		tempDirectory, err = ioutil.TempDir("", "")
+		tempDirectory, err = os.MkdirTemp("", "")
 		Expect(err).NotTo(HaveOccurred())
 
 		stateValidator = application.NewStateValidator(tempDirectory)
@@ -30,7 +29,7 @@ var _ = Describe("StateValidator", func() {
 
 	Context("when state file exists", func() {
 		BeforeEach(func() {
-			err := ioutil.WriteFile(filepath.Join(tempDirectory, "bbl-state.json"), []byte(""), storage.StateMode)
+			err := os.WriteFile(filepath.Join(tempDirectory, "bbl-state.json"), []byte(""), storage.StateMode)
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/backends/backend.go
+++ b/backends/backend.go
@@ -3,7 +3,6 @@ package backends
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/araddon/gou"
@@ -111,7 +110,7 @@ func (g gcsStateBackend) getGCPServiceAccountKey(key string) (string, error) {
 		return key, nil
 	}
 
-	keyBytes, err := ioutil.ReadFile(key)
+	keyBytes, err := os.ReadFile(key)
 	if err != nil {
 		return "", fmt.Errorf("Reading key: %v", err)
 	}

--- a/bbl/main.go
+++ b/bbl/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/rand"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -104,7 +103,7 @@ func main() {
 		out = os.Stdout
 	} else {
 		terraformCLI = bufferingCLI
-		out = ioutil.Discard
+		out = io.Discard
 	}
 	terraformExecutor := terraform.NewExecutor(terraformCLI, bufferingCLI, stateStore, afs, appConfig.Global.Debug, out)
 

--- a/bosh/manager_test.go
+++ b/bosh/manager_test.go
@@ -2,7 +2,6 @@ package bosh_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 
 	"github.com/cloudfoundry/bosh-bootloader/bosh"
@@ -511,7 +510,7 @@ director_ssl:
 
 		BeforeEach(func() {
 			var err error
-			varsDir, err = ioutil.TempDir("", "")
+			varsDir, err = os.MkdirTemp("", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			stateStore.GetVarsDirCall.Returns.Directory = varsDir

--- a/certs/validator.go
+++ b/certs/validator.go
@@ -7,7 +7,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -190,7 +190,7 @@ func readFile(propertyName string, flagName string, filePath string) ([]byte, er
 		return []byte{}, fmt.Errorf(`%s is not a regular file: %q`, propertyName, filePath)
 	}
 
-	fileData, err := ioutil.ReadAll(file)
+	fileData, err := io.ReadAll(file)
 	if err != nil {
 		return []byte{}, fmt.Errorf("%s: %s", err, filePath)
 	}

--- a/certs/validator_test.go
+++ b/certs/validator_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/cloudfoundry/bosh-bootloader/certs"
 	"github.com/cloudfoundry/bosh-bootloader/testhelpers"
@@ -317,10 +317,10 @@ var _ = Describe("CertificateValidator", func() {
 
 			BeforeEach(func() {
 				var err error
-				cert, err = ioutil.ReadFile("fixtures/pkcs8.crt")
+				cert, err = os.ReadFile("fixtures/pkcs8.crt")
 				Expect(err).NotTo(HaveOccurred())
 
-				key, err = ioutil.ReadFile("fixtures/pkcs8.key")
+				key, err = os.ReadFile("fixtures/pkcs8.key")
 				Expect(err).NotTo(HaveOccurred())
 			})
 

--- a/cloudconfig/azure/ops_generator_test.go
+++ b/cloudconfig/azure/ops_generator_test.go
@@ -2,7 +2,7 @@ package azure_test
 
 import (
 	"errors"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/cloudfoundry/bosh-bootloader/cloudconfig/azure"
@@ -37,7 +37,7 @@ var _ = Describe("AzureOpsGenerator", func() {
 		}}
 
 		var err error
-		expectedOpsFile, err = ioutil.ReadFile(filepath.Join("fixtures", "azure-ops.yml"))
+		expectedOpsFile, err = os.ReadFile(filepath.Join("fixtures", "azure-ops.yml"))
 		Expect(err).NotTo(HaveOccurred())
 
 		opsGenerator = azure.NewOpsGenerator(terraformManager)

--- a/cloudconfig/gcp/ops_generator_test.go
+++ b/cloudconfig/gcp/ops_generator_test.go
@@ -3,7 +3,7 @@ package gcp_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -133,7 +133,7 @@ concourse_target_pool: some-concourse-target-pool
 
 		BeforeEach(func() {
 			var err error
-			expectedOpsFile, err = ioutil.ReadFile(filepath.Join("fixtures", "gcp-ops.yml"))
+			expectedOpsFile, err = os.ReadFile(filepath.Join("fixtures", "gcp-ops.yml"))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -146,7 +146,7 @@ concourse_target_pool: some-concourse-target-pool
 		DescribeTable("returns an ops file with additional vm extensions to support lb",
 			func(lbType string) {
 				incomingState.LB.Type = lbType
-				expectedLBOpsFile, err := ioutil.ReadFile(filepath.Join("fixtures", fmt.Sprintf("gcp-%s-lb-ops.yml", lbType)))
+				expectedLBOpsFile, err := os.ReadFile(filepath.Join("fixtures", fmt.Sprintf("gcp-%s-lb-ops.yml", lbType)))
 				Expect(err).NotTo(HaveOccurred())
 				expectedOps := strings.Join([]string{string(expectedOpsFile), string(expectedLBOpsFile)}, "\n")
 

--- a/cloudconfig/manager_test.go
+++ b/cloudconfig/manager_test.go
@@ -2,7 +2,6 @@ package cloudconfig_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,7 +59,7 @@ var _ = Describe("Manager", func() {
 		opsGenerator.GenerateVarsCall.Returns.VarsYAML = "some-vars"
 
 		var err error
-		baseCloudConfig, err = ioutil.ReadFile("fixtures/base-cloud-config.yml")
+		baseCloudConfig, err = os.ReadFile("fixtures/base-cloud-config.yml")
 		Expect(err).NotTo(HaveOccurred())
 
 		manager = cloudconfig.NewManager(logger, configUpdater, dirProvider, opsGenerator, terraformManager, fileIO)

--- a/commands/print_env.go
+++ b/commands/print_env.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/cloudfoundry/bosh-bootloader/fileio"
@@ -116,7 +116,7 @@ func (p PrintEnv) Execute(args []string, state storage.State) error {
 			IaasType string            `json:"iaas_type"`
 			Bosh     map[string]string `json:"bosh"`
 		}
-		metadataContents, err := ioutil.ReadFile(metadataFile)
+		metadataContents, err := os.ReadFile(metadataFile)
 		if err != nil {
 			p.stderrLogger.Println(fmt.Sprintf("Failed to read %s: %s", metadataFile, err))
 			return err
@@ -138,7 +138,7 @@ func (p PrintEnv) Execute(args []string, state storage.State) error {
 		variables["CREDHUB_CA_CERT"] = metadata.Bosh["credhub_ca_cert"]
 
 		privateKeyPath := fmt.Sprintf("/tmp/%s.priv", metadata.Name)
-		err = ioutil.WriteFile(privateKeyPath, []byte(metadata.Bosh["jumpbox_private_key"]), 0600)
+		err = os.WriteFile(privateKeyPath, []byte(metadata.Bosh["jumpbox_private_key"]), 0600)
 		if err != nil {
 			p.stderrLogger.Println(fmt.Sprintf("Failed to write private key to %s: %s", privateKeyPath, err))
 			return err

--- a/commands/print_env_test.go
+++ b/commands/print_env_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -137,7 +136,7 @@ var _ = Describe("PrintEnv", func() {
 
 			BeforeEach(func() {
 				var err error
-				tmpDir, err = ioutil.TempDir("", "")
+				tmpDir, err = os.MkdirTemp("", "")
 				Expect(err).NotTo(HaveOccurred())
 
 				metadataState = map[string]interface{}{
@@ -165,7 +164,7 @@ var _ = Describe("PrintEnv", func() {
 
 				metadataFilePath = filepath.Join(tmpDir, "metadata.json")
 
-				err = ioutil.WriteFile(metadataFilePath, metadataJson, 0660)
+				err = os.WriteFile(metadataFilePath, metadataJson, 0660)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -192,7 +191,7 @@ var _ = Describe("PrintEnv", func() {
 				Expect(logger.PrintlnCall.Messages).To(ContainElement(`export JUMPBOX_PRIVATE_KEY=/tmp/sweetsixteen.priv`))
 				Expect(logger.PrintlnCall.Messages).To(ContainElement(`export BOSH_ALL_PROXY=ssh+socks5://jumpbox@8.8.8.8:22?private-key=/tmp/sweetsixteen.priv`))
 
-				contents, err := ioutil.ReadFile("/tmp/sweetsixteen.priv")
+				contents, err := os.ReadFile("/tmp/sweetsixteen.priv")
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(string(contents)).To(Equal("-----BEGIN RSA PRIVATE KEY-----\nsome-jumpbox-private-key\n-----END RSA PRIVATE KEY-----\n"))
@@ -222,7 +221,7 @@ var _ = Describe("PrintEnv", func() {
 				Context("when unmarshalling fails", func() {
 					BeforeEach(func() {
 						badJsonFilePath := filepath.Join(tmpDir, "bad.json")
-						err := ioutil.WriteFile(badJsonFilePath, []byte(`{"name": "", asdf}`), 0660)
+						err := os.WriteFile(badJsonFilePath, []byte(`{"name": "", asdf}`), 0660)
 						Expect(err).NotTo(HaveOccurred())
 					})
 

--- a/config/bosh_path_test.go
+++ b/config/bosh_path_test.go
@@ -1,7 +1,6 @@
 package config_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -20,12 +19,12 @@ var _ = Describe("GetBOSHPath", func() {
 	BeforeEach(func() {
 		originalPath = os.Getenv("PATH")
 
-		tempDir, err := ioutil.TempDir("", "")
+		tempDir, err := os.MkdirTemp("", "")
 		Expect(err).NotTo(HaveOccurred())
 
 		pathToBOSH = filepath.Join(tempDir, "bosh")
 
-		err = ioutil.WriteFile(pathToBOSH, []byte("fake"), os.ModePerm)
+		err = os.WriteFile(pathToBOSH, []byte("fake"), os.ModePerm)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/config/load_state.go
+++ b/config/load_state.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -68,7 +67,7 @@ func ParseArgs(args []string) (GlobalFlags, []string, error) {
 	}
 
 	if globals.StateBucket != "" && globals.StateDir == "" {
-		tempDir, err := ioutil.TempDir("", "bbl-state")
+		tempDir, err := os.MkdirTemp("", "bbl-state")
 		if err != nil {
 			return GlobalFlags{}, remainingArgs, err // not tested
 		}

--- a/config/load_state_test.go
+++ b/config/load_state_test.go
@@ -3,7 +3,6 @@ package config_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -279,7 +278,7 @@ var _ = Describe("LoadState", func() {
 				var stateDir string
 				BeforeEach(func() {
 					var err error
-					stateDir, err = ioutil.TempDir("", "my-state-dir-")
+					stateDir, err = os.MkdirTemp("", "my-state-dir-")
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -821,7 +820,7 @@ var _ = Describe("LoadState", func() {
 			)
 			BeforeEach(func() {
 				var err error
-				tempFile, err = ioutil.TempFile("", "temp")
+				tempFile, err = os.CreateTemp("", "temp")
 				Expect(err).NotTo(HaveOccurred())
 				serviceAccountKey = `{"project_id": "some-project-id"}`
 

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -2,7 +2,7 @@ package flags
 
 import (
 	"flag"
-	"io/ioutil"
+	"io"
 )
 
 type Flags struct {
@@ -12,7 +12,7 @@ type Flags struct {
 func New(name string) Flags {
 	set := flag.NewFlagSet(name, flag.ContinueOnError)
 	set.Usage = func() {}
-	set.SetOutput(ioutil.Discard)
+	set.SetOutput(io.Discard)
 
 	return Flags{
 		set: set,

--- a/gcp/client_provider_test.go
+++ b/gcp/client_provider_test.go
@@ -3,9 +3,9 @@ package gcp_test
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 
 	"github.com/cloudfoundry/bosh-bootloader/gcp"
 	"github.com/cloudfoundry/bosh-bootloader/storage"
@@ -21,7 +21,7 @@ var _ = Describe("NewClient", func() {
 	)
 
 	BeforeEach(func() {
-		privateKeyContents, err := ioutil.ReadFile("fixtures/service-account-key")
+		privateKeyContents, err := os.ReadFile("fixtures/service-account-key")
 		Expect(err).NotTo(HaveOccurred())
 		serviceAccountKey = fmt.Sprintf(`{
 				"type": "service_account",

--- a/storage/bootstrap_test.go
+++ b/storage/bootstrap_test.go
@@ -1,7 +1,6 @@
 package storage_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -27,14 +26,14 @@ var _ = Describe("StateBootstrap", func() {
 			bootstrap = storage.NewStateBootstrap(logger, latestVersion)
 
 			var err error
-			tempDir, err = ioutil.TempDir("", "")
+			tempDir, err = os.MkdirTemp("", "")
 
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		Context("when there is a completely empty state file", func() {
 			BeforeEach(func() {
-				err := ioutil.WriteFile(filepath.Join(tempDir, "bbl-state.json"), []byte(`{}`), storage.StateMode)
+				err := os.WriteFile(filepath.Join(tempDir, "bbl-state.json"), []byte(`{}`), storage.StateMode)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -50,7 +49,7 @@ var _ = Describe("StateBootstrap", func() {
 
 		Context("when there is a pre v3 state file", func() {
 			BeforeEach(func() {
-				err := ioutil.WriteFile(filepath.Join(tempDir, "bbl-state.json"), []byte(`{
+				err := os.WriteFile(filepath.Join(tempDir, "bbl-state.json"), []byte(`{
 					"version": 2
 				}`), storage.StateMode)
 				Expect(err).NotTo(HaveOccurred())
@@ -64,7 +63,7 @@ var _ = Describe("StateBootstrap", func() {
 
 		Context("when there is a current version state file", func() {
 			BeforeEach(func() {
-				err := ioutil.WriteFile(filepath.Join(tempDir, "bbl-state.json"), []byte(`{
+				err := os.WriteFile(filepath.Join(tempDir, "bbl-state.json"), []byte(`{
 					"version": 13,
 					"bblVersion": "some-bbl-version",
 					"iaas": "aws",
@@ -106,7 +105,7 @@ var _ = Describe("StateBootstrap", func() {
 
 		Context("when there is a state file missing BBL version", func() {
 			BeforeEach(func() {
-				err := ioutil.WriteFile(filepath.Join(tempDir, "bbl-state.json"), []byte(`{
+				err := os.WriteFile(filepath.Join(tempDir, "bbl-state.json"), []byte(`{
 					"version": 12
 				}`), storage.StateMode)
 				Expect(err).NotTo(HaveOccurred())
@@ -125,7 +124,7 @@ var _ = Describe("StateBootstrap", func() {
 
 		Context("when there is a state file with a newer version than internal version", func() {
 			BeforeEach(func() {
-				err := ioutil.WriteFile(filepath.Join(tempDir, "bbl-state.json"), []byte(`{
+				err := os.WriteFile(filepath.Join(tempDir, "bbl-state.json"), []byte(`{
 					"version": 999,
 					"bblVersion": "9.9.9"
 				}`), storage.StateMode)
@@ -148,7 +147,7 @@ var _ = Describe("StateBootstrap", func() {
 
 			Context("when state.json exists", func() {
 				BeforeEach(func() {
-					err := ioutil.WriteFile(filepath.Join(tempDir, "state.json"), []byte(`{
+					err := os.WriteFile(filepath.Join(tempDir, "state.json"), []byte(`{
 						"version": 2,
 						"aws": {
 							"accessKeyId": "some-aws-access-key-id",
@@ -193,7 +192,7 @@ var _ = Describe("StateBootstrap", func() {
 
 			Context("when it fails to decode the bbl-state.json file", func() {
 				It("returns an error", func() {
-					err := ioutil.WriteFile(filepath.Join(tempDir, "bbl-state.json"), []byte(`%%%%`), storage.StateMode)
+					err := os.WriteFile(filepath.Join(tempDir, "bbl-state.json"), []byte(`%%%%`), storage.StateMode)
 					Expect(err).NotTo(HaveOccurred())
 
 					_, err = bootstrap.GetState(tempDir)

--- a/storage/migrator_test.go
+++ b/storage/migrator_test.go
@@ -2,7 +2,6 @@ package storage_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -32,7 +31,7 @@ var _ = Describe("Migrator", func() {
 		migrator = storage.NewMigrator(store, fileIO)
 
 		var err error
-		stateDir, err = ioutil.TempDir("", "")
+		stateDir, err = os.MkdirTemp("", "")
 		Expect(err).NotTo(HaveOccurred())
 
 		cloudConfigDir = filepath.Join(stateDir, "cloud-config")

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -2,7 +2,6 @@ package storage_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -25,7 +24,7 @@ var _ = Describe("Store", func() {
 
 	BeforeEach(func() {
 		var err error
-		tempDir, err = ioutil.TempDir("", "")
+		tempDir, err = os.MkdirTemp("", "")
 
 		fileIO = &fakes.FileIO{}
 		garbageCollector = &fakes.GarbageCollector{}

--- a/terraform/aws/template_generator_test.go
+++ b/terraform/aws/template_generator_test.go
@@ -2,7 +2,7 @@ package aws_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/cloudfoundry/bosh-bootloader/storage"
@@ -81,7 +81,7 @@ var _ = Describe("TemplateGenerator", func() {
 func expectTemplate(parts ...string) string {
 	var contents []string
 	for _, p := range parts {
-		content, err := ioutil.ReadFile(fmt.Sprintf("templates/%s.tf", p))
+		content, err := os.ReadFile(fmt.Sprintf("templates/%s.tf", p))
 		Expect(err).NotTo(HaveOccurred())
 		contents = append(contents, string(content))
 	}

--- a/terraform/azure/template_generator_test.go
+++ b/terraform/azure/template_generator_test.go
@@ -2,7 +2,7 @@ package azure_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/cloudfoundry/bosh-bootloader/storage"
@@ -66,7 +66,7 @@ var _ = Describe("TemplateGenerator", func() {
 func expectTemplate(parts ...string) string {
 	var contents []string
 	for _, p := range parts {
-		content, err := ioutil.ReadFile(fmt.Sprintf("templates/%s.tf", p))
+		content, err := os.ReadFile(fmt.Sprintf("templates/%s.tf", p))
 		Expect(err).NotTo(HaveOccurred())
 		contents = append(contents, string(content))
 	}

--- a/terraform/executor.go
+++ b/terraform/executor.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -329,7 +328,7 @@ func (e Executor) IsPaved() (bool, error) {
 		return false, err
 	}
 
-	err = e.cli.Run(ioutil.Discard, terraformDir, []string{"init"})
+	err = e.cli.Run(io.Discard, terraformDir, []string{"init"})
 	if err != nil {
 		return false, fmt.Errorf("Run terraform init in terraform dir: %s", err)
 	}

--- a/terraform/executor_test.go
+++ b/terraform/executor_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,11 +46,11 @@ var _ = Describe("Executor", func() {
 		debugFalse = terraform.NewExecutor(cli, bufferingCLI, stateStore, fileIO, false, nil)
 
 		var err error
-		terraformDir, err = ioutil.TempDir("", "terraform")
+		terraformDir, err = os.MkdirTemp("", "terraform")
 		Expect(err).NotTo(HaveOccurred())
 		stateStore.GetTerraformDirCall.Returns.Directory = terraformDir
 
-		varsDir, err = ioutil.TempDir("", "vars")
+		varsDir, err = os.MkdirTemp("", "vars")
 		Expect(err).NotTo(HaveOccurred())
 		stateStore.GetVarsDirCall.Returns.Directory = varsDir
 
@@ -197,10 +196,10 @@ var _ = Describe("Executor", func() {
 					FileName: "bbl.tfvars",
 				},
 			}
-			err := ioutil.WriteFile(tfStatePath, []byte("some-updated-terraform-state"), storage.StateMode)
+			err := os.WriteFile(tfStatePath, []byte("some-updated-terraform-state"), storage.StateMode)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = ioutil.WriteFile(tfVarsPath, []byte("some-tfvars"), storage.StateMode)
+			err = os.WriteFile(tfVarsPath, []byte("some-tfvars"), storage.StateMode)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -272,7 +271,7 @@ var _ = Describe("Executor", func() {
 
 		Context("when terraform command run fails", func() {
 			BeforeEach(func() {
-				err := ioutil.WriteFile(tfStatePath, []byte("some-tf-state"), storage.StateMode)
+				err := os.WriteFile(tfStatePath, []byte("some-tf-state"), storage.StateMode)
 				Expect(err).NotTo(HaveOccurred())
 
 				cli.RunCall.Returns.Errors = []error{errors.New("the-executor-error")}
@@ -303,10 +302,10 @@ var _ = Describe("Executor", func() {
 					FileName: "bbl.tfvars",
 				},
 			}
-			err := ioutil.WriteFile(tfStatePath, []byte("some-updated-terraform-state"), storage.StateMode)
+			err := os.WriteFile(tfStatePath, []byte("some-updated-terraform-state"), storage.StateMode)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = ioutil.WriteFile(tfVarsPath, []byte("some-tfvars"), storage.StateMode)
+			err = os.WriteFile(tfVarsPath, []byte("some-tfvars"), storage.StateMode)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -382,7 +381,7 @@ var _ = Describe("Executor", func() {
 
 		Context("when terraform command run fails", func() {
 			BeforeEach(func() {
-				err := ioutil.WriteFile(tfStatePath, []byte("some-tf-state"), storage.StateMode)
+				err := os.WriteFile(tfStatePath, []byte("some-tf-state"), storage.StateMode)
 				Expect(err).NotTo(HaveOccurred())
 
 				cli.RunCall.Returns.Errors = []error{errors.New("the-executor-error")}
@@ -464,7 +463,7 @@ var _ = Describe("Executor", func() {
 
 			Context("when command run fails", func() {
 				BeforeEach(func() {
-					err := ioutil.WriteFile(tfStatePath, []byte("some-tf-state"), storage.StateMode)
+					err := os.WriteFile(tfStatePath, []byte("some-tf-state"), storage.StateMode)
 					Expect(err).NotTo(HaveOccurred())
 					cli.RunCall.Returns.Errors = []error{errors.New("the-executor-error")}
 				})
@@ -533,7 +532,7 @@ var _ = Describe("Executor", func() {
 
 	Describe("Output", func() {
 		BeforeEach(func() {
-			err := ioutil.WriteFile(tfStatePath, []byte("some-tf-state"), storage.StateMode)
+			err := os.WriteFile(tfStatePath, []byte("some-tf-state"), storage.StateMode)
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/terraform/gcp/template_generator_test.go
+++ b/terraform/gcp/template_generator_test.go
@@ -2,7 +2,7 @@ package gcp_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/cloudfoundry/bosh-bootloader/storage"
@@ -156,7 +156,7 @@ resource "google_compute_instance_group" "router-lb-2" {
 func expectTemplate(parts ...string) string {
 	var contents []string
 	for _, p := range parts {
-		content, err := ioutil.ReadFile(fmt.Sprintf("templates/%s.tf", p))
+		content, err := os.ReadFile(fmt.Sprintf("templates/%s.tf", p))
 		Expect(err).NotTo(HaveOccurred())
 		contents = append(contents, string(content))
 	}

--- a/terraform/openstack/template_generator_test.go
+++ b/terraform/openstack/template_generator_test.go
@@ -2,7 +2,7 @@ package openstack_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/cloudfoundry/bosh-bootloader/storage"
@@ -36,7 +36,7 @@ var _ = Describe("TemplateGenerator", func() {
 func expectTemplate(parts ...string) string {
 	var contents []string
 	for _, p := range parts {
-		content, err := ioutil.ReadFile(fmt.Sprintf("templates/%s.tf", p))
+		content, err := os.ReadFile(fmt.Sprintf("templates/%s.tf", p))
 		Expect(err).NotTo(HaveOccurred())
 		contents = append(contents, string(content))
 	}

--- a/testhelpers/temp_file_helpers.go
+++ b/testhelpers/temp_file_helpers.go
@@ -1,18 +1,17 @@
 package testhelpers
 
 import (
-	"io/ioutil"
 	"os"
 )
 
 func WriteByteContentsToTempFile(contents []byte) (string, error) {
-	tempFile, err := ioutil.TempFile("", "")
+	tempFile, err := os.CreateTemp("", "")
 	if err != nil {
 		return "", err
 	}
 	defer tempFile.Close()
 
-	err = ioutil.WriteFile(tempFile.Name(), contents, os.ModePerm)
+	err = os.WriteFile(tempFile.Name(), contents, os.ModePerm)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
as we moved to go 1.19 for the packr to embed pr #549 
ioutil is deprecated since go 1.17
and we need to use there io/os counter part packages

first pr #549 needs to be merged before this