### PR TITLE
update ci for the main branch

### DIFF
--- a/ci/dockerfiles/deployment/Dockerfile
+++ b/ci/dockerfiles/deployment/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.13
-MAINTAINER https://github.com/cloudfoundry/bosh-bootloader
+FROM golang:1.19
+LABEL maintainer="https://github.com/cloudfoundry/bosh-bootloader"
 
 ARG GITHUB_TOKEN
-ENV TERRAFORM_VERSION 0.15.3
+ENV TERRAFORM_VERSION 1.3.9
 ENV RUBY_VERSION 3.0.1
 
 # Create testuser

--- a/ci/pipelines/bosh-bootloader.yml
+++ b/ci/pipelines/bosh-bootloader.yml
@@ -18,7 +18,7 @@ groups:
 - name: misc
   jobs:
   - bump-bbl-docs
-  - bump-bbl-deployment-image
+  # - bump-bbl-deployment-image
 #  - bump-brew-tap
 
 resource_types:
@@ -28,17 +28,17 @@ resource_types:
     repository: cloudfoundry/bosh-deployment-resource
 
 resources:
-- name: once-a-day
-  type: time
-  source:
-    interval: 24h
+# - name: once-a-day
+#   type: time
+#   source:
+#     interval: 24h
 
-- name: cryogenics-bbl-deployment
-  type: docker-image
-  source:
-    repository: cryogenics/bbl-deployment
-    username: ((dockerhub.username))
-    password: ((dockerhub.password))
+# - name: cryogenics-bbl-deployment
+#   type: docker-image
+#   source:
+#     repository: cryogenics/bbl-deployment
+#     username: ((dockerhub.username))
+#     password: ((dockerhub.password))
 
 - name: ubuntu-bionic-stemcell-gcp
   type: bosh-io-stemcell
@@ -60,7 +60,7 @@ resources:
   source:
     uri: git@github.com:cloudfoundry/bosh-bootloader.git
     branch: main
-    private_key: ((readwrite_deploy_key.private_key))
+    private_key: ((github.private_key))
     # ignore_paths:
     #   - docs/**
     #   - README.md
@@ -77,14 +77,14 @@ resources:
   source:
     uri: git@github.com:cloudfoundry/bosh-bootloader.git
     branch: gh-pages
-    private_key: ((readwrite_deploy_key.private_key))
+    private_key: ((github.private_key))
 
 - name: relint-envs
   type: git
   source:
-    uri: git@github.com:cloudfoundry/relint-envs.git
+    uri: git@github.com:cloudfoundry/bosh-bootloader-ci-envs.git
     branch: main
-    private_key: ((hagrid_env_readwrite_deploy_key.private_key))
+    private_key: ((github.private_key))
 
 # - name: version
 #   type: semver
@@ -100,12 +100,12 @@ resources:
 - name: version-bump-deployments
   type: semver
   source:
-    driver: s3
-    bucket: bbl-version
-    region_name: us-east-1
-    key: bbl-version-bump-deployments
-    access_key_id: ((s3_aws.access_key_id))
-    secret_access_key: ((s3_aws.secret_access_key))
+    driver: git
+    uri: git@github.com:cloudfoundry/bosh-bootloader.git
+    private_key: ((github.private_key))
+    branch: version
+    file: main
+    initial_version: 9.0.0
 
 # - name: bbl-release
 #   type: github-release
@@ -120,7 +120,7 @@ resources:
   source:
     owner: cloudfoundry
     repository: bosh-bootloader
-    access_token: ((github.access_token))
+    access_token: ((github-access-token))
     drafts: false
 
 # - name: homebrew-tap
@@ -163,8 +163,8 @@ resources:
   type: docker-image
   source:
     repository: relintdockerhubpushbot/cf-deployment-concourse-tasks-bbl-dev
-    username: ((bbl_dockerhub.username))
-    password: ((bbl_dockerhub.password))
+    username: ((dockerhub_username))
+    password: ((dockerhub_password))
     email: cf-release-integration+dockerhub-push-bot@pivotal.io
 
 - name: cf-deployment-concourse-tasks-docker-image
@@ -178,7 +178,7 @@ resources:
   source:
     uri: git@github.com:cloudfoundry/bosh-bootloader.git
     branch: main
-    private_key: ((readwrite_deploy_key.private_key))
+    private_key: ((github.private_key))
     paths:
     - dockerfiles/cf-deployment-concourse-tasks-bbl-dev
 
@@ -187,7 +187,7 @@ resources:
   source:
     uri: git@github.com:cloudfoundry/bosh-bootloader.git
     branch: bump-deployments-ci
-    private_key: ((readwrite_deploy_key.private_key))
+    private_key: ((github.private_key))
 
 - name: concourse-smoke-tests
   type: git
@@ -212,15 +212,16 @@ resources:
     uri: https://github.com/cloudfoundry/runtime-ci
 
 jobs:
-- name: bump-bbl-deployment-image
-  plan:
-  - in_parallel:
-    - get: bosh-bootloader
-    - get: once-a-day
-      trigger: true
-  - put: cryogenics-bbl-deployment
-    params:
-      build: bosh-bootloader/ci/dockerfiles/deployment-8.4.x/
+# - name: bump-bbl-deployment-image
+#   plan:
+#   - in_parallel:
+#     - get: bosh-bootloader
+#     - get: once-a-day
+#       trigger: true
+#   - put: cryogenics-bbl-deployment
+#     params:
+#       tag: master
+#       build: bosh-bootloader/ci/dockerfiles/deployment/
 
 - name: sync-version-bump-deployments
   serial: true
@@ -267,7 +268,7 @@ jobs:
     input_mapping:
       bbl-release: bbl-release-official
     params:
-      DEPLOY_KEY: ((readwrite_deploy_key.private_key))
+      DEPLOY_KEY: ((github.private_key))
 
   - put: bump-deployments-ci
     resource: bosh-bootloader-bump-deployments-ci
@@ -311,7 +312,7 @@ jobs:
 #   - task: download-terraform
 #     file: bbl-ci/ci/tasks/download-terraform/task.yml
 #     params:
-#       TF_VERSION: 0.15.3
+#       TF_VERSION: 1.3.9
 #
 #   - in_parallel:
 #     - task: plan
@@ -378,13 +379,13 @@ jobs:
   - task: download-terraform
     file: bbl-ci/ci/tasks/download-terraform/task.yml
     params:
-      TF_VERSION: 0.15.3
+      TF_VERSION: 1.3.9
 
   - task: bbl-tests
     file: bbl-ci/ci/tasks/acceptance/task.yml
     params:
       BBL_IAAS: gcp
-      BBL_GCP_SERVICE_ACCOUNT_KEY: ((bbl_gcp.service_account_json))
+      BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp_json_key))
       BBL_GCP_REGION: us-central1
       BBL_TEST_ENV_ID_PREFIX: bump-deployments
       BBL_TEST_PACKAGES: bbl
@@ -413,7 +414,7 @@ jobs:
   - task: download-terraform
     file: bbl-ci/ci/tasks/download-terraform/task.yml
     params:
-      TF_VERSION: 0.15.3
+      TF_VERSION: 1.3.9
 
   - task: generate-version-from-sha
     file: bbl-ci/ci/tasks/generate-version-from-sha/task.yml
@@ -741,7 +742,7 @@ jobs:
     image: cf-deployment-concourse-tasks-bbl-dev
     params:
       BBL_IAAS: gcp
-      BBL_GCP_SERVICE_ACCOUNT_KEY: ((bbl_gcp.service_account_json))
+      BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp_json_key))
       BBL_GCP_REGION: us-central1
       BBL_ENV_NAME: bump-deployments-downstream
       BBL_STATE_DIR: bump-deployments/bbl-gcp-cf
@@ -751,11 +752,11 @@ jobs:
     image: cf-deployment-concourse-tasks-bbl-dev
     params:
       BBL_IAAS: gcp
-      BBL_GCP_SERVICE_ACCOUNT_KEY: ((bbl_gcp.service_account_json))
+      BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp_json_key))
       BBL_GCP_REGION: us-central1
-      BBL_LB_CERT: ((bbl_cf_ssl_cert.certificate))
-      BBL_LB_KEY: ((bbl_cf_ssl_cert.private_key))
-      LB_DOMAIN: bump-deployments-cf.infrastructure.cf-app.com
+      BBL_LB_CERT: ((bbl_lb_cert.certificate))
+      BBL_LB_KEY: ((bbl_lb_cert.private_key))
+      LB_DOMAIN: bosh-bootloader-cf.ci.cloudfoundry.org
       BBL_ENV_NAME: bump-deployments-downstream
       BBL_STATE_DIR: bump-deployments/bbl-gcp-cf
       GIT_COMMIT_EMAIL: cf-infrastructure@pivotal.io
@@ -769,7 +770,7 @@ jobs:
       image: cf-deployment-concourse-tasks-bbl-dev
       params:
         BBL_STATE_DIR: bump-deployments/bbl-gcp-cf
-        BBL_GCP_SERVICE_ACCOUNT_KEY: ((bbl_gcp.service_account_json))
+        BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp_json_key))
       input_mapping:
         bbl-state: updated-bbl-state
       ensure:
@@ -797,7 +798,7 @@ jobs:
         bbl-state: updated-bbl-state
       params:
         BBL_STATE_DIR: bump-deployments/bbl-gcp-cf
-        BBL_GCP_SERVICE_ACCOUNT_KEY: ((bbl_gcp.service_account_json))
+        BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp_json_key))
       ensure:
         put: relint-envs
         params:
@@ -811,7 +812,7 @@ jobs:
       bbl-state: updated-bbl-state
     params:
       BBL_STATE_DIR: bump-deployments/bbl-gcp-cf
-      BBL_GCP_SERVICE_ACCOUNT_KEY: ((bbl_gcp.service_account_json))
+      BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp_json_key))
       SYSTEM_DOMAIN: bump-deployments-cf.infrastructure.cf-app.com
       VARS_STORE_FILE: bump-deployments/bbl-gcp-cf/deployment-vars.yml
       OPS_FILES: "operations/use-compiled-releases.yml"
@@ -836,7 +837,7 @@ jobs:
           bbl-state: updated-bbl-state
         params:
           BBL_STATE_DIR: bump-deployments/bbl-gcp-cf
-          BBL_GCP_SERVICE_ACCOUNT_KEY: ((bbl_gcp.service_account_json))
+          BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp_json_key))
 
       - task: bosh-cleanup
         file: cf-deployment-concourse-tasks/bosh-cleanup/task.yml
@@ -846,7 +847,7 @@ jobs:
         params:
           CLEAN_ALL: true
           BBL_STATE_DIR: bump-deployments/bbl-gcp-cf
-          BBL_GCP_SERVICE_ACCOUNT_KEY: ((bbl_gcp.service_account_json))
+          BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp_json_key))
 
       - task: destroy-infrastructure
         file: cf-deployment-concourse-tasks/bbl-destroy/task.yml
@@ -855,7 +856,7 @@ jobs:
           bbl-state: updated-bbl-state
         params:
           BBL_STATE_DIR: bump-deployments/bbl-gcp-cf
-          BBL_GCP_SERVICE_ACCOUNT_KEY: ((bbl_gcp.service_account_json))
+          BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp_json_key))
         ensure:
           put: relint-envs
           params:
@@ -879,7 +880,7 @@ jobs:
           bbl-state: updated-bbl-state
         params:
           BBL_STATE_DIR: bump-deployments/bbl-gcp-cf
-          BBL_GCP_SERVICE_ACCOUNT_KEY: ((bbl_gcp.service_account_json))
+          BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp_json_key))
 
       - task: bosh-cleanup
         file: cf-deployment-concourse-tasks/bosh-cleanup/task.yml
@@ -889,7 +890,7 @@ jobs:
         params:
           CLEAN_ALL: true
           BBL_STATE_DIR: bump-deployments/bbl-gcp-cf
-          BBL_GCP_SERVICE_ACCOUNT_KEY: ((bbl_gcp.service_account_json))
+          BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp_json_key))
 
       - task: remove-from-gcp-dns
         file: runtime-ci/tasks/manage-gcp-dns/task.yml
@@ -910,7 +911,7 @@ jobs:
           bbl-state: updated-bbl-state
         params:
           BBL_STATE_DIR: bump-deployments/bbl-gcp-cf
-          BBL_GCP_SERVICE_ACCOUNT_KEY: ((bbl_gcp.service_account_json))
+          BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp_json_key))
         on_failure:
           put: relint-envs
           params:
@@ -947,7 +948,7 @@ jobs:
     image: cf-deployment-concourse-tasks-bbl-dev
     params:
       BBL_IAAS: gcp
-      BBL_GCP_SERVICE_ACCOUNT_KEY: ((bbl_gcp.service_account_json))
+      BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp_json_key))
       BBL_GCP_REGION: us-central1
       BBL_ENV_NAME: bump-deployments-gcp-concourse
       BBL_STATE_DIR: bump-deployments/bbl-gcp-concourse
@@ -957,7 +958,7 @@ jobs:
     image: cf-deployment-concourse-tasks-bbl-dev
     params:
       BBL_IAAS: gcp
-      BBL_GCP_SERVICE_ACCOUNT_KEY: ((bbl_gcp.service_account_json))
+      BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp_json_key))
       BBL_GCP_REGION: us-central1
       BBL_ENV_NAME: bump-deployments-gcp-concourse
       BBL_STATE_DIR: bump-deployments/bbl-gcp-concourse
@@ -969,7 +970,7 @@ jobs:
       image: cf-deployment-concourse-tasks-bbl-dev
       params:
         BBL_STATE_DIR: bump-deployments/bbl-gcp-concourse
-        BBL_GCP_SERVICE_ACCOUNT_KEY: ((bbl_gcp.service_account_json))
+        BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp_json_key))
       input_mapping:
         bbl-state: updated-bbl-state
       ensure:
@@ -1027,7 +1028,7 @@ jobs:
           bbl-state: updated-bbl-state
         params:
           BBL_STATE_DIR: bump-deployments/bbl-gcp-concourse
-          BBL_GCP_SERVICE_ACCOUNT_KEY: ((bbl_gcp.service_account_json))
+          BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp_json_key))
         on_failure:
           put: relint-envs
           params:
@@ -1242,7 +1243,7 @@ jobs:
   - task: download-terraform
     file: bbl-ci/ci/tasks/download-terraform/task.yml
     params:
-      TF_VERSION: 0.15.3
+      TF_VERSION: 1.3.9
 
   - task: build-binaries
     file: bbl-ci/ci/tasks/build-release/task.yml

--- a/ci/tasks/bump-deployments/task.yml
+++ b/ci/tasks/bump-deployments/task.yml
@@ -4,11 +4,12 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfinfrastructure/golang
+    repository: bosh/integration
+    tag: main
 
 inputs:
 - name: bbl-ci
-- name: bbl-release
+- name: bbl-release-official
 - name: bosh-bootloader
 - name: bosh-deployment
 - name: jumpbox-deployment

--- a/ci/tasks/download-terraform/task.yml
+++ b/ci/tasks/download-terraform/task.yml
@@ -4,7 +4,8 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfinfrastructure/golang
+    repository: bosh/integration
+    tag: main
 
 inputs:
 - name: bbl-ci


### PR DESCRIPTION
- changed tasks to our general maintained docker images
- temp remove the creation of new crygenic-bbl docker-images to see if we actually need them
- refelect the credentials names as we use them in the infra credhub

these changes are all needed for the move to bosh.ci.cloudfoundry.org