### PR TITLE
run terraform init when plugins are missing

### DIFF
--- a/cloudconfig/azure/fixtures/azure-ops.yml
+++ b/cloudconfig/azure/fixtures/azure-ops.yml
@@ -1,6 +1,6 @@
 - type: replace
   path: /compilation/vm_type
-  value: Standard_F2s_v2
+  value: small
 
 - type: replace
   path: /azs/-

--- a/terraform/executor.go
+++ b/terraform/executor.go
@@ -286,10 +286,23 @@ func (e Executor) Output(outputName string) (string, error) {
 	return strings.TrimSuffix(buffer.String(), "\n"), nil
 }
 
+func (e Executor) terraformInitIfNeeded(terraformDir string) error {
+	_, err := e.fs.Stat(filepath.Join(terraformDir, ".terraform"))
+	if err == nil {
+		return nil
+	}
+
+	return e.Init()
+}
+
 func (e Executor) Outputs() (map[string]interface{}, error) {
 	terraformDir, err := e.stateStore.GetTerraformDir()
 	if err != nil {
 		return map[string]interface{}{}, err
+	}
+
+	if err = e.terraformInitIfNeeded(terraformDir); err != nil {
+		return nil, err
 	}
 
 	varsDir, err := e.stateStore.GetVarsDir()


### PR DESCRIPTION
Many environments remove the `./terraform/.terraform` directory from the
bbl state directory to reduce the bbl-state size.

bbl replaces these plugins on subsequent "up" and "destroy" operations
as needed, but as of bbl v9, these plugins are also required for "bbl
outputs" and "bbl jumpbox-address" commands.

This change runs "terraform init --upgrade" when terraform outputs are
requested and the terraform/.terraform directory is missing.

This allow environments to omit the .terraform directory to still reduce
the bbl-state size and also supports consuming bbl-state across
different architectures (e.g. linux <=> darwin) without having to
manually run "terraform init".

Fixes #560