### PR TITLE
Fix azure templates according to the newer terraform versions

### DIFF
--- a/plan-patches/byoresource-group-azure/terraform/resource_group_override.tf
+++ b/plan-patches/byoresource-group-azure/terraform/resource_group_override.tf
@@ -24,14 +24,6 @@ resource "azurerm_storage_account" "bosh" {
   resource_group_name = "${data.azurerm_resource_group.bosh.name}"
 }
 
-resource "azurerm_storage_container" "bosh" {
-  resource_group_name = "${data.azurerm_resource_group.bosh.name}"
-}
-
-resource "azurerm_storage_container" "stemcell" {
-  resource_group_name = "${data.azurerm_resource_group.bosh.name}"
-}
-
 resource "azurerm_network_security_group" "bosh" {
   resource_group_name = "${data.azurerm_resource_group.bosh.name}"
 }

--- a/plan-patches/cf-azure/terraform/cf_lb_override.tf
+++ b/plan-patches/cf-azure/terraform/cf_lb_override.tf
@@ -2,7 +2,7 @@ resource "azurerm_public_ip" "cf-balancer-ip" {
   name                         = "${var.env_id}-cf-lb-ip"
   location                     = "${var.region}"
   resource_group_name          = "${azurerm_resource_group.bosh.name}"
-  public_ip_address_allocation = "static"
+  allocation_method            = "Static"
   sku                          = "Standard"
 }
 
@@ -20,13 +20,11 @@ resource "azurerm_lb" "cf-balancer" {
 
 resource "azurerm_lb_backend_address_pool" "cf-balancer-backend-pool" {
   name                = "${var.env_id}-cf-backend-pool"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id     = "${azurerm_lb.cf-balancer.id}"
 }
 
 resource "azurerm_lb_probe" "health-probe" {
   name                = "${var.env_id}-health-probe"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id     = "${azurerm_lb.cf-balancer.id}"
   protocol            = "HTTP"
   request_path        = "/health"
@@ -37,24 +35,22 @@ resource "azurerm_lb_probe" "health-probe" {
 
 resource "azurerm_lb_rule" "cf-balancer-rule-https" {
   name                           = "${var.env_id}-https-rule"
-  resource_group_name            = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id                = "${azurerm_lb.cf-balancer.id}"
   protocol                       = "Tcp"
   frontend_port                  = 443
   backend_port                   = 443
   frontend_ip_configuration_name = "${azurerm_public_ip.cf-balancer-ip.name}"
   probe_id                       = "${azurerm_lb_probe.health-probe.id}"
-  backend_address_pool_id        = "${azurerm_lb_backend_address_pool.cf-balancer-backend-pool.id}"
+  backend_address_pool_ids       = ["${azurerm_lb_backend_address_pool.cf-balancer-backend-pool.id}"]
 }
 
 resource "azurerm_lb_rule" "cf-balancer-rule-http" {
   name                           = "${var.env_id}-http-rule"
-  resource_group_name            = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id                = "${azurerm_lb.cf-balancer.id}"
   protocol                       = "Tcp"
   frontend_port                  = 80
   backend_port                   = 80
   frontend_ip_configuration_name = "${azurerm_public_ip.cf-balancer-ip.name}"
   probe_id                       = "${azurerm_lb_probe.health-probe.id}"
-  backend_address_pool_id        = "${azurerm_lb_backend_address_pool.cf-balancer-backend-pool.id}"
+  backend_address_pool_ids       = ["${azurerm_lb_backend_address_pool.cf-balancer-backend-pool.id}"]
 }

--- a/plan-patches/cf-azure/terraform/cf_resource_group_override.tf
+++ b/plan-patches/cf-azure/terraform/cf_resource_group_override.tf
@@ -3,7 +3,7 @@ resource "azurerm_resource_group" "cf" {
   name     = "${var.env_id}-cf"
   location = "${var.region}"
 
-  tags {
+  tags = {
     environment = "${var.env_id}"
   }
 }

--- a/plan-patches/cf-azure/terraform/cf_subnet.tf
+++ b/plan-patches/cf-azure/terraform/cf_subnet.tf
@@ -3,5 +3,5 @@ resource "azurerm_subnet" "cf-subnet" {
   name                 = "${var.env_id}-cf-sn"
   resource_group_name  = "${azurerm_resource_group.bosh.name}"
   virtual_network_name = "${azurerm_virtual_network.bosh.name}"
-  address_prefix       = "${cidrsubnet(var.network_cidr, 4, 1)}"
+  address_prefixes     = ["${cidrsubnet(var.network_cidr, 4, 1)}"]
 }

--- a/plan-patches/cf-lite-azure/terraform/cf_lb_override.tf
+++ b/plan-patches/cf-lite-azure/terraform/cf_lb_override.tf
@@ -2,7 +2,7 @@ resource "azurerm_public_ip" "cf-balancer-ip" {
   name                         = "${var.env_id}-cf-lb-ip"
   location                     = "${var.region}"
   resource_group_name          = "${azurerm_resource_group.bosh.name}"
-  public_ip_address_allocation = "static"
+  allocation_method            = "Static"
   sku                          = "Standard"
 }
 
@@ -20,13 +20,11 @@ resource "azurerm_lb" "cf-balancer" {
 
 resource "azurerm_lb_backend_address_pool" "cf-balancer-backend-pool" {
   name                = "${var.env_id}-cf-backend-pool"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id     = "${azurerm_lb.cf-balancer.id}"
 }
 
 resource "azurerm_lb_probe" "health-probe" {
   name                = "${var.env_id}-health-probe"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id     = "${azurerm_lb.cf-balancer.id}"
   protocol            = "HTTP"
   request_path        = "/health"
@@ -37,24 +35,22 @@ resource "azurerm_lb_probe" "health-probe" {
 
 resource "azurerm_lb_rule" "cf-balancer-rule-https" {
   name                           = "${var.env_id}-https-rule"
-  resource_group_name            = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id                = "${azurerm_lb.cf-balancer.id}"
   protocol                       = "Tcp"
   frontend_port                  = 443
   backend_port                   = 443
   frontend_ip_configuration_name = "${azurerm_public_ip.cf-balancer-ip.name}"
   probe_id                       = "${azurerm_lb_probe.health-probe.id}"
-  backend_address_pool_id        = "${azurerm_lb_backend_address_pool.cf-balancer-backend-pool.id}"
+  backend_address_pool_ids       = ["${azurerm_lb_backend_address_pool.cf-balancer-backend-pool.id}"]
 }
 
 resource "azurerm_lb_rule" "cf-balancer-rule-http" {
   name                           = "${var.env_id}-http-rule"
-  resource_group_name            = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id                = "${azurerm_lb.cf-balancer.id}"
   protocol                       = "Tcp"
   frontend_port                  = 80
   backend_port                   = 80
   frontend_ip_configuration_name = "${azurerm_public_ip.cf-balancer-ip.name}"
   probe_id                       = "${azurerm_lb_probe.health-probe.id}"
-  backend_address_pool_id        = "${azurerm_lb_backend_address_pool.cf-balancer-backend-pool.id}"
+  backend_address_pool_ids       = ["${azurerm_lb_backend_address_pool.cf-balancer-backend-pool.id}"]
 }

--- a/plan-patches/cf-lite-azure/terraform/cf_subnet.tf
+++ b/plan-patches/cf-lite-azure/terraform/cf_subnet.tf
@@ -3,5 +3,5 @@ resource "azurerm_subnet" "cf-subnet" {
   name                 = "${var.env_id}-cf-sn"
   resource_group_name  = "${azurerm_resource_group.bosh.name}"
   virtual_network_name = "${azurerm_virtual_network.bosh.name}"
-  address_prefix       = "${cidrsubnet(var.network_cidr, 4, 1)}"
+  address_prefixes     = ["${cidrsubnet(var.network_cidr, 4, 1)}"]
 }

--- a/plan-patches/cfcr-azure/terraform/cfcr_lb_override.tf
+++ b/plan-patches/cfcr-azure/terraform/cfcr_lb_override.tf
@@ -2,7 +2,7 @@ resource "azurerm_public_ip" "cfcr-balancer-ip" {
   name                         = "${var.env_id}-cfcr-lb-ip"
   location                     = "${var.region}"
   resource_group_name          = "${azurerm_resource_group.cfcr.name}"
-  public_ip_address_allocation = "static"
+  allocation_method            = "Static"
   sku                          = "Standard"
 }
 
@@ -20,13 +20,11 @@ resource "azurerm_lb" "cfcr-balancer" {
 
 resource "azurerm_lb_backend_address_pool" "cfcr-balancer-backend-pool" {
   name                = "${var.env_id}-cfcr-backend-pool"
-  resource_group_name = "${azurerm_resource_group.cfcr.name}"
   loadbalancer_id     = "${azurerm_lb.cfcr-balancer.id}"
 }
 
 resource "azurerm_lb_probe" "api-health-probe" {
   name                = "${var.env_id}-api-health-probe"
-  resource_group_name = "${azurerm_resource_group.cfcr.name}"
   loadbalancer_id     = "${azurerm_lb.cfcr-balancer.id}"
   protocol            = "Tcp"
   interval_in_seconds = 5
@@ -36,12 +34,11 @@ resource "azurerm_lb_probe" "api-health-probe" {
 
 resource "azurerm_lb_rule" "cfcr-balancer-api-rule" {
   name                           = "${var.env_id}-api-rule"
-  resource_group_name            = "${azurerm_resource_group.cfcr.name}"
   loadbalancer_id                = "${azurerm_lb.cfcr-balancer.id}"
   protocol                       = "Tcp"
   frontend_port                  = 8443
   backend_port                   = 8443
   frontend_ip_configuration_name = "${azurerm_public_ip.cfcr-balancer-ip.name}"
   probe_id                       = "${azurerm_lb_probe.api-health-probe.id}"
-  backend_address_pool_id        = "${azurerm_lb_backend_address_pool.cfcr-balancer-backend-pool.id}"
+  backend_address_pool_ids       = ["${azurerm_lb_backend_address_pool.cfcr-balancer-backend-pool.id}"]
 }

--- a/plan-patches/cfcr-azure/terraform/cfcr_subnet.tf
+++ b/plan-patches/cfcr-azure/terraform/cfcr_subnet.tf
@@ -3,6 +3,6 @@ resource "azurerm_subnet" "cfcr-subnet" {
   name                 = "${var.env_id}-cfcr-sn"
   resource_group_name  = "${azurerm_resource_group.bosh.name}"
   virtual_network_name = "${azurerm_virtual_network.bosh.name}"
-  address_prefix       = "${cidrsubnet(var.network_cidr, 4, 1)}"
+  address_prefixes     = ["${cidrsubnet(var.network_cidr, 4, 1)}"]
   network_security_group_id = "${azurerm_network_security_group.cfcr-master.id}"
 }

--- a/terraform/azure/templates/cf_dns.tf
+++ b/terraform/azure/templates/cf_dns.tf
@@ -8,7 +8,7 @@ resource "azurerm_dns_zone" "cf" {
   name                = "${var.system_domain}"
   resource_group_name = "${azurerm_resource_group.bosh.name}"
 
-  tags {
+  tags = {
     environment = "${var.env_id}"
   }
 }

--- a/terraform/azure/templates/cf_lb.tf
+++ b/terraform/azure/templates/cf_lb.tf
@@ -6,7 +6,7 @@ variable "pfx_password" {}
 
 resource "azurerm_subnet" "cf-sn" {
   name                 = "${var.env_id}-cf-sn"
-  address_prefix       = "${cidrsubnet(var.network_cidr, 8, 1)}"
+  address_prefixes     = ["${cidrsubnet(var.network_cidr, 8, 1)}"]
   resource_group_name  = "${azurerm_resource_group.bosh.name}"
   virtual_network_name = "${azurerm_virtual_network.bosh.name}"
 }
@@ -16,7 +16,7 @@ resource "azurerm_network_security_group" "cf" {
   location            = "${var.region}"
   resource_group_name = "${azurerm_resource_group.bosh.name}"
 
-  tags {
+  tags = {
     environment = "${var.env_id}"
   }
 }
@@ -67,7 +67,7 @@ resource "azurerm_public_ip" "cf" {
   name                         = "${var.env_id}-cf-lb-ip"
   location                     = "${var.region}"
   resource_group_name          = "${azurerm_resource_group.bosh.name}"
-  public_ip_address_allocation = "dynamic"
+  allocation_method            = "Dynamic"
 }
 
 resource "azurerm_application_gateway" "cf" {

--- a/terraform/azure/templates/concourse_lb.tf
+++ b/terraform/azure/templates/concourse_lb.tf
@@ -2,10 +2,10 @@ resource "azurerm_public_ip" "concourse" {
   name                         = "${var.env_id}-concourse-lb"
   location                     = "${var.region}"
   resource_group_name          = "${azurerm_resource_group.bosh.name}"
-  public_ip_address_allocation = "static"
+  allocation_method            = "Static"
   sku                          = "Standard"
 
-  tags {
+  tags = {
     environment = "${var.env_id}"
   }
 }
@@ -24,89 +24,81 @@ resource "azurerm_lb" "concourse" {
 
 resource "azurerm_lb_rule" "concourse-https" {
   name                = "${var.env_id}-concourse-https"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id     = "${azurerm_lb.concourse.id}"
 
   frontend_ip_configuration_name = "${var.env_id}-concourse-frontend-ip-configuration"
-  protocol                       = "TCP"
+  protocol                       = "Tcp"
   frontend_port                  = 443
   backend_port                   = 443
 
-  backend_address_pool_id = "${azurerm_lb_backend_address_pool.concourse.id}"
+  backend_address_pool_ids = ["${azurerm_lb_backend_address_pool.concourse.id}"]
   probe_id                = "${azurerm_lb_probe.concourse-https.id}"
 }
 
 resource "azurerm_lb_probe" "concourse-https" {
   name                = "${var.env_id}-concourse-https"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id     = "${azurerm_lb.concourse.id}"
-  protocol            = "TCP"
+  protocol            = "Tcp"
   port                = 443
 }
 
 resource "azurerm_lb_rule" "concourse-http" {
   name                = "${var.env_id}-concourse-http"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id     = "${azurerm_lb.concourse.id}"
 
   frontend_ip_configuration_name = "${var.env_id}-concourse-frontend-ip-configuration"
-  protocol                       = "TCP"
+  protocol                       = "Tcp"
   frontend_port                  = 80
   backend_port                   = 80
 
-  backend_address_pool_id = "${azurerm_lb_backend_address_pool.concourse.id}"
+  backend_address_pool_ids = ["${azurerm_lb_backend_address_pool.concourse.id}"]
   probe_id                = "${azurerm_lb_probe.concourse-http.id}"
 }
 
 resource "azurerm_lb_probe" "concourse-http" {
   name                = "${var.env_id}-concourse-http"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id     = "${azurerm_lb.concourse.id}"
-  protocol            = "TCP"
+  protocol            = "Tcp"
   port                = 80
 }
 
 resource "azurerm_lb_rule" "concourse-uaa" {
   name                = "${var.env_id}-concourse-uaa"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id     = "${azurerm_lb.concourse.id}"
 
   frontend_ip_configuration_name = "${var.env_id}-concourse-frontend-ip-configuration"
-  protocol                       = "TCP"
+  protocol                       = "Tcp"
   frontend_port                  = 8443
   backend_port                   = 8443
 
-  backend_address_pool_id = "${azurerm_lb_backend_address_pool.concourse.id}"
+  backend_address_pool_ids = ["${azurerm_lb_backend_address_pool.concourse.id}"]
   probe_id                = "${azurerm_lb_probe.concourse-uaa.id}"
 }
 
 resource "azurerm_lb_probe" "concourse-uaa" {
   name                = "${var.env_id}-concourse-uaa"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id     = "${azurerm_lb.concourse.id}"
-  protocol            = "TCP"
+  protocol            = "Tcp"
   port                = 8443
 }
 
 resource "azurerm_lb_rule" "concourse-credhub" {
   name                = "${var.env_id}-concourse-credhub"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id     = "${azurerm_lb.concourse.id}"
 
   frontend_ip_configuration_name = "${var.env_id}-concourse-frontend-ip-configuration"
-  protocol                       = "TCP"
+  protocol                       = "Tcp"
   frontend_port                  = 8844
   backend_port                   = 8844
 
-  backend_address_pool_id = "${azurerm_lb_backend_address_pool.concourse.id}"
+  backend_address_pool_ids = ["${azurerm_lb_backend_address_pool.concourse.id}"]
   probe_id                = "${azurerm_lb_probe.concourse-credhub.id}"
 }
 
 resource "azurerm_lb_probe" "concourse-credhub" {
   name                = "${var.env_id}-concourse-credhub"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id     = "${azurerm_lb.concourse.id}"
-  protocol            = "TCP"
+  protocol            = "Tcp"
   port                = 8844
 }
 
@@ -168,7 +160,6 @@ resource "azurerm_network_security_rule" "uaa" {
 
 resource "azurerm_lb_backend_address_pool" "concourse" {
   name                = "${var.env_id}-concourse-backend-pool"
-  resource_group_name = "${azurerm_resource_group.bosh.name}"
   loadbalancer_id     = "${azurerm_lb.concourse.id}"
 }
 

--- a/terraform/azure/templates/network.tf
+++ b/terraform/azure/templates/network.tf
@@ -7,7 +7,7 @@ resource "azurerm_virtual_network" "bosh" {
 
 resource "azurerm_subnet" "bosh" {
   name                 = "${var.env_id}-bosh-sn"
-  address_prefix       = "${cidrsubnet(var.network_cidr, 8, 0)}"
+  address_prefixes     = ["${cidrsubnet(var.network_cidr, 8, 0)}"]
   resource_group_name  = "${azurerm_resource_group.bosh.name}"
   virtual_network_name = "${azurerm_virtual_network.bosh.name}"
 }

--- a/terraform/azure/templates/network_security_group.tf
+++ b/terraform/azure/templates/network_security_group.tf
@@ -3,7 +3,7 @@ resource "azurerm_network_security_group" "bosh" {
   location            = "${var.region}"
   resource_group_name = "${azurerm_resource_group.bosh.name}"
 
-  tags {
+  tags = {
     environment = "${var.env_id}"
   }
 }

--- a/terraform/azure/templates/resource_group.tf
+++ b/terraform/azure/templates/resource_group.tf
@@ -2,7 +2,7 @@ resource "azurerm_resource_group" "bosh" {
   name     = "${var.env_id}-bosh"
   location = "${var.region}"
 
-  tags {
+  tags = {
     environment = "${var.env_id}"
   }
 }
@@ -11,9 +11,9 @@ resource "azurerm_public_ip" "bosh" {
   name                         = "${var.env_id}-bosh"
   location                     = "${var.region}"
   resource_group_name          = "${azurerm_resource_group.bosh.name}"
-  public_ip_address_allocation = "static"
+  allocation_method            = "Static"
 
-  tags {
+  tags = {
     environment = "${var.env_id}"
   }
 }

--- a/terraform/azure/templates/storage.tf
+++ b/terraform/azure/templates/storage.tf
@@ -12,7 +12,7 @@ resource "azurerm_storage_account" "bosh" {
   account_tier             = "Standard"
   account_replication_type = "GRS"
 
-  tags {
+  tags = {
     environment = "${var.env_id}"
   }
 
@@ -23,14 +23,12 @@ resource "azurerm_storage_account" "bosh" {
 
 resource "azurerm_storage_container" "bosh" {
   name                  = "bosh"
-  resource_group_name   = "${azurerm_resource_group.bosh.name}"
   storage_account_name  = "${azurerm_storage_account.bosh.name}"
   container_access_type = "private"
 }
 
 resource "azurerm_storage_container" "stemcell" {
   name                  = "stemcell"
-  resource_group_name   = "${azurerm_resource_group.bosh.name}"
   storage_account_name  = "${azurerm_storage_account.bosh.name}"
   container_access_type = "blob"
 }

--- a/terraform/azure/templates/vars.tf
+++ b/terraform/azure/templates/vars.tf
@@ -25,6 +25,7 @@ provider "azurerm" {
   tenant_id       = "${var.tenant_id}"
   client_id       = "${var.client_id}"
   client_secret   = "${var.client_secret}"
+  features {}
 }
 
 terraform {


### PR DESCRIPTION
Newer version of terraform introduced changes to the template syntax.
This PR fixes all Azure templates so that:
```
bbl up
bbl plan --lb-type concourse && bbl up
bbl plan --lb-type cf ....  && bbl up
```
all execute without errors.