### PR TITLE
ci: Fix ops files for deploy-cf task

### DIFF
--- a/ci/pipelines/bosh-bootloader.yml
+++ b/ci/pipelines/bosh-bootloader.yml
@@ -825,9 +825,7 @@ jobs:
       BBL_GCP_SERVICE_ACCOUNT_KEY: ((gcp_json_key))
       SYSTEM_DOMAIN: bump-deployments-cf.bbl.ci.cloudfoundry.org
       VARS_STORE_FILE: bump-deployments/bbl-gcp-cf/deployment-vars.yml
-      OPS_FILES:
-        - "operations/use-compiled-releases.yml"
-        - "operations/experimental/fast-deploy-with-downtime-and-danger.yml"
+      OPS_FILES: operations/use-compiled-releases.yml operations/experimental/fast-deploy-with-downtime-and-danger.yml
     on_failure:
       do:
       - task: remove-from-gcp-dns


### PR DESCRIPTION
The cf-deployment-concourse-tasks/bosh-deploy/task.yml task expects that the OPS_FILES variable is formatted as a list of space-separated file names.

See: https://github.com/cloudfoundry/cf-deployment-concourse-tasks/blob/03f785df60c5d851ee47aee4967b06fa7327d8e2/shared-functions#L122-L125

Configuring it as a YAML array of file names led to the following error when it tries to build up the `-o` options for bosh:
```
invalid argument for flag `-o, --ops-file' (expected []opts.OpsFileArg):
Reading ops file
'ops-files/["operations/use-compiled-releases.yml","operations/experimental/fast-deploy-with-downtime-and-danger.yml"]':
Opening file
ops-files/["operations/use-compiled-releases.yml","operations/experimental/fast-deploy-with-downtime-and-danger.yml"]:
open
ops-files/["operations/use-compiled-releases.yml","operations/experimental/fast-deploy-with-downtime-and-danger.yml"]:
no such file or directory
```