### PR TITLE
Fix issues with the AWS DNS terraform template

### DIFF
--- a/terraform/aws/templates/cf_dns.tf
+++ b/terraform/aws/templates/cf_dns.tf
@@ -19,8 +19,8 @@ output "env_dns_zone_name_servers" {
 }
 
 locals {
-  zone_id      = "${var.parent_zone == "" ? element(concat(aws_route53_zone.env_dns_zone.*.zone_id, tolist([""])), 0) : element(concat(data.aws_route53_zone.parent.*.zone_id, tolist([""])), 0)}"
-  name_servers = "${var.parent_zone == "" ? join(",", flatten(concat(aws_route53_zone.env_dns_zone.*.name_servers, tolist([list([""])])))) :  join(",", flatten(concat(data.aws_route53_zone.env_dns_zone.*.name_servers, tolist([list([""])]))))}"
+  zone_id      = one(try(aws_route53_zone.env_dns_zone[*].zone_id, data.aws_route53_zone.parent[*].zone_id))
+  name_servers = join(",", flatten(concat(try(aws_route53_zone.env_dns_zone[*].name_servers, data.aws_route53_zone.parent[*].name_servers), tolist([tolist([""])]))))
 }
 
 resource "aws_route53_zone" "env_dns_zone" {
@@ -88,5 +88,5 @@ resource "aws_route53_record" "iso" {
   type    = "CNAME"
   ttl     = 300
 
-  records = ["${aws_elb.iso_router_lb.dns_name}"]
+  records = [one(aws_elb.iso_router_lb[*].dns_name)]
 }

--- a/terraform/aws/templates/iso_segments.tf
+++ b/terraform/aws/templates/iso_segments.tf
@@ -208,11 +208,11 @@ resource "aws_security_group_rule" "nat_to_isolated_cells_rule" {
 }
 
 output "cf_iso_router_lb_name" {
-  value = "${element(concat(aws_elb.iso_router_lb.*.name, tolist([""])), 0)}"
+  value = one(aws_elb.iso_router_lb[*].name)
 }
 
 output "iso_security_group_id" {
-  value = "${element(concat(aws_security_group.iso_security_group.*.id, tolist([""])), 0)}"
+  value = one(aws_security_group.iso_security_group[*].id)
 }
 
 output "iso_az_subnet_id_mapping" {
@@ -228,5 +228,5 @@ output "iso_az_subnet_cidr_mapping" {
 }
 
 output "iso_shared_security_group_id" {
-  value = "${element(concat(aws_security_group.iso_shared_security_group.*.id, tolist([""])), 0)}"
+  value = one(aws_security_group.iso_shared_security_group[*].id)
 }


### PR DESCRIPTION
This PR addresses a couple of issues when installing on AWS:

- Correctly reference the `dns_name` property of the `iso_router_lb` resource.
- Fix the `name_servers` variable when `parent_zone` is set.

See #570 for details.