### PR TITLE
Update resources.tf - allocation_pool as a block

### DIFF
--- a/terraform/openstack/templates/resources.tf
+++ b/terraform/openstack/templates/resources.tf
@@ -17,7 +17,7 @@ resource "openstack_networking_subnet_v2" "bosh_subnet" {
   cidr             = "10.0.1.0/24"
   ip_version       = 4
   name             = "${var.env_id}-subnet"
-  allocation_pools = {
+  allocation_pool {
     start = "10.0.1.200"
     end   = "10.0.1.254"
   }


### PR DESCRIPTION
https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/networking_subnet_v2#allocation_pools

```
 bbl latest-error
╷
│ Error: Unsupported argument
│
│   on bbl-template.tf line 178, in resource "openstack_networking_subnet_v2" "bosh_subnet":
│  178:   allocation_pools = {
│
│ An argument named "allocation_pools" is not expected here. Did you mean to
│ define a block of type "allocation_pools"?
```