### PR TITLE
OpenStack terraform subnet customization

### DIFF
--- a/terraform/openstack/templates/resources-outputs.tf
+++ b/terraform/openstack/templates/resources-outputs.tf
@@ -82,3 +82,7 @@ output "env_id" {
 output "director_name" {
   value = "${var.env_id}"
 }
+
+output "dns_nameservers" {
+  value = "${var.dns_nameservers}"
+}

--- a/terraform/openstack/templates/resources-vars.tf
+++ b/terraform/openstack/templates/resources-vars.tf
@@ -21,3 +21,23 @@ variable "ext_net_name" {
 variable "region_name" {
   description = "OpenStack region name"
 }
+
+variable "subnet_cidr" {
+  description = "CIDR representing IP range for this subnet, IPv4"
+  default = "10.0.1.0/24"
+}
+
+variable "subnet_allocation_pool_start" {
+  description = "The start IP address available for use with DHCP in this subnet, each IP range must be from the same CIDR that the subnet is part of"
+  default = "10.0.1.200"
+}
+
+variable "subnet_allocation_pool_end" {
+  description = "The end IP address available for use with DHCP in this subnet, each IP range must be from the same CIDR that the subnet is part of"
+  default = "10.0.1.254"
+}
+
+variable "subnet_gateway_ip" {
+  description = "Default gateway used by devices in this subnet"
+  default = "10.0.1.1"
+}

--- a/terraform/openstack/templates/resources.tf
+++ b/terraform/openstack/templates/resources.tf
@@ -11,17 +11,18 @@ resource "openstack_networking_network_v2" "bosh" {
   admin_state_up = "true"
 }
 
+# subnet
 resource "openstack_networking_subnet_v2" "bosh_subnet" {
   region           = "${var.region_name}"
   network_id       = "${openstack_networking_network_v2.bosh.id}"
-  cidr             = "10.0.1.0/24"
+  cidr             = "${var.subnet_cidr}"
   ip_version       = 4
   name             = "${var.env_id}-subnet"
   allocation_pool {
-    start = "10.0.1.200"
-    end   = "10.0.1.254"
+    start = "${var.subnet_allocation_pool_start}"
+    end   = "${var.subnet_allocation_pool_end}"
   }
-  gateway_ip       = "10.0.1.1"
+  gateway_ip       = "${var.subnet_gateway_ip}"
   enable_dhcp      = "true"
   dns_nameservers  = "${var.dns_nameservers}"
 }


### PR DESCRIPTION
The change, thanks to the new variables, allows easy network configuration of: 
- `subnet_cidr` CIDR representing IP range for this subnet, IPv4, default = "10.0.1.0/24"
- `subnet_allocation_pool_start` - The start IP address available for use with DHCP in this subnet, each IP range must be from the same CIDR that the subnet is part of, default = "10.0.1.200"
- `subnet_allocation_pool_end` - The end IP address available for use with DHCP in this subnet, each IP range must be from the same CIDR that the subnet is part of, default = "10.0.1.254"
- `subnet_gateway_ip` - Default gateway used by devices in this subnet, default = "10.0.1.1"
These variables have default values set to those that were in the previous configuration, therefore without overwriting these variables, the configuration will be the same as in previous versions.

Additionally, the output publishes the DNS server addresses (`dns_nameservers`), which can be used in further processing.