### PR TITLE
Disable ephemeral_external_ip for GCP cloud config

### DIFF
--- a/cloudconfig/gcp/fixtures/gcp-ops.yml
+++ b/cloudconfig/gcp/fixtures/gcp-ops.yml
@@ -553,7 +553,7 @@
       static:
       - ((subnetwork_static_ips))
       cloud_properties:
-        ephemeral_external_ip: true
+        ephemeral_external_ip: false
         network_name: ((network))
         subnetwork_name: ((subnetwork))
         tags:
@@ -573,7 +573,7 @@
       static:
       - ((subnetwork_static_ips))
       cloud_properties:
-        ephemeral_external_ip: true
+        ephemeral_external_ip: false
         network_name: ((network))
         subnetwork_name: ((subnetwork))
         tags:

--- a/cloudconfig/gcp/ops_generator.go
+++ b/cloudconfig/gcp/ops_generator.go
@@ -168,7 +168,7 @@ func (o *OpsGenerator) generateGCPOps(state storage.State) ([]op, error) {
 			"((subnetwork_static_ips))",
 		},
 		CloudProperties: subnetCloudProperties{
-			EphemeralExternalIP: true,
+			EphemeralExternalIP: false,
 			NetworkName:         "((network))",
 			SubnetworkName:      "((subnetwork))",
 			Tags:                []string{"((internal_tag_name))"},


### PR DESCRIPTION
* since v9.0.11 bbl deploys a cloud NAT gateway on GCP for outgoing traffic, so we don't need external IPs anymore
* main problem were orphaned external IPs which incur additional cost