### PR TITLE
Enable dynamic port allocation for GCP Cloud NAT gateway

### DIFF
--- a/terraform/gcp/templates/bosh_director.tf
+++ b/terraform/gcp/templates/bosh_director.tf
@@ -120,6 +120,7 @@ resource "google_compute_router_nat" "nat" {
   region                             = "${var.region}"
   nat_ip_allocate_option             = "AUTO_ONLY"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+  enable_dynamic_port_allocation     = true
 
   log_config {
     enable = true


### PR DESCRIPTION
* with static port allocation we have a performance degradation