### PR TITLE
Removing required providers for cloudstack

### DIFF
--- a/terraform/cloudstack/templates/provider.tf
+++ b/terraform/cloudstack/templates/provider.tf
@@ -1,21 +1,3 @@
-terraform {
-  required_providers {
-    cloudstack = {
-      source = "orange-cloudfoundry/cloudstack"
-    }
-    local      = {
-      source = "hashicorp/local"
-    }
-    template   = {
-      source = "hashicorp/template"
-    }
-    tls        = {
-      source = "hashicorp/tls"
-    }
-  }
-  required_version = ">= 0.13"
-}
-
 provider "cloudstack" {
   api_url    = var.cloudstack_endpoint
   api_key    = var.cloudstack_api_key


### PR DESCRIPTION
For Cloudstack only, the required providers are genereted to the `bbl-template.tf` file. Therefore it is not possible to override the provider versions.

This change removes the required providers definition from the `bbl-template.tf` file for Cloudstack so the provider versions can be overridden like the others IaaS.
