### PR TITLE
Use local terraform binary if it exists

### DIFF
--- a/application/configuration.go
+++ b/application/configuration.go
@@ -3,9 +3,10 @@ package application
 import "github.com/cloudfoundry/bosh-bootloader/storage"
 
 type GlobalConfiguration struct {
-	StateDir string
-	Debug    bool
-	Name     string
+	StateDir         string
+	Debug            bool
+	Name             string
+	UseTfLocalBinary bool
 }
 
 type StringSlice []string

--- a/bbl/main.go
+++ b/bbl/main.go
@@ -94,14 +94,14 @@ func main() {
 	// Terraform
 	terraformOutputBuffer := bytes.NewBuffer([]byte{})
 	dotTerraformDir := filepath.Join(appConfig.Global.StateDir, "terraform", ".terraform")
-	bufferingCLI := terraform.NewCLI(terraformOutputBuffer, terraformOutputBuffer, dotTerraformDir)
+	bufferingCLI := terraform.NewCLI(terraformOutputBuffer, terraformOutputBuffer, dotTerraformDir, globals.UseTfLocalBinary)
 	var (
 		terraformCLI terraform.CLI
 		out          io.Writer
 	)
 	if appConfig.Global.Debug {
 		errBuffer := io.MultiWriter(os.Stderr, terraformOutputBuffer)
-		terraformCLI = terraform.NewCLI(errBuffer, terraformOutputBuffer, dotTerraformDir)
+		terraformCLI = terraform.NewCLI(errBuffer, terraformOutputBuffer, dotTerraformDir, globals.UseTfLocalBinary)
 		out = os.Stdout
 	} else {
 		terraformCLI = bufferingCLI

--- a/commands/usage.go
+++ b/commands/usage.go
@@ -13,11 +13,12 @@ Usage:
   bbl [GLOBAL OPTIONS] %s [OPTIONS]
 
 Global Options:
-  --help       [-h]        Prints usage. Use "bbl [command] --help" for more information about a command
-  --state-dir  [-s]        Directory containing the bbl state                                            env:"BBL_STATE_DIRECTORY"
-  --debug      [-d]        Prints debugging output                                                       env:"BBL_DEBUG"
-  --version    [-v]        Prints version
-  --no-confirm [-n]        No confirm
+  --help                 [-h] Prints usage. Use "bbl [command] --help" for more information about a command
+  --state-dir            [-s] Directory containing the bbl state                                            env:"BBL_STATE_DIRECTORY"
+  --debug                [-d] Prints debugging output                                                       env:"BBL_DEBUG"
+  --version              [-v] Prints version
+  --no-confirm           [-n] No confirm
+  --use-tf-local-binary  [-u] Use the local terraform binary if it exists                                   env:"BBL_USE_TF_LOCAL_BINARY"
 %s
 `
 	CommandUsage = `

--- a/commands/usage_test.go
+++ b/commands/usage_test.go
@@ -39,11 +39,12 @@ Usage:
   bbl [GLOBAL OPTIONS] COMMAND [OPTIONS]
 
 Global Options:
-  --help       [-h]        Prints usage. Use "bbl [command] --help" for more information about a command
-  --state-dir  [-s]        Directory containing the bbl state                                            env:"BBL_STATE_DIRECTORY"
-  --debug      [-d]        Prints debugging output                                                       env:"BBL_DEBUG"
-  --version    [-v]        Prints version
-  --no-confirm [-n]        No confirm
+  --help                 [-h] Prints usage. Use "bbl [command] --help" for more information about a command
+  --state-dir            [-s] Directory containing the bbl state                                            env:"BBL_STATE_DIRECTORY"
+  --debug                [-d] Prints debugging output                                                       env:"BBL_DEBUG"
+  --version              [-v] Prints version
+  --no-confirm           [-n] No confirm
+  --use-tf-local-binary  [-u] Use the local terraform binary if it exists                                   env:"BBL_USE_TF_LOCAL_BINARY"
 
 Basic Commands: A good place to start
   up                      Deploys BOSH director on an IAAS, creates CF/Concourse load balancers. Updates existing director.
@@ -84,11 +85,12 @@ Troubleshooting Commands:
   bbl [GLOBAL OPTIONS] my-command [OPTIONS]
 
 Global Options:
-  --help       [-h]        Prints usage. Use "bbl [command] --help" for more information about a command
-  --state-dir  [-s]        Directory containing the bbl state                                            env:"BBL_STATE_DIRECTORY"
-  --debug      [-d]        Prints debugging output                                                       env:"BBL_DEBUG"
-  --version    [-v]        Prints version
-  --no-confirm [-n]        No confirm
+  --help                 [-h] Prints usage. Use "bbl [command] --help" for more information about a command
+  --state-dir            [-s] Directory containing the bbl state                                            env:"BBL_STATE_DIRECTORY"
+  --debug                [-d] Prints debugging output                                                       env:"BBL_DEBUG"
+  --version              [-v] Prints version
+  --no-confirm           [-n] No confirm
+  --use-tf-local-binary  [-u] Use the local terraform binary if it exists                                   env:"BBL_USE_TF_LOCAL_BINARY"
 
 [my-command command options]
   some message

--- a/config/global_flags.go
+++ b/config/global_flags.go
@@ -1,14 +1,15 @@
 package config
 
 type GlobalFlags struct {
-	Help        bool   `short:"h" long:"help"`
-	Debug       bool   `short:"d" long:"debug"        env:"BBL_DEBUG"`
-	Version     bool   `short:"v" long:"version"`
-	NoConfirm   bool   `short:"n" long:"no-confirm"`
-	StateDir    string `short:"s" long:"state-dir"    env:"BBL_STATE_DIRECTORY"`
-	StateBucket string `          long:"state-bucket" env:"BBL_STATE_BUCKET"`
-	EnvID       string `          long:"name"`
-	IAAS        string `          long:"iaas"         env:"BBL_IAAS"`
+	Help             bool   `short:"h" long:"help"`
+	Debug            bool   `short:"d" long:"debug"               env:"BBL_DEBUG"`
+	Version          bool   `short:"v" long:"version"`
+	NoConfirm        bool   `short:"n" long:"no-confirm"`
+	StateDir         string `short:"s" long:"state-dir"           env:"BBL_STATE_DIRECTORY"`
+	StateBucket      string `          long:"state-bucket"        env:"BBL_STATE_BUCKET"`
+	EnvID            string `          long:"name"`
+	IAAS             string `          long:"iaas"                env:"BBL_IAAS"`
+	UseTfLocalBinary bool   `short:"u" long:"use-tf-local-binary" env:"BBL_USE_TF_LOCAL_BINARY"`
 
 	AWSAccessKeyID     string `long:"aws-access-key-id"       env:"BBL_AWS_ACCESS_KEY_ID"`
 	AWSSecretAccessKey string `long:"aws-secret-access-key"   env:"BBL_AWS_SECRET_ACCESS_KEY"`

--- a/terraform/binary_path_test.go
+++ b/terraform/binary_path_test.go
@@ -39,9 +39,10 @@ var _ = Describe("BinaryPath", func() {
 		fileSystem.ExistsCall.Returns.Bool = false
 
 		binary = &terraform.Binary{
-			Path:      "testassets/success",
-			EmbedData: content,
-			FS:        fileSystem,
+			Path:           "testassets/success",
+			EmbedData:      content,
+			FS:             fileSystem,
+			UseLocalBinary: false,
 		}
 	})
 

--- a/terraform/cli.go
+++ b/terraform/cli.go
@@ -8,16 +8,18 @@ import (
 )
 
 type CLI struct {
-	errorBuffer  io.Writer
-	outputBuffer io.Writer
-	tfDataDir    string
+	errorBuffer      io.Writer
+	outputBuffer     io.Writer
+	tfDataDir        string
+	tfUseLocalBinary bool
 }
 
-func NewCLI(errorBuffer, outputBuffer io.Writer, tfDataDir string) CLI {
+func NewCLI(errorBuffer, outputBuffer io.Writer, tfDataDir string, tfUseLocalBinary bool) CLI {
 	return CLI{
-		errorBuffer:  errorBuffer,
-		outputBuffer: outputBuffer,
-		tfDataDir:    tfDataDir,
+		errorBuffer:      errorBuffer,
+		outputBuffer:     outputBuffer,
+		tfDataDir:        tfDataDir,
+		tfUseLocalBinary: tfUseLocalBinary,
 	}
 }
 
@@ -26,7 +28,7 @@ func (c CLI) Run(stdout io.Writer, workingDirectory string, args []string) error
 }
 
 func (c CLI) RunWithEnv(stdout io.Writer, workingDirectory string, args []string, extraEnvVars []string) error {
-	path, err := NewBinary().BinaryPath()
+	path, err := NewBinary(c.tfUseLocalBinary).BinaryPath()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Today it is not possible to choose which version of terraform to use with bbl.

This change adds a global flag to use the local terraform binary if it exists.
