### PR TITLE
Rename AWS S3 Terraform outputs

### DIFF
--- a/plan-patches/s3-blobstore-aws/terraform/s3_blobstore_outputs.tf
+++ b/plan-patches/s3-blobstore-aws/terraform/s3_blobstore_outputs.tf
@@ -1,24 +1,28 @@
-output "s3_blobstore_buildpacks_bucket" {
+output "buildpack_directory_key" {
   value = "${aws_s3_bucket.buildpacks_bucket.bucket}"
 }
 
-output "s3_blobstore_droplets_bucket" {
+output "droplet_directory_key" {
   value = "${aws_s3_bucket.droplets_bucket.bucket}"
 }
 
-output "s3_blobstore_packages_bucket" {
+output "app_package_directory_key" {
   value = "${aws_s3_bucket.packages_bucket.bucket}"
 }
 
-output "s3_blobstore_resources_bucket" {
+output "resource_directory_key" {
   value = "${aws_s3_bucket.resources_bucket.bucket}"
 }
 
-output "s3_blobstore_access_key_id" {
+output "blobstore_access_key_id" {
   value = "${aws_iam_access_key.blobstore_access.id}"
 }
 
-output "s3_blobstore_secret_access_key" {
+output "blobstore_secret_access_key" {
   value = "${aws_iam_access_key.blobstore_access.secret}"
   sensitive = true
+}
+
+output "aws_region" {
+  value = "${var.region}"
 }


### PR DESCRIPTION
The new names harmonize better with the cf-deployment ops files:

- https://github.com/cloudfoundry/cf-deployment/blob/main/operations/use-external-blobstore.yml
- https://github.com/cloudfoundry/cf-deployment/blob/main/operations/use-s3-blobstore.yml

Note that this is a breaking change and should be mentioned in the release notes.