### PR TITLE
Fix azure application gateway sku

### DIFF
--- a/terraform/azure/templates/cf_lb.tf
+++ b/terraform/azure/templates/cf_lb.tf
@@ -68,6 +68,8 @@ resource "azurerm_public_ip" "cf" {
   location                     = "${var.region}"
   resource_group_name          = "${azurerm_resource_group.bosh.name}"
   allocation_method            = "Dynamic"
+  sku                          = "Standard"
+
 }
 
 resource "azurerm_application_gateway" "cf" {

--- a/terraform/azure/templates/cf_lb.tf
+++ b/terraform/azure/templates/cf_lb.tf
@@ -69,7 +69,6 @@ resource "azurerm_public_ip" "cf" {
   resource_group_name          = "${azurerm_resource_group.bosh.name}"
   allocation_method            = "Dynamic"
   sku                          = "Standard"
-
 }
 
 resource "azurerm_application_gateway" "cf" {

--- a/terraform/azure/templates/cf_lb.tf
+++ b/terraform/azure/templates/cf_lb.tf
@@ -67,7 +67,7 @@ resource "azurerm_public_ip" "cf" {
   name                         = "${var.env_id}-cf-lb-ip"
   location                     = "${var.region}"
   resource_group_name          = "${azurerm_resource_group.bosh.name}"
-  allocation_method            = "Dynamic"
+  allocation_method            = "Static"
   sku                          = "Standard"
 }
 

--- a/terraform/azure/templates/cf_lb.tf
+++ b/terraform/azure/templates/cf_lb.tf
@@ -76,8 +76,8 @@ resource "azurerm_application_gateway" "cf" {
   location            = "${var.region}"
 
   sku {
-    name     = "Standard_Small"
-    tier     = "Standard"
+    name     = "Standard_v2"
+    tier     = "Standard_v2"
     capacity = 2
   }
 
@@ -164,6 +164,7 @@ resource "azurerm_application_gateway" "cf" {
     http_listener_name         = "${azurerm_virtual_network.bosh.name}-http-lstn"
     backend_address_pool_name  = "${var.env_id}-cf-backend-address-pool"
     backend_http_settings_name = "${azurerm_virtual_network.bosh.name}-be-htst"
+    priority                   = 201
   }
 
   request_routing_rule {
@@ -172,6 +173,7 @@ resource "azurerm_application_gateway" "cf" {
     http_listener_name         = "${azurerm_virtual_network.bosh.name}-https-lstn"
     backend_address_pool_name  = "${var.env_id}-cf-backend-address-pool"
     backend_http_settings_name = "${azurerm_virtual_network.bosh.name}-be-htst"
+    priority                   = 202
   }
 
   request_routing_rule {
@@ -180,6 +182,7 @@ resource "azurerm_application_gateway" "cf" {
     http_listener_name         = "${azurerm_virtual_network.bosh.name}-logs-lstn"
     backend_address_pool_name  = "${var.env_id}-cf-backend-address-pool"
     backend_http_settings_name = "${azurerm_virtual_network.bosh.name}-be-htst"
+    priority                   = 203
   }
 }
 


### PR DESCRIPTION
fix #595

When changing Application Gateway to Standard_v2, priority must be added to request_routing_rule.
[for more info..](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_gateway#priority)

and Standard_v2 SKU supports standard SKU public IPs that are static only.
[for more info..](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/configure-public-ip-application-gateway)
