### PR TITLE
Set role_arn to null if not provided

### DIFF
--- a/terraform/aws/templates/base.tf
+++ b/terraform/aws/templates/base.tf
@@ -16,7 +16,7 @@ provider "aws" {
   secret_key = "${var.secret_key}"
   region     = "${var.region}"
   assume_role {
-    role_arn = "${var.role_arn}"
+    role_arn = var.role_arn == "" ? null : "${var.role_arn}"
   }
 }
 


### PR DESCRIPTION
Fix/workaround for error 'The argument "role_arn" is required, but no definition was found.' (terraform-provider-aws v5.67.0).

See also issue hashicorp/terraform-provider-aws#39296.