### PR TITLE
fix(plan-patches): Add medium VM type to BOSH Lite Cloud Configs

### DIFF
--- a/plan-patches/bosh-lite-aws/cloud-config/cloud-confg.yml
+++ b/plan-patches/bosh-lite-aws/cloud-config/cloud-confg.yml
@@ -70,3 +70,4 @@
   - name: minimal
   - name: small
   - name: small-highmem
+  - name: medium

--- a/plan-patches/bosh-lite-gcp/cloud-config/bosh-lite.yml
+++ b/plan-patches/bosh-lite-gcp/cloud-config/bosh-lite.yml
@@ -70,3 +70,4 @@
   - name: minimal
   - name: small
   - name: small-highmem
+  - name: medium


### PR DESCRIPTION
Adds a medium VM type to the Cloud Configs of the bosh-lite-gcp and bosh-lite-aws plan patches. This is a trivial change because VM types don't matter in BOSH Lite. However, CF-D now requires a medium VM type, so this change will smooth deployment.