### PR TITLE
ci: Update test environment to Go latest

### DIFF
--- a/ci/dockerfiles/deployment/Dockerfile
+++ b/ci/dockerfiles/deployment/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM golang:latest
 LABEL maintainer="https://github.com/cloudfoundry/bosh-bootloader"
 
 ARG GITHUB_TOKEN

--- a/ci/tasks/acceptance/task.yml
+++ b/ci/tasks/acceptance/task.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cryogenics/bbl-deployment
+    repository: cloudfoundry/bbl-deployment
 
 inputs:
 - name: bbl-ci

--- a/ci/tasks/build-release/task.yml
+++ b/ci/tasks/build-release/task.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cryogenics/bbl-deployment
+    repository: cloudfoundry/bbl-deployment
 
 inputs:
 - name: bbl-ci

--- a/ci/tasks/bump-brew-tap/task.yml
+++ b/ci/tasks/bump-brew-tap/task.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cryogenics/bbl-deployment
+    repository: cloudfoundry/bbl-deployment
 
 inputs:
 - name: bbl-ci

--- a/ci/tasks/create-bosh-deployment-source-file/task.yml
+++ b/ci/tasks/create-bosh-deployment-source-file/task.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cryogenics/bbl-deployment
+    repository: cloudfoundry/bbl-deployment
 
 inputs:
 - name: bbl-ci

--- a/ci/tasks/generate-version-from-sha/task.yml
+++ b/ci/tasks/generate-version-from-sha/task.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cryogenics/bbl-deployment
+    repository: cloudfoundry/bbl-deployment
 
 inputs:
 - name: bbl-ci

--- a/ci/tasks/get-concourse-test-vars/task.yml
+++ b/ci/tasks/get-concourse-test-vars/task.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cryogenics/bbl-deployment
+    repository: cloudfoundry/bbl-deployment
 
 inputs:
 - name: bbl-ci

--- a/ci/tasks/setup-github-release/task.yml
+++ b/ci/tasks/setup-github-release/task.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cryogenics/bbl-deployment
+    repository: cloudfoundry/bbl-deployment
 
 inputs:
 - name: bbl-ci

--- a/ci/tasks/test-bosh-bootloader/task
+++ b/ci/tasks/test-bosh-bootloader/task
@@ -1,16 +1,5 @@
 #!/bin/bash -exu
 
-ROOT="${PWD}"
-
-function main() {
-  mkdir -p "${GOPATH}/src/github.com/cloudfoundry"
-
-  pushd "${GOPATH}/src/github.com/cloudfoundry" > /dev/null
-    ln -s "${ROOT}/bosh-bootloader"
-    local username="testuser"
-    chown -R ${username}:${username} ${ROOT}/bosh-bootloader
-    chpst -u ${username}:${username} env HOME=/home/${username} ./bosh-bootloader/scripts/test
-  popd > /dev/null
-}
-
-main
+username="testuser"
+chown -R ${username}:${username} ${PWD}/bosh-bootloader
+chpst -u ${username}:${username} env HOME=/home/${username} ${PWD}/bosh-bootloader/scripts/test

--- a/ci/tasks/test-bosh-bootloader/task.yml
+++ b/ci/tasks/test-bosh-bootloader/task.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cryogenics/bbl-deployment
+    repository: cloudfoundry/bbl-deployment
 
 inputs:
 - name: bbl-ci


### PR DESCRIPTION
Updates Go to the latest available Docker base image.

Replaces the cryogenics image with the `cloudfoundry` image, which is actually built from the Dockerfile.

Thanks @ramonskie for the support.
