### PR TITLE
ci: pull bosh cli form GitHub releases

### DIFF
--- a/ci/dockerfiles/deployment/Dockerfile
+++ b/ci/dockerfiles/deployment/Dockerfile
@@ -52,8 +52,11 @@ RUN wget https://github.com/stedolan/jq/releases/latest/download/jq-linux64 && \
   chmod +x /usr/local/bin/jq
 
 # Install bosh_cli v2
-RUN curl -L "https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-$(curl -s https://api.github.com/repos/cloudfoundry/bosh-cli/releases | jq -r '.[0].name' | tr -d 'v')-linux-amd64" -o "/usr/local/bin/bosh" && \
-  chmod +x "/usr/local/bin/bosh"
+RUN curl -s https://api.github.com/repos/cloudfoundry/bosh-cli/releases/latest | \
+  jq -r '.assets[] | .browser_download_url | select(contains("linux-amd64"))' | \
+  xargs wget && \
+  mv bosh-cli-* /usr/local/bin/bosh && \
+  chmod +x /usr/local/bin/bosh
 
 # Install bbl
 RUN curl -s https://api.github.com/repos/cloudfoundry/bosh-bootloader/releases/latest | \


### PR DESCRIPTION
The S3 bucket from where the releases were pulled before doesn't seem to exist anymore.

The download is done similar to the `bbl` cli download a few lines further down.

Files look good now in /usr/local/bin:
```shell
root@5cd469cdd204:/usr/local/bin# ls -la
total 303428
drwxr-xr-x. 1 root root        38 Apr 16 13:35 .
drwxr-xr-x. 1 root root        16 Apr 16 13:35 ..
lrwxrwxrwx. 1 root root        37 Apr 16 13:35 aws -> /usr/local/aws-cli/v2/current/bin/aws
lrwxrwxrwx. 1 root root        47 Apr 16 13:35 aws_completer -> /usr/local/aws-cli/v2/current/bin/aws_completer
-rwxr-xr-x. 1 root root 124094215 Apr  7 18:46 bbl
-rwxr-xr-x. 1 root root  65302805 Mar 11 02:10 bosh
lrwxrwxrwx. 1 1001  118         3 Apr 11 17:22 cf -> cf8
-rwxr-xr-x. 1 1001  118  26497176 Apr 11 17:22 cf8
-rwxr-xr-x. 1 root root   6379780 Mar 13 19:48 credhub
-rwxr-xr-x. 1 root root   2319424 Dec 13  2023 jq
-rwxr-xr-x. 1 root root   5063744 Dec  6  2021 spiff
-rwxr-xr-x. 1 root root  64573440 Apr 12  2023 terraform
-rwxr-xr-x. 1 root root  16458049 Mar 28 05:40 ytt
```