### PR TITLE
feat: Add dualstack support for AWS Infrastructure

### DIFF
--- a/terraform/aws/templates/cf_lb.tf
+++ b/terraform/aws/templates/cf_lb.tf
@@ -10,6 +10,7 @@ resource "aws_security_group" "cf_ssh_lb_security_group" {
 
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
     protocol    = "tcp"
     from_port   = 2222
     to_port     = 2222
@@ -20,6 +21,7 @@ resource "aws_security_group" "cf_ssh_lb_security_group" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   tags = {
@@ -52,6 +54,7 @@ resource "aws_security_group" "cf_ssh_lb_internal_security_group" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   tags = {
@@ -111,6 +114,7 @@ resource "aws_security_group" "cf_router_lb_security_group" {
 
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
     protocol    = "tcp"
     from_port   = 80
     to_port     = 80
@@ -118,6 +122,7 @@ resource "aws_security_group" "cf_router_lb_security_group" {
 
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
     protocol    = "tcp"
     from_port   = 443
     to_port     = 443
@@ -125,6 +130,7 @@ resource "aws_security_group" "cf_router_lb_security_group" {
 
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
     protocol    = "tcp"
     from_port   = 4443
     to_port     = 4443
@@ -135,6 +141,7 @@ resource "aws_security_group" "cf_router_lb_security_group" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   tags = {
@@ -167,6 +174,7 @@ resource "aws_security_group" "cf_router_lb_internal_security_group" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   tags = {
@@ -257,6 +265,7 @@ resource "aws_security_group" "cf_tcp_lb_security_group" {
 
   ingress {
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
     protocol    = "tcp"
     from_port   = 1024
     to_port     = 1123
@@ -267,6 +276,7 @@ resource "aws_security_group" "cf_tcp_lb_security_group" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   tags = {
@@ -306,6 +316,7 @@ resource "aws_security_group" "cf_tcp_lb_internal_security_group" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   tags = {

--- a/terraform/aws/templates/concourse_lb.tf
+++ b/terraform/aws/templates/concourse_lb.tf
@@ -18,6 +18,7 @@ resource "aws_security_group_rule" "concourse_lb_internal_80" {
   from_port   = 80
   to_port     = 80
   cidr_blocks = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
 
   security_group_id = "${aws_security_group.concourse_lb_internal_security_group.id}"
 }
@@ -28,6 +29,7 @@ resource "aws_security_group_rule" "concourse_lb_internal_2222" {
   from_port   = 2222
   to_port     = 2222
   cidr_blocks = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
 
   security_group_id = "${aws_security_group.concourse_lb_internal_security_group.id}"
 }
@@ -38,6 +40,7 @@ resource "aws_security_group_rule" "concourse_lb_internal_443" {
   from_port   = 443
   to_port     = 443
   cidr_blocks = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
 
   security_group_id = "${aws_security_group.concourse_lb_internal_security_group.id}"
 }
@@ -48,6 +51,7 @@ resource "aws_security_group_rule" "concourse_lb_internal_egress" {
   from_port   = 0
   to_port     = 0
   cidr_blocks = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
 
   security_group_id = "${aws_security_group.concourse_lb_internal_security_group.id}"
 }
@@ -141,6 +145,7 @@ resource "aws_security_group_rule" "concourse_lb_internal_8844" {
   from_port   = 8844
   to_port     = 8844
   cidr_blocks = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
 
   security_group_id = "${aws_security_group.concourse_lb_internal_security_group.id}"
 }
@@ -151,6 +156,7 @@ resource "aws_security_group_rule" "concourse_lb_internal_8443" {
   from_port   = 8443
   to_port     = 8443
   cidr_blocks = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
 
   security_group_id = "${aws_security_group.concourse_lb_internal_security_group.id}"
 }

--- a/terraform/aws/templates/iso_segments.tf
+++ b/terraform/aws/templates/iso_segments.tf
@@ -24,10 +24,13 @@ locals {
 }
 
 resource "aws_subnet" "iso_subnets" {
-  count             = "${local.iso_az_count}"
-  vpc_id            = "${local.vpc_id}"
-  cidr_block        = "${cidrsubnet(var.vpc_cidr, 4, count.index + length(var.availability_zones) + 1)}"
-  availability_zone = "${element(var.availability_zones, count.index)}"
+  count                           = "${local.iso_az_count}"
+  vpc_id                          = "${local.vpc_id}"
+  cidr_block                      = "${cidrsubnet(var.vpc_cidr, 4, count.index + length(var.availability_zones) + 1)}"
+  ipv6_cidr_block                 = "${cidrsubnet(aws_vpc.vpc[0].ipv6_cidr_block, 8, count.index + 2 + length(var.availability_zones))}"
+  availability_zone               = "${element(var.availability_zones, count.index)}"
+  assign_ipv6_address_on_creation = true
+  enable_dns64                    = true
 
   tags = {
     Name = "${var.env_id}-iso-subnet${count.index}"

--- a/terraform/aws/templates/vpc.tf
+++ b/terraform/aws/templates/vpc.tf
@@ -14,6 +14,7 @@ resource "aws_vpc" "vpc" {
   cidr_block           = "${var.vpc_cidr}"
   instance_tenancy     = "default"
   enable_dns_hostnames = true
+  assign_generated_ipv6_cidr_block = true
 
   tags = {
     Name = "${var.env_id}-vpc"


### PR DESCRIPTION
Makes the necessary changes to the VPC, subnets, security groups and gateways to add IPv6 Dualstack support.