### PR TITLE
Azure cloud-config: Change Standard_D2ls_v6 to Standard_D2s_v5

### DIFF
--- a/cloudconfig/azure/base_ops_template.go
+++ b/cloudconfig/azure/base_ops_template.go
@@ -65,7 +65,7 @@ const (
   value:
     ephemeral_disk:
       size: 20480
-    instance_type: Standard_D2ls_v6
+    instance_type: Standard_D2s_v5
 
 - type: replace
   path: /vm_types/name=medium/cloud_properties?

--- a/cloudconfig/azure/fixtures/azure-ops.yml
+++ b/cloudconfig/azure/fixtures/azure-ops.yml
@@ -61,7 +61,7 @@
   value:
     ephemeral_disk:
       size: 20480
-    instance_type: Standard_D2ls_v6
+    instance_type: Standard_D2s_v5
 
 - type: replace
   path: /vm_types/name=medium/cloud_properties?


### PR DESCRIPTION
* the Azure VM type "Standard_D2ls_v6" cannot boot Hypervisor Generation '1' -> cf deployments fail