### PR TITLE
Re-enable homebrew tap for bbl

### DIFF
--- a/ci/pipelines/bosh-bootloader.yml
+++ b/ci/pipelines/bosh-bootloader.yml
@@ -19,7 +19,7 @@ groups:
   jobs:
   - bump-bbl-docs
   - bump-bbl-deployment-image
-#  - bump-brew-tap
+  - bump-brew-tap
 
 resource_types:
 - name: bosh-deployment
@@ -125,12 +125,12 @@ resources:
     access_token: ((github-access-token))
     drafts: false
 
-# - name: homebrew-tap
-#   type: git
-#   source:
-#     uri: git@github.com:cloudfoundry/homebrew-tap.git
-#     branch: master
-#     private_key: ((cf_infra_bot_github_user.private_key))
+- name: homebrew-tap
+  type: git
+  source:
+    uri: git@github.com:cloudfoundry/homebrew-tap
+    branch: master
+    private_key: ((github_deploy_key_homebrew-tap.private_key))
 
 # - name: terraform
 #   type: github-release
@@ -1335,26 +1335,25 @@ jobs:
       rebase: true
       repository: bbl-docs
 
-# - name: bump-brew-tap
-#   plan:
-#   - in_parallel:
-#     - get: homebrew-tap
-#     - get: bbl-release
-#       resource: bbl-release-official
-#       params:
-#         version:
-#           tag: bbl-release/number
-#         globs:
-#         - bbl-*_osx
-#         - bbl-*_linux_x86-64
-#         - bbl-*_windows
-#       # trigger: true
-#     - get: bbl-ci
-#       resource: bosh-bootloader-ci
+- name: bump-brew-tap
+  plan:
+  - in_parallel:
+    - get: homebrew-tap
+    - get: bbl-release
+      resource: bbl-release-official
+      params:
+        globs:
+        - bbl-*_osx_amd64
+        - bbl-*_osx_arm64
+        - bbl-*_linux_amd64
+        - bbl-*_linux_arm64
+      trigger: true
+    - get: bbl-ci
+      resource: bosh-bootloader-ci
 
-#   - task: update-brew-formula
-#     file: bbl-ci/ci/tasks/bump-brew-tap/task.yml
+  - task: update-brew-formula
+    file: bbl-ci/ci/tasks/bump-brew-tap/task.yml
 
-#   - put: homebrew-tap
-#     params:
-#       repository: updated-brew-tap/homebrew-tap
+  - put: homebrew-tap
+    params:
+      repository: updated-brew-tap/homebrew-tap

--- a/ci/tasks/bump-brew-tap/task
+++ b/ci/tasks/bump-brew-tap/task
@@ -5,8 +5,10 @@ set -e -x -u
 root="${PWD}"
 version=$(cat "${root}/bbl-release/version")
 
-shaOS=$(shasum -a 256 bbl-release/bbl-*_osx | cut -d ' ' -f 1)
-shaLinux=$(shasum -a 256 bbl-release/bbl-*_linux_x86-64 | cut -d ' ' -f 1)
+shaOSAmd64=$(shasum -a 256 bbl-release/bbl-*_osx_amd64 | cut -d ' ' -f 1)
+shaOSArm64=$(shasum -a 256 bbl-release/bbl-*_osx_arm64 | cut -d ' ' -f 1)
+shaLinuxAmd64=$(shasum -a 256 bbl-release/bbl-*_linux_amd64 | cut -d ' ' -f 1)
+shaLinuxArm64=$(shasum -a 256 bbl-release/bbl-*_linux_arm64 | cut -d ' ' -f 1)
 
 pushd homebrew-tap
   cat <<EOF > bbl.rb
@@ -16,28 +18,42 @@ class Bbl < Formula
   version "v${version}"
 
   if OS.mac?
-    url "https://github.com/cloudfoundry/bosh-bootloader/releases/download/#{version}/bbl-#{version}_osx"
-    sha256 "${shaOS}"
+    if Hardware::CPU.arm?
+      url "https://github.com/cloudfoundry/bosh-bootloader/releases/download/#{version}/bbl-#{version}_osx_arm64"
+      sha256 "${shaOSArm64}"
+    else
+      url "https://github.com/cloudfoundry/bosh-bootloader/releases/download/#{version}/bbl-#{version}_osx_amd64"
+      sha256 "${shaOSAmd64}"
+    end
   elsif OS.linux?
-    url "https://github.com/cloudfoundry/bosh-bootloader/releases/download/#{version}/bbl-#{version}_linux_x86-64"
-    sha256 "${shaLinux}"
+    if Hardware::CPU.arm?
+      url "https://github.com/cloudfoundry/bosh-bootloader/releases/download/#{version}/bbl-#{version}_linux_arm64"
+      sha256 "${shaLinuxArm64}"
+    else
+      url "https://github.com/cloudfoundry/bosh-bootloader/releases/download/#{version}/bbl-#{version}_linux_amd64"
+      sha256 "${shaLinuxAmd64}"
+    end
   end
-
-  depends_on :arch => :x86_64
-  depends_on "terraform" => "0.11.0"
-  depends_on "cloudfoundry/tap/bosh-cli" => "2.0.48"
 
   def install
     binary_name = "bbl"
     if OS.mac?
-      bin.install "bbl-#{version}_osx" => binary_name
+      if Hardware::CPU.arm?
+        bin.install "bbl-#{version}_osx_arm64" => binary_name
+      else
+        bin.install "bbl-#{version}_osx_amd64" => binary_name
+      end
     elsif OS.linux?
-      bin.install "bbl-#{version}_linux_x86-64" => binary_name
+      if Hardware::CPU.arm?
+        bin.install "bbl-#{version}_linux_arm64" => binary_name
+      else
+        bin.install "bbl-#{version}_linux_amd64" => binary_name
+      end
     end
   end
 
   test do
-    system "#{bin}/#{binary_name} --help"
+    system "#{bin}/bbl", "--help"
   end
 end
 EOF
@@ -47,8 +63,8 @@ EOF
   git add bbl.rb
   if ! [ -z "$(git status --porcelain)" ];
   then
-    git config --global user.email "cf-infrastructure@pivotal.io"
-    git config --global user.name "CF Infrastructure"
+    git config --global user.email "cf-bosh-eng@pivotal.io"
+    git config --global user.name "BOSH CI"
     git commit -m "Release bbl ${version}"
   else
     echo "No new version to commit"


### PR DESCRIPTION
The bump-brew-tap CI job was commented out back in 2021, which is why the bbl Homebrew formula has been stuck at v8.4.103.

This PR re-enables the job and fixes the task format.
Updates the asset globs to match the current naming. The bosh-cli code was used for reference.

Adds ARM64 support to the generated formula (both macOS and Linux)

Tested the updated formula locally on darwin/arm64.

Should fix the following:

-  cloudfoundry/bosh-bootloader#626
-  cloudfoundry/homebrew-tap#89

Would probably be able to close cloudfoundry/homebrew-tap/pull/75.