### PR TITLE
Switch custom resource types to registry-image

### DIFF
--- a/ci/pipelines/bosh-bootloader.yml
+++ b/ci/pipelines/bosh-bootloader.yml
@@ -23,7 +23,7 @@ groups:
 
 resource_types:
 - name: bosh-deployment
-  type: docker-image
+  type: registry-image
   source:
     repository: cloudfoundry/bosh-deployment-resource
 


### PR DESCRIPTION
Using docker-image for the type was leading to a cloudflare challenge when checking.

I didn't fly this, as there were other pipeline changes which I wasn't sure about:

```
jobs:
  job bbl-gcp-concourse-bump-deployments has changed:
- build_log_retention:
-   builds: 100
+ build_logs_to_retain: 100

...

DEPRECATION WARNING:
  - jobs.bbl-gcp-concourse-bump-deployments.build_logs_to_retain is deprecated. Use build_log_retention instead.
```