### PR TITLE
Use LRS replication for bosh storage account

### DIFF
--- a/terraform/azure/templates/storage.tf
+++ b/terraform/azure/templates/storage.tf
@@ -10,7 +10,7 @@ resource "azurerm_storage_account" "bosh" {
 
   location                 = "${var.region}"
   account_tier             = "Standard"
-  account_replication_type = "GRS"
+  account_replication_type = "LRS"
 
   tags = {
     environment = "${var.env_id}"


### PR DESCRIPTION
LRS (Locally redundant storage) is cheaper than GRS (geo-redundant storage).

We observed nearly $500 cost per month for "Geo-Replication v2 Data Transfer".

GRS is not necessary for bbl envs used in CF validation (the dominate use case of bbl I would say). Replication type can be overridden if bbl is used for setting up a productive foundation.