### PR TITLE
Migrate docker image builds from docker-image to registry-image resource

### DIFF
--- a/ci/pipelines/bosh-bootloader.yml
+++ b/ci/pipelines/bosh-bootloader.yml
@@ -29,7 +29,7 @@ resource_types:
 
 resources:
 - name: docker-bbl-deployment
-  type: docker-image
+  type: registry-image
   source:
     repository: cloudfoundry/bbl-deployment
     username: ((foundationalinfrastructure-dockerhub_username))
@@ -168,7 +168,6 @@ resources:
     tag: main
     username: ((dockerhub_username))
     password: ((dockerhub_password))
-    email: cf-release-integration+dockerhub-push-bot@pivotal.io
 
 - name: cf-deployment-concourse-tasks-docker-image
   type: registry-image
@@ -228,10 +227,26 @@ jobs:
     - get: bosh-bootloader
     - get: bbl-release-official
       trigger: true
+  - task: build-bbl-deployment-image
+    privileged: true
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: concourse/oci-build-task
+      inputs:
+      - name: bosh-bootloader
+      outputs:
+      - name: image
+      params:
+        DOCKERFILE: bosh-bootloader/ci/dockerfiles/deployment/Dockerfile
+        CONTEXT: bosh-bootloader/ci/dockerfiles/deployment/
+      run:
+        path: build
   - put: docker-bbl-deployment
     params:
-      # tag: main
-      build: bosh-bootloader/ci/dockerfiles/deployment/
+      image: image/image.tar
 
 - name: sync-version-bump-deployments
   serial: true
@@ -444,11 +459,27 @@ jobs:
     params:
       DOCKERFILE: dockerfiles/cf-deployment-concourse-tasks-bbl-dev/Dockerfile
 
+  - task: build-bbl-dev-image
+    privileged: true
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: concourse/oci-build-task
+      inputs:
+      - name: docker-workspace
+      outputs:
+      - name: image
+      params:
+        DOCKERFILE: docker-workspace/Dockerfile
+        CONTEXT: docker-workspace
+      run:
+        path: build
+
   - put: cf-deployment-concourse-tasks-bbl-dev
     params:
-      build: docker-workspace
-      cache: false
-      # tag: main
+      image: image/image.tar
 
 # - name: bbl-aws-cf-bump-deployments
 #   serial: true


### PR DESCRIPTION
## Summary

- Replace deprecated `docker-image` resource type with `registry-image` + `concourse/oci-build-task` for building and pushing Docker images in the BBL pipeline
- Add explicit `oci-build-task` build steps before each `registry-image` put in `bump-bbl-deployment-image` and `bbl-downstream-docker-image-bump-deployments` jobs
- Remove deprecated `email` field from `cf-deployment-concourse-tasks-bbl-dev` resource source config

## Root Cause

The `docker-image` resource forces `DOCKER_BUILDKIT=0` (legacy builder), which Docker 28+ has dropped. The image builds successfully but is invisible to `docker push` because the legacy builder's image store is incompatible with Docker 28's containerd-backed image store. This caused the pipeline's push step to silently fail with just `failed`.

## Approach

Follows the same pattern used in [bosh-shared-ci#6](https://github.com/cloudfoundry/bosh-shared-ci/pull/6):
- Use `concourse/oci-build-task` (BuildKit-based) to build the image, producing `image/image.tar`
- Use `registry-image` resource `put` with `image: image/image.tar` to push