### PR TITLE
CI: bump-deployments - skip commit when submodules already up to date

### DIFF
--- a/ci/tasks/bump-deployments/task
+++ b/ci/tasks/bump-deployments/task
@@ -29,7 +29,7 @@ function main() {
     git config user.email "cf-infrastructure@pivotal.io"
     git config user.name "cf-infra-bot"
 
-    git commit -am 'Update deployments'
+    git diff-index --quiet HEAD || git commit -am 'Update deployments'
 
     cp -r . ${ROOT}/bump-deployments-ci
   popd > /dev/null


### PR DESCRIPTION
git commit exits 1 when there is nothing to commit, failing the task even when the submodules are already pinned to the desired versions. This blocks the following tasks in the pipeline.