### PR TITLE
CI: bump-deployments - refresh index before checking for changes

### DIFF
--- a/ci/tasks/bump-deployments/task
+++ b/ci/tasks/bump-deployments/task
@@ -29,6 +29,7 @@ function main() {
     git config user.email "cf-infrastructure@pivotal.io"
     git config user.name "cf-infra-bot"
 
+    git update-index -q --refresh
     git diff-index --quiet HEAD || git commit -am 'Update deployments'
 
     cp -r . ${ROOT}/bump-deployments-ci


### PR DESCRIPTION
## Problem

The `bump-deployments` task fails with exit 1 even when the submodules are already pinned to the desired commits:

```
+ git diff-index --quiet HEAD
+ git commit -am 'Update deployments'
On branch bump-deployments-ci
nothing to commit, working tree clean
```

## Root cause

The task rewrites `deployment-versions.txt` with `echo >` on every run. After Concourse's shallow clone (which resets file mtimes), the file content is byte-identical but its stat metadata differs from git's cached stat. `git diff-index --quiet HEAD` trusts the stale stat cache and reports the file as modified (blob SHA `0000000…`), so the `|| git commit` branch runs — but `git commit` refreshes the index internally, finds no real change, and exits 1, failing the task.
Isolate in: https://bosh.ci.cloudfoundry.org/builds/373771172

## Fix

Run `git update-index -q --refresh` before the check. This re-hashes stat-dirty files and, when the content is unchanged, clears the dirty flag — so `git diff-index --quiet` gets an accurate answer and the commit is correctly skipped. A genuine submodule bump still commits normally.

Verified in: https://bosh.ci.cloudfoundry.org/builds/373773086