### PR TITLE
gcp-acceptance-tests: fetch cf-deployment-concourse-tasks-bbl-dev image in job plan

### DIFF
--- a/ci/pipelines/bosh-bootloader.yml
+++ b/ci/pipelines/bosh-bootloader.yml
@@ -449,6 +449,7 @@ jobs:
       trigger: true
     - get: bbl-ci
       resource: bosh-bootloader-ci
+    - get: cf-deployment-concourse-tasks-bbl-dev
     - get: version
       resource: version-bump-deployments
       passed:


### PR DESCRIPTION
## Summary

- The `on_failure` leftovers cleanup task in `gcp-acceptance-tests-bump-deployments` uses `image: cf-deployment-concourse-tasks-bbl-dev`, but the job had no `get` step for that resource
- Concourse errors when initializing the `on_failure` container, causing the job status to show `errored` instead of `failed`
- This was invisible until builds started failing (build 143 passed, so `on_failure` never triggered)

## Fix

Added `get: cf-deployment-concourse-tasks-bbl-dev` to the job's `in_parallel` fetch block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)