### PR TITLE
CI: run ssh and up_and_down specs serially

### DIFF
--- a/acceptance-tests/bbl/ssh_linux_test.go
+++ b/acceptance-tests/bbl/ssh_linux_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/onsi/gomega/gexec"
 )
 
-var _ = Describe("ssh", func() {
+var _ = Describe("ssh", Serial, func() {
 	var (
 		bbl actors.BBL
 

--- a/acceptance-tests/bbl/up_and_down_test.go
+++ b/acceptance-tests/bbl/up_and_down_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/onsi/gomega/gexec"
 )
 
-var _ = Describe("up_and_down", func() {
+var _ = Describe("up_and_down", Serial, func() {
 	var (
 		bbl     actors.BBL
 		boshcli actors.BOSHCLI


### PR DESCRIPTION
Both specs perform a full 'bbl up' (terraform apply + bosh create-env for jumpbox and director). Under ginkgo -p they ran concurrently, causing two director bootstraps to race on the same worker and GCP project. Potentially fixes the flaky director reachability, which causes the job to fail.

Marking both containers Serial ensures they run one at a time on process 1, never overlapping each other or other specs, while lighter specs still run in parallel.